### PR TITLE
fix: adjustments to heights and positions

### DIFF
--- a/src/components/ItemSelector/styles/ItemSelector.style.js
+++ b/src/components/ItemSelector/styles/ItemSelector.style.js
@@ -13,16 +13,16 @@ export default css`
         border: 1px solid ${colors.greyLight};
         display: flex;
         flex-direction: column;
-        height: 534px;
+        height: 510px;
         position: relative;
     }
 
     .unselected {
         margin-right: 55px;
-        width: 419px;
+        width: 418px;
     }
 
     .selected {
-        width: 277px;
+        width: 276px;
     }
 `

--- a/src/components/ItemSelector/styles/SelectedItems.style.js
+++ b/src/components/ItemSelector/styles/SelectedItems.style.js
@@ -4,7 +4,6 @@ import css from 'styled-jsx/css'
 export default css`
     .selected-list {
         flex: 1;
-        height: 455px;
         list-style: none;
         margin: 0px;
         overflow-y: auto;

--- a/src/components/ItemSelector/styles/UnselectedItems.style.js
+++ b/src/components/ItemSelector/styles/UnselectedItems.style.js
@@ -26,7 +26,7 @@ export default css`
     }
 
     .select-highlighted-button {
-        left: 429px;
+        left: 426px;
         position: absolute;
         top: 230px;
     }


### PR DESCRIPTION
Fixes include:
- reduce height by 24px so that the total height of the dialog stays under 768px which is our minimum supported resolution.
- adjust position of the "Select" button by a few pixels
- a few other small pixel adjustments to attempt to ensure that odd browsers are less likely to show a scrollbar.