### PR TITLE
chore: remove deploy-build from provider in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,13 +7,6 @@ deploy:
 - provider: script
   skip_cleanup: true
   script:
-  - npx --package @dhis2/deploy-build deploy-build
-  on:
-    tags: false
-    all_branches: true
-- provider: script
-  skip_cleanup: true
-  script:
   - npx @dhis2/cli-utils release --publish npm
   on:
     tags: false


### PR DESCRIPTION
Deploy build is not strictly required for libraries which are published from the root, so it is safe to remove it from the Travis deployment pipeline and only use `d2-utils release` to publish the package to NPM.

Mitigates the problem outlined in https://github.com/dhis2/deploy-build/issues/11.