### PR TITLE
fix: adjust item selector arrow button styles when being acted on

### DIFF
--- a/src/components/ItemSelector/widgets/styles/ArrowButton.style.js
+++ b/src/components/ItemSelector/widgets/styles/ArrowButton.style.js
@@ -3,14 +3,27 @@ import css from 'styled-jsx/css'
 
 export default css`
     .arrow-button {
-        background-color: ${colors.white};
+        background-color: transparent;
+        border: 1px solid #d5dde5;
         border-radius: 4px;
-        box-shadow: 0px 2px 5px #b1b1b1;
         height: 36px;
         min-height: 36px;
         min-width: 40px;
         padding: 0px;
         width: 40px;
+    }
+
+    .arrow-button:focus {
+        outline: none;
+    }
+
+    .arrow-button:active:focus {
+        background-color: rgba(158,158,158,0.18);
+    }
+    
+    .arrow-button:hover {
+        cursor: pointer;
+        background-color: rgba(158, 158, 158, 0.07);
     }
 
     .arrow-icon {


### PR DESCRIPTION
Changes are to make the buttons look more like the ui-core Secondary button. At the moment we cannot actually use ui-core due to build issues with es6.