### PR TITLE
fix: Single value title should only include the first data item

### DIFF
--- a/src/visualizations/config/adapters/dhis_dhis/__tests__/getFilterText.spec.js
+++ b/src/visualizations/config/adapters/dhis_dhis/__tests__/getFilterText.spec.js
@@ -1,15 +1,15 @@
-import getFilterTitle from '../getFilterTitle'
+import getFilterText from '../getFilterText'
 
-describe('getFilterTitle', () => {
+describe('getFilterText', () => {
     it('returns null when no filter array', () => {
-        expect(getFilterTitle('abc')).toBeNull()
+        expect(getFilterText('abc')).toEqual('')
     })
 
-    it('returns null when no filter array does not contain items', () => {
-        expect(getFilterTitle([])).toBeNull()
+    it('returns null when filter array does not contain items', () => {
+        expect(getFilterText([])).toEqual('')
     })
 
-    it('creates the filter title', () => {
+    it('returns the filter text', () => {
         const filters = [
             {
                 dimension: 'ou',
@@ -45,7 +45,7 @@ describe('getFilterTitle', () => {
                 },
             },
         }
-        expect(getFilterTitle(filters, metadata)).toEqual(
+        expect(getFilterText(filters, metadata)).toEqual(
             'Top-down - Eons ago, The Future'
         )
     })

--- a/src/visualizations/config/adapters/dhis_dhis/__tests__/getFilterTitle.spec.js
+++ b/src/visualizations/config/adapters/dhis_dhis/__tests__/getFilterTitle.spec.js
@@ -1,0 +1,52 @@
+import getFilterTitle from '../getFilterTitle'
+
+describe('getFilterTitle', () => {
+    it('returns null when no filter array', () => {
+        expect(getFilterTitle('abc')).toBeNull()
+    })
+
+    it('returns null when no filter array does not contain items', () => {
+        expect(getFilterTitle([])).toBeNull()
+    })
+
+    it('creates the filter title', () => {
+        const filters = [
+            {
+                dimension: 'ou',
+                items: [
+                    {
+                        id: 'topdown',
+                    },
+                ],
+            },
+            {
+                dimension: 'pe',
+                items: [
+                    {
+                        id: 'eon',
+                    },
+                    {
+                        id: 'future',
+                    },
+                ],
+            },
+        ]
+
+        const metadata = {
+            items: {
+                eon: {
+                    name: 'Eons ago',
+                },
+                topdown: {
+                    name: 'Top-down',
+                },
+                future: {
+                    name: 'The Future',
+                },
+            },
+        }
+        expect(getFilterTitle(filters, metadata)).toEqual(
+            'Top-down - Eons ago, The Future'
+        )
+    })
+})

--- a/src/visualizations/config/adapters/dhis_dhis/getFilterText.js
+++ b/src/visualizations/config/adapters/dhis_dhis/getFilterText.js
@@ -15,5 +15,5 @@ export default function(filters, metaData) {
         return titleFragments.join(' - ')
     }
 
-    return null
+    return ''
 }

--- a/src/visualizations/config/adapters/dhis_dhis/getFilterTitle.js
+++ b/src/visualizations/config/adapters/dhis_dhis/getFilterTitle.js
@@ -1,7 +1,5 @@
-import isArray from 'd2-utilizr/lib/isArray'
-
 export default function(filters, metaData) {
-    if (isArray(filters) && filters.length) {
+    if (Array.isArray(filters) && filters.length) {
         const titleFragments = []
 
         filters.forEach(filter => {

--- a/src/visualizations/config/adapters/dhis_dhis/getFilterTitle.js
+++ b/src/visualizations/config/adapters/dhis_dhis/getFilterTitle.js
@@ -1,41 +1,21 @@
 import isArray from 'd2-utilizr/lib/isArray'
 
 export default function(filters, metaData) {
-    let title
-
     if (isArray(filters) && filters.length) {
-        title = ''
+        const titleFragments = []
 
-        filters.forEach((dimension, index, array) => {
-            const filterItems = metaData.dimensions[dimension.dimension]
+        filters.forEach(filter => {
+            const filterItems = filter.items || []
+            const sectionParts = filterItems.map(item => {
+                const id = item.id
+                return metaData.items[id] ? metaData.items[id].name : id
+            })
 
-            if (isArray(filterItems)) {
-                const l = filterItems.length
-
-                for (let i = 0; i < l; i++) {
-                    const id = filterItems[i]
-
-                    // if the value is present in items take the name to show from there
-                    if (metaData.items[id]) {
-                        title +=
-                            metaData.items[id].name + (i < l - 1 ? ', ' : '')
-                    }
-                    // otherwise use the values directly
-                    // this is a temporary fix to avoid app crashing when using filters with data items in EV
-                    else {
-                        title +=
-                            metaData.items[dimension.dimension].name +
-                            ': ' +
-                            filterItems.join(', ')
-
-                        break
-                    }
-                }
-
-                title += index < array.length - 1 ? ' - ' : ''
-            }
+            titleFragments.push(sectionParts.join(', '))
         })
+
+        return titleFragments.join(' - ')
     }
 
-    return title || null
+    return null
 }

--- a/src/visualizations/config/adapters/dhis_dhis/subtitle/__tests__/index.spec.js
+++ b/src/visualizations/config/adapters/dhis_dhis/subtitle/__tests__/index.spec.js
@@ -1,0 +1,50 @@
+import getSubtitle from '../index'
+import { VISUALIZATION_TYPE_SINGLE_VALUE } from '../../type'
+
+jest.mock('../singleValue', () => () => 'The sv filter title')
+jest.mock('../../getFilterText', () => () => 'The default filter text')
+
+describe('getSubtitle', () => {
+    it('returns empty subtitle when flag hideSubtitle exists', () => {
+        expect(getSubtitle({ hideSubtitle: true })).toEqual('')
+    })
+
+    it('returns the subtitle provided in the layout', () => {
+        const subtitle = 'The subtitle was already set'
+        expect(getSubtitle({ subtitle })).toEqual(subtitle)
+    })
+
+    it('returns subtitle for single value vis', () => {
+        expect(getSubtitle({ type: VISUALIZATION_TYPE_SINGLE_VALUE })).toEqual(
+            'The sv filter title'
+        )
+    })
+
+    describe('not dashboard', () => {
+        describe('layout does not include title', () => {
+            it('returns empty subtitle', () => {
+                expect(getSubtitle({ filters: {} }, {}, false)).toEqual('')
+            })
+        })
+
+        describe('layout includes title', () => {
+            it('returns filter title as subtitle', () => {
+                expect(
+                    getSubtitle(
+                        { filters: {}, title: 'Chart title' },
+                        {},
+                        false
+                    )
+                ).toEqual('The default filter text')
+            })
+        })
+    })
+
+    describe('dashboard', () => {
+        it('returns filter title as subtitle', () => {
+            expect(getSubtitle({ filters: {} }, {}, true)).toEqual(
+                'The default filter text'
+            )
+        })
+    })
+})

--- a/src/visualizations/config/adapters/dhis_dhis/subtitle/__tests__/singleValue.spec.js
+++ b/src/visualizations/config/adapters/dhis_dhis/subtitle/__tests__/singleValue.spec.js
@@ -1,0 +1,15 @@
+import getSingleValueSubtitle from '../singleValue'
+
+jest.mock('../../getFilterText', () => () => 'The filter text')
+
+describe('getSingleValueSubtitle', () => {
+    it('returns null when layout does not have filters', () => {
+        expect(getSingleValueSubtitle({})).toEqual('')
+    })
+
+    it('returns the filter text', () => {
+        expect(getSingleValueSubtitle({ filters: [] })).toEqual(
+            'The filter text'
+        )
+    })
+})

--- a/src/visualizations/config/adapters/dhis_dhis/subtitle/index.js
+++ b/src/visualizations/config/adapters/dhis_dhis/subtitle/index.js
@@ -19,13 +19,7 @@ export default function(layout, metaData, dashboard) {
     } else {
         switch (layout.type) {
             case VISUALIZATION_TYPE_SINGLE_VALUE:
-                subtitle = getSingleValueTitle(
-                    layout,
-                    metaData,
-                    dashboard,
-                    false,
-                    true
-                )
+                subtitle = getSingleValueTitle(layout, metaData)
 
                 break
             default:

--- a/src/visualizations/config/adapters/dhis_dhis/subtitle/index.js
+++ b/src/visualizations/config/adapters/dhis_dhis/subtitle/index.js
@@ -1,7 +1,7 @@
 import isString from 'd2-utilizr/lib/isString'
 import getFilterTitle from '../getFilterTitle'
 import { VISUALIZATION_TYPE_SINGLE_VALUE } from '../type'
-import getSingleValueTitle from '../title/singleValue'
+import getSingleValueTitle from './singleValue'
 
 function getDefault(layout, dashboard, filterTitle) {
     return dashboard || isString(layout.title) ? filterTitle : ''
@@ -17,17 +17,19 @@ export default function(layout, metaData, dashboard) {
     if (isString(layout.subtitle) && layout.subtitle.length) {
         subtitle = layout.subtitle
     } else {
-        const filterTitle = getFilterTitle(layout.filters, metaData)
-
         switch (layout.type) {
             case VISUALIZATION_TYPE_SINGLE_VALUE:
                 subtitle = getSingleValueTitle(
                     layout,
                     metaData,
-                    Boolean(!dashboard)
+                    dashboard,
+                    false,
+                    true
                 )
+
                 break
             default:
+                const filterTitle = getFilterTitle(layout.filters, metaData)
                 subtitle = getDefault(layout, dashboard, filterTitle)
         }
     }

--- a/src/visualizations/config/adapters/dhis_dhis/subtitle/index.js
+++ b/src/visualizations/config/adapters/dhis_dhis/subtitle/index.js
@@ -1,32 +1,33 @@
-import isString from 'd2-utilizr/lib/isString'
-import getFilterTitle from '../getFilterTitle'
+import getFilterText from '../getFilterText'
 import { VISUALIZATION_TYPE_SINGLE_VALUE } from '../type'
 import getSingleValueTitle from './singleValue'
 
-function getDefault(layout, dashboard, filterTitle) {
-    return dashboard || isString(layout.title) ? filterTitle : ''
+function getDefault(layout, dashboard, metaData) {
+    if (dashboard || typeof layout.title === 'string') {
+        return getFilterText(layout.filters, metaData)
+    }
+
+    return ''
 }
 
 export default function(layout, metaData, dashboard) {
-    let subtitle = ''
-
     if (layout.hideSubtitle) {
-        return subtitle
+        return ''
     }
 
-    if (isString(layout.subtitle) && layout.subtitle.length) {
-        subtitle = layout.subtitle
+    if (typeof layout.subtitle === 'string' && layout.subtitle.length) {
+        return layout.subtitle
     } else {
+        let subtitle
         switch (layout.type) {
             case VISUALIZATION_TYPE_SINGLE_VALUE:
                 subtitle = getSingleValueTitle(layout, metaData)
 
                 break
             default:
-                const filterTitle = getFilterTitle(layout.filters, metaData)
-                subtitle = getDefault(layout, dashboard, filterTitle)
+                subtitle = getDefault(layout, dashboard, metaData)
         }
-    }
 
-    return subtitle
+        return subtitle
+    }
 }

--- a/src/visualizations/config/adapters/dhis_dhis/subtitle/singleValue.js
+++ b/src/visualizations/config/adapters/dhis_dhis/subtitle/singleValue.js
@@ -1,9 +1,5 @@
 import getFilterTitle from '../getFilterTitle'
 
 export default function(layout, metaData) {
-    if (layout.filters) {
-        return getFilterTitle(layout.filters, metaData)
-    }
-
-    return nulll
+    return layout.filters ? getFilterTitle(layout.filters, metaData) : null
 }

--- a/src/visualizations/config/adapters/dhis_dhis/subtitle/singleValue.js
+++ b/src/visualizations/config/adapters/dhis_dhis/subtitle/singleValue.js
@@ -1,0 +1,9 @@
+import getFilterTitle from '../getFilterTitle'
+
+export default function(layout, metaData) {
+    if (layout.filters) {
+        return getFilterTitle(layout.filters, metaData)
+    }
+
+    return nulll
+}

--- a/src/visualizations/config/adapters/dhis_dhis/subtitle/singleValue.js
+++ b/src/visualizations/config/adapters/dhis_dhis/subtitle/singleValue.js
@@ -1,5 +1,5 @@
-import getFilterTitle from '../getFilterTitle'
+import getFilterText from '../getFilterText'
 
 export default function(layout, metaData) {
-    return layout.filters ? getFilterTitle(layout.filters, metaData) : null
+    return layout.filters ? getFilterText(layout.filters, metaData) : ''
 }

--- a/src/visualizations/config/adapters/dhis_dhis/title/__tests__/index.spec.js
+++ b/src/visualizations/config/adapters/dhis_dhis/title/__tests__/index.spec.js
@@ -1,0 +1,36 @@
+import getTitle from '../index'
+import { VISUALIZATION_TYPE_SINGLE_VALUE } from '../../type'
+
+jest.mock('../singleValue', () => () => 'The sv filter title')
+jest.mock('../../getFilterText', () => () => 'The filter text')
+
+describe('getTitle', () => {
+    it('returns empty title when flag hideTitle exists', () => {
+        expect(getTitle({ hideTitle: true })).toEqual('')
+    })
+
+    it('returns the title provided in the layout', () => {
+        const title = 'The title was already set'
+        expect(getTitle({ title })).toEqual(title)
+    })
+
+    it('returns title for single value vis', () => {
+        expect(getTitle({ type: VISUALIZATION_TYPE_SINGLE_VALUE })).toEqual(
+            'The sv filter title'
+        )
+    })
+
+    describe('not dashboard', () => {
+        it('returns filter text as title', () => {
+            expect(getTitle({ filters: {} }, {}, false)).toEqual(
+                'The filter text'
+            )
+        })
+    })
+
+    describe('dashboard', () => {
+        it('returns empty string', () => {
+            expect(getTitle({ filters: {} }, {}, true)).toEqual('')
+        })
+    })
+})

--- a/src/visualizations/config/adapters/dhis_dhis/title/__tests__/singleValue.spec.js
+++ b/src/visualizations/config/adapters/dhis_dhis/title/__tests__/singleValue.spec.js
@@ -1,0 +1,21 @@
+import getSingleValueTitle from '../singleValue'
+
+jest.mock('../../getFilterText', () => () => 'The filter text')
+
+describe('getSingleValueTitle', () => {
+    it('returns null when layout does not have columns', () => {
+        expect(getSingleValueTitle({})).toEqual('')
+    })
+
+    it('returns the filter text based on column items', () => {
+        expect(
+            getSingleValueTitle({
+                columns: [
+                    {
+                        items: [{}],
+                    },
+                ],
+            })
+        ).toEqual('The filter text')
+    })
+})

--- a/src/visualizations/config/adapters/dhis_dhis/title/index.js
+++ b/src/visualizations/config/adapters/dhis_dhis/title/index.js
@@ -1,27 +1,22 @@
-import isString from 'd2-utilizr/lib/isString'
-import getFilterTitle from '../getFilterTitle'
+import getFilterText from '../getFilterText'
 import { VISUALIZATION_TYPE_SINGLE_VALUE } from '../type'
 import getSingleValueTitle from './singleValue'
 
 function getDefault(layout, metaData, dashboard) {
-    // filters
-    if (layout.filters && !dashboard) {
-        return getFilterTitle(layout.filters, metaData)
-    }
-
-    return null
+    return layout.filters && !dashboard
+        ? getFilterText(layout.filters, metaData)
+        : ''
 }
 
 export default function(layout, metaData, dashboard) {
-    let title = ''
-
     if (layout.hideTitle) {
-        return title
+        return ''
     }
 
-    if (isString(layout.title) && layout.title.length) {
-        title = layout.title
+    if (typeof layout.title === 'string' && layout.title.length) {
+        return layout.title
     } else {
+        let title
         switch (layout.type) {
             case VISUALIZATION_TYPE_SINGLE_VALUE:
                 title = getSingleValueTitle(layout, metaData)
@@ -30,7 +25,6 @@ export default function(layout, metaData, dashboard) {
             default:
                 title = getDefault(layout, metaData, dashboard)
         }
+        return title
     }
-
-    return title
 }

--- a/src/visualizations/config/adapters/dhis_dhis/title/index.js
+++ b/src/visualizations/config/adapters/dhis_dhis/title/index.js
@@ -24,7 +24,8 @@ export default function(layout, metaData, dashboard) {
     } else {
         switch (layout.type) {
             case VISUALIZATION_TYPE_SINGLE_VALUE:
-                title = getSingleValueTitle(layout, metaData, dashboard)
+                title = getSingleValueTitle(layout, metaData)
+
                 break
             default:
                 title = getDefault(layout, metaData, dashboard)

--- a/src/visualizations/config/adapters/dhis_dhis/title/singleValue.js
+++ b/src/visualizations/config/adapters/dhis_dhis/title/singleValue.js
@@ -1,15 +1,12 @@
 import getFilterTitle from '../getFilterTitle'
 
-export default function(layout, metaData, dashboard) {
-    const titleFragments = []
+export default function(layout, metaData) {
+    if (layout.columns) {
+        const items = [layout.columns[0].items[0]]
+        const single = Object.assign({}, layout.columns[0], { items })
 
-    if (layout.columns && !dashboard) {
-        titleFragments.push(getFilterTitle(layout.columns, metaData))
+        return getFilterTitle([single], metaData)
     }
 
-    if (layout.filters && !dashboard) {
-        titleFragments.push(getFilterTitle(layout.filters, metaData))
-    }
-
-    return titleFragments.length ? titleFragments.join(' - ') : null
+    return null
 }

--- a/src/visualizations/config/adapters/dhis_dhis/title/singleValue.js
+++ b/src/visualizations/config/adapters/dhis_dhis/title/singleValue.js
@@ -1,12 +1,15 @@
-import getFilterTitle from '../getFilterTitle'
+import getFilterText from '../getFilterText'
 
 export default function(layout, metaData) {
     if (layout.columns) {
-        const items = [layout.columns[0].items[0]]
-        const single = Object.assign({}, layout.columns[0], { items })
+        const firstItem = layout.columns[0].items[0]
 
-        return getFilterTitle([single], metaData)
+        const column = Object.assign({}, layout.columns[0], {
+            items: [firstItem],
+        })
+
+        return getFilterText([column], metaData)
     }
 
-    return null
+    return ''
 }


### PR DESCRIPTION
Changes include:
- include only the first dimension item in the title for SV
- for SV, the layout.filters is the source of the subtitle
- consistently return empty string when no title or subtitle
- added unit tests

[DHIS2-3536]