### PR TITLE
fix(api): fetch also dataDimensionType for dimensions

### DIFF
--- a/src/api/dimensions.js
+++ b/src/api/dimensions.js
@@ -39,7 +39,7 @@ const requestWithPaging = (
 
 // Fetch functions
 export const apiFetchDimensions = (d2, nameProp) => {
-    const fields = `fields=id,${nameProp}~rename(name),dimensionType`
+    const fields = `fields=id,${nameProp}~rename(name),dimensionType,dataDimensionType`
     const order = `order=${nameProp}:asc`
 
     const params = `${fields}&${order}`


### PR DESCRIPTION
This is needed in dashboards app to filter out some dimensions from the list of possible dimensions to use as filters.