### PR TITLE
fix: sort items in selected list in same order as unselected

### DIFF
--- a/src/components/ItemSelector/modules/__tests__/reorderList.spec.js
+++ b/src/components/ItemSelector/modules/__tests__/reorderList.spec.js
@@ -121,5 +121,43 @@ describe('reorderList', () => {
             const expected = ['1', '3', '4', '2', '6', '5']
             expect(result).toEqual(expected)
         })
+
+        it('moves first three items to 2nd position', () => {
+            props.highlightedItemIds = [items[0].id, items[1].id, items[2].id]
+            props.draggableId = items[1].id
+            props.sourceIndex = 0
+            props.destinationIndex = 4
+
+            const result = reorderList(props)
+            const expected = ['4', '1', '2', '3', '5', '6']
+            expect(result).toEqual(expected)
+        })
+
+        it('moves first four items to 2nd position', () => {
+            props.highlightedItemIds = [
+                items[0].id,
+                items[1].id,
+                items[2].id,
+                items[3].id,
+            ]
+            props.draggableId = items[1].id
+            props.sourceIndex = 0
+            props.destinationIndex = 5
+
+            const result = reorderList(props)
+            const expected = ['5', '1', '2', '3', '4', '6']
+            expect(result).toEqual(expected)
+        })
+
+        it('moves last three items to 1st position', () => {
+            props.highlightedItemIds = [items[3].id, items[4].id, items[5].id]
+            props.draggableId = items[4].id
+            props.sourceIndex = 4
+            props.destinationIndex = 0
+
+            const result = reorderList(props)
+            const expected = ['4', '5', '6', '1', '2', '3']
+            expect(result).toEqual(expected)
+        })
     })
 })

--- a/src/components/ItemSelector/modules/__tests__/toggler.spec.js
+++ b/src/components/ItemSelector/modules/__tests__/toggler.spec.js
@@ -102,6 +102,12 @@ describe('using the toggler ', () => {
             ]
         })
 
+        it('should return the highlighted ids in the same order as original item list', () => {
+            const actual = toggler('id', false, true, 2, 0, ['ones'], items)
+
+            expect(actual.ids).toEqual(['ones', 'some', 'id'])
+        })
+
         it('should not update the lastClickedIndex', () => {
             const expectedResult = {
                 ids: items,
@@ -125,7 +131,7 @@ describe('using the toggler ', () => {
 
         it('should keep the highlighted ids and not add duplicate items', () => {
             const expectedResult = {
-                ids: ['some', 'ones', 'stuff', 'here'],
+                ids: ['ones', 'some', 'stuff', 'here'],
                 lastClickedIndex: lastClickedIndex,
             }
 
@@ -144,7 +150,7 @@ describe('using the toggler ', () => {
 
         it('should add items from lastClickedIndex to current index into the array', () => {
             const expectedResult = {
-                ids: ['some', 'ones', 'stuff', 'here'],
+                ids: ['ones', 'some', 'stuff', 'here'],
                 lastClickedIndex: lastClickedIndex,
             }
 
@@ -196,7 +202,7 @@ describe('using the toggler ', () => {
 
         it('should be able to add one item and update the lastClickedIndex', () => {
             const expectedResult = {
-                ids: highlightedIds.concat(id),
+                ids: ['ones', 'stuff', 'here'],
                 lastClickedIndex: index,
             }
 

--- a/src/components/ItemSelector/modules/reorderList.js
+++ b/src/components/ItemSelector/modules/reorderList.js
@@ -19,15 +19,12 @@ export const reorderList = ({
             'idx'
         )
 
-        let newDestinationIndex = destinationIndex
+        const highlightedAboveDestination = indexedItemsToMove.filter(
+            item => item.idx < destinationIndex
+        )
 
-        if (newDestinationIndex < items.length && newDestinationIndex > 1) {
-            indexedItemsToMove.forEach(indexed => {
-                if (indexed.idx < newDestinationIndex) {
-                    --newDestinationIndex
-                }
-            })
-        }
+        const newDestinationIndex =
+            destinationIndex - highlightedAboveDestination.length
 
         indexedItemsToMove.forEach(indexed => {
             const idx = list.indexOf(indexed.item)

--- a/src/components/ItemSelector/modules/toggler.js
+++ b/src/components/ItemSelector/modules/toggler.js
@@ -24,8 +24,10 @@ export const toggler = (
         newIndex = newArr.newIndex
     }
 
+    const orderedIds = items.filter(item => ids.includes(item))
+
     return {
-        ids,
+        ids: orderedIds,
         lastClickedIndex: newIndex,
     }
 }

--- a/stories/ItemSelector.stories.js
+++ b/stories/ItemSelector.stories.js
@@ -47,7 +47,12 @@ const updateStore = (unselectedIds, selectedIds) => {
 
 const onSelect = newIds => {
     const selectedIds = [
-        ...new Set(newIds.concat(store.get('selected').items.map(i => i.id))),
+        ...new Set(
+            store
+                .get('selected')
+                .items.map(i => i.id)
+                .concat(newIds)
+        ),
     ]
 
     const unselectedIds = Object.keys(items).filter(
@@ -58,9 +63,13 @@ const onSelect = newIds => {
 }
 
 const onDeselect = newIds => {
-    const unselectedIds = [
+    const unorderedUnselectedIds = [
         ...new Set(newIds.concat(store.get('unselected').items.map(i => i.id))),
     ]
+
+    const unselectedIds = Object.keys(items).filter(id =>
+        unorderedUnselectedIds.includes(id)
+    )
 
     const selectedIds = Object.keys(items).filter(
         id => !unselectedIds.includes(id)


### PR DESCRIPTION
When the toggler calculates which items are added, the items needed to be re-sorted to match the unselected list.