### PR TITLE
chore: update period-selector-dialog to enable epi weekly periods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # Editor settings
 /.vscode
+/.idea
 
 # dependencies
 /node_modules

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "dependencies": {
         "@dhis2/d2-i18n": "^1.0.4",
         "@dhis2/d2-ui-org-unit-dialog": "^6.1.0",
-        "@dhis2/d2-ui-period-selector-dialog": "^6.1.0",
+        "@dhis2/d2-ui-period-selector-dialog": "^6.2.0",
         "@dhis2/ui-core": "^3.4.0",
         "@material-ui/core": "^3.9.3",
         "@material-ui/icons": "^3.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1159,6 +1159,25 @@
   dependencies:
     find-up "^2.1.0"
 
+"@dhis2/analytics@^2.1.0":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-2.2.1.tgz#ed46681c56089db8b5ac8223b5c09cc9a96a1096"
+  integrity sha512-9KWd3hOe6JRhlb3eibxh4Dm/0UjijVer7J4wDLDdvtnoeSo6U0ue6WZ3gw9pVRShqjUU4IsUe7cFgwXpDDlHXQ==
+  dependencies:
+    "@dhis2/d2-i18n" "^1.0.4"
+    "@dhis2/d2-ui-org-unit-dialog" "^6.1.0"
+    "@dhis2/d2-ui-period-selector-dialog" "^6.1.0"
+    "@dhis2/ui-core" "^3.4.0"
+    "@material-ui/core" "^3.9.3"
+    "@material-ui/icons" "^3.0.2"
+    classnames "^2.2.6"
+    d2-utilizr "^0.2.16"
+    d3-color "^1.2.3"
+    highcharts "^7.1.2"
+    lodash "^4.17.11"
+    react-beautiful-dnd "^10.1.1"
+    styled-jsx "^3.2.1"
+
 "@dhis2/cli-helpers-engine@1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@dhis2/cli-helpers-engine/-/cli-helpers-engine-1.3.0.tgz#e12f7a1bfd6223054cf9254e675b2b660b0690a5"
@@ -1297,6 +1316,18 @@
   dependencies:
     "@dhis2/d2-i18n" "^1.0.4"
     "@dhis2/d2-ui-analytics" "^1.0.0"
+    "@material-ui/core" "^3.3.1"
+    "@material-ui/icons" "^3.0.1"
+    babel-runtime "^6.26.0"
+    prop-types "^15.6.0"
+
+"@dhis2/d2-ui-period-selector-dialog@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-period-selector-dialog/-/d2-ui-period-selector-dialog-6.2.0.tgz#7c27654b846775faa014f67ac7ea0178e40f8066"
+  integrity sha512-NaCeAuwXgHX1Gle6kjFMI5hdtQqeQlBfHtFCa9IPZNvDoN3yn4pDSGx5XW9DPNESEoBg3KVhkdm8NDmcyglbqg==
+  dependencies:
+    "@dhis2/analytics" "^2.1.0"
+    "@dhis2/d2-i18n" "^1.0.4"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"


### PR DESCRIPTION
Relates to [DHIS2-6983](https://jira.dhis2.org/browse/DHIS2-6983).

Changes include:
- Updating `@dhis2/d2-ui-period-selector-dialog` dependency to v6.2.0 to include epi weekly periods.