### PR TITLE
chore: update highcharts dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,10 +68,6 @@
         "d2-utilizr": "^0.2.16",
         "d3-color": "^1.2.3",
         "highcharts": "^7.1.2",
-        "highcharts-exporting": "^0.1.7",
-        "highcharts-more": "^0.1.7",
-        "highcharts-no-data-to-display": "^0.1.7",
-        "highcharts-solid-gauge": "^0.1.7",
         "lodash": "^4.17.11",
         "react-beautiful-dnd": "^10.1.1",
         "styled-jsx": "^3.2.1"

--- a/src/visualizations/config/generators/highcharts/index.js
+++ b/src/visualizations/config/generators/highcharts/index.js
@@ -1,8 +1,8 @@
 import H from 'highcharts'
-import HM from 'highcharts-more'
-import HSG from 'highcharts-solid-gauge'
-import HNDTD from 'highcharts-no-data-to-display'
-import HE from 'highcharts-exporting'
+import HM from 'highcharts/highcharts-more'
+import HSG from 'highcharts/modules/solid-gauge'
+import HNDTD from 'highcharts/modules/no-data-to-display'
+import HE from 'highcharts/modules/exporting'
 
 // apply
 HM(H)

--- a/yarn.lock
+++ b/yarn.lock
@@ -5906,26 +5906,6 @@ he@1.2.x:
   resolved "https://registry.yarnpkg.com/he/-/he-1.2.0.tgz#84ae65fa7eafb165fddb61566ae14baf05664f0f"
   integrity sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==
 
-highcharts-exporting@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/highcharts-exporting/-/highcharts-exporting-0.1.7.tgz#f38024b9ef78ce2ac3a39f853f83b55822ae1630"
-  integrity sha1-84Akue94zirDo5+FP4O1WCKuFjA=
-
-highcharts-more@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/highcharts-more/-/highcharts-more-0.1.7.tgz#43cd6274cccba443166c94d4536d904bbabf9c77"
-  integrity sha1-Q81idMzLpEMWbJTUU22QS7q/nHc=
-
-highcharts-no-data-to-display@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/highcharts-no-data-to-display/-/highcharts-no-data-to-display-0.1.7.tgz#a9eb8b28da3df299d0d8262b78437cfe7d81d877"
-  integrity sha1-qeuLKNo98pnQ2CYreEN8/n2B2Hc=
-
-highcharts-solid-gauge@^0.1.7:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/highcharts-solid-gauge/-/highcharts-solid-gauge-0.1.7.tgz#4bf2dca76b5f559034b59d0c6d4755d1c71a6a5b"
-  integrity sha1-S/Lcp2tfVZA0tZ0MbUdV0ccaals=
-
 highcharts@^7.1.2:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-7.1.2.tgz#f337e75cf0614f58f87fb28fbab48e1096265b5d"


### PR DESCRIPTION
Some npm  Highcharts modules have been deprecated.
They can be imported from the main Highcharts package instead.