### PR TITLE
chore: use uids rather than numbers when choosing orgunit levels

### DIFF
--- a/src/components/OrgUnitDimension/OrgUnitDimension.js
+++ b/src/components/OrgUnitDimension/OrgUnitDimension.js
@@ -87,7 +87,7 @@ class OrgUnitDimension extends Component {
 
                     return {
                         ...levelOu,
-                        id: `${LEVEL_ID_PREFIX}-${levelOu.level}`,
+                        id: `${LEVEL_ID_PREFIX}-${levelOu.id}`,
                     }
                 }),
             ],

--- a/src/modules/__tests__/orgUnitDimension.spec.js
+++ b/src/modules/__tests__/orgUnitDimension.spec.js
@@ -1,0 +1,15 @@
+import { getLevelsFromIds } from '../orgUnitDimensions'
+
+const levelOptions = [{ id: 'fluttershy' }, { id: 'rarity' }]
+
+describe('orgUnitDimension module', () => {
+    it('returns array with id when level-id received', () => {
+        expect(getLevelsFromIds(['abc', 'LEVEL-rarity'], levelOptions)).toEqual(
+            ['rarity']
+        )
+    })
+
+    it('returns empty array when level-id not received', () => {
+        expect(getLevelsFromIds(['abc', 'rarity'], levelOptions)).toEqual([])
+    })
+})

--- a/src/modules/orgUnitDimensions.js
+++ b/src/modules/orgUnitDimensions.js
@@ -86,12 +86,8 @@ export const getLevelsFromIds = (ids, levelOptions) => {
     return ids
         .filter(isLevelId)
         .map(id => id.substr(LEVEL_ID_PREFIX.length + 1))
-        .map(
-            level =>
-                levelOptions.find(
-                    option => Number(option.level) === Number(level)
-                ).id
-        )
+        .map(id => levelOptions.find(option => option.id === id))
+        .map(level => level.id)
 }
 
 /**


### PR DESCRIPTION
Part of fix for [DHIS2-6990]

The api has supported use of uid since 2.31 [DHIS2- 4889]