### PR TITLE
chore: revert to using material-ui button instead of ui-core button

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
         "@dhis2/d2-i18n": "^1.0.4",
         "@dhis2/d2-ui-org-unit-dialog": "5.3.1",
         "@dhis2/d2-ui-period-selector-dialog": "^5.3.1",
-        "@dhis2/ui-core": "^1.1.3",
         "@material-ui/core": "^3.9.3",
         "@material-ui/icons": "^3.0.2",
         "classnames": "^2.2.6",

--- a/src/components/ItemSelector/SelectedItems.js
+++ b/src/components/ItemSelector/SelectedItems.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import i18n from '@dhis2/d2-i18n'
-import { Button } from '@dhis2/ui-core'
+import Button from '@material-ui/core/Button/Button'
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd'
 import { sortBy } from 'lodash'
 
@@ -262,12 +262,9 @@ export class SelectedItems extends Component {
                     </Droppable>
                 </DragDropContext>
                 <div className="deselect-all-button">
-                    <Button
-                        kind="secondary"
-                        size="small"
-                        onClick={this.onDeselectAll}
-                        label={i18n.t('Deselect All')}
-                    />
+                    <Button onClick={this.onDeselectAll}>
+                        {i18n.t('Deselect All')}
+                    </Button>
                 </div>
                 <div className="deselect-highlighted-button">
                     <UnAssignButton

--- a/src/components/ItemSelector/UnselectedItems.js
+++ b/src/components/ItemSelector/UnselectedItems.js
@@ -1,7 +1,7 @@
 import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import i18n from '@dhis2/d2-i18n'
-import { Button } from '@dhis2/ui-core'
+import Button from '@material-ui/core/Button/Button'
 import throttle from 'lodash/throttle'
 
 import Item from './widgets/UnselectedItem'
@@ -107,12 +107,9 @@ export class UnselectedItems extends Component {
                     <ul className="unselected-list">{listItems}</ul>
                 </div>
                 <div className="select-all-button">
-                    <Button
-                        kind="secondary"
-                        size="small"
-                        onClick={this.onSelectAllClick}
-                        label={i18n.t('Select All')}
-                    />
+                    <Button onClick={this.onSelectAllClick}>
+                        {i18n.t('Select all')}
+                    </Button>
                 </div>
                 <div className="select-highlighted-button">
                     <AssignButton

--- a/src/components/ItemSelector/styles/ItemSelector.style.js
+++ b/src/components/ItemSelector/styles/ItemSelector.style.js
@@ -19,10 +19,10 @@ export default css`
 
     .unselected {
         margin-right: 55px;
-        width: 420px;
+        width: 419px;
     }
 
     .selected {
-        width: 278px;
+        width: 277px;
     }
 `

--- a/yarn.lock
+++ b/yarn.lock
@@ -1140,14 +1140,6 @@
     react-sortable-hoc "^0.8.4"
     redux "^4.0.1"
 
-"@dhis2/ui-core@^1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-1.1.3.tgz#9adbdf56c2035cd628b7053d080604a88a63c102"
-  integrity sha512-rWcYGgUW1asQWckG48I6kr8vZKS+LPDlGnmmIJd7t5H5b/PdbORlcl9Cp4iAa3J5hszgxA8kbs+JcW9NbVG7Zg==
-  dependencies:
-    classnames "^2.2.6"
-    styled-jsx "^3.2.1"
-
 "@emotion/cache@^10.0.9":
   version "10.0.9"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.9.tgz#e0c7b7a289f7530edcfad4dcf3858bd2e5700a6f"


### PR DESCRIPTION
There are transpilation problems when using CRA < 2. Also adjusted the width of ItemSelector components to get rid of scrollbars in surrounding dialogs