### PR TITLE
fix: add function to replace a dimension in the layout

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -47,6 +47,7 @@ export {
     layoutGetAxisNameDimensionIdsObject,
 } from './modules/layout/layoutGetAxisNameDimensionIdsObject'
 export { layoutGetDimension } from './modules/layout/layoutGetDimension'
+export { layoutReplaceDimension } from './modules/layout/layoutReplaceDimension'
 export {
     layoutGetDimensionIdItemIdsObject,
 } from './modules/layout/layoutGetDimensionIdItemIdsObject'

--- a/src/index.js
+++ b/src/index.js
@@ -73,6 +73,7 @@ export { axisGetDimensionIds } from './modules/layout/axisGetDimensionIds'
 export { axisHasDataDimension } from './modules/layout/axisHasDataDimension'
 export { axisHasDimension } from './modules/layout/axisHasDimension'
 export { axisHasPeriodDimension } from './modules/layout/axisHasPeriodDimension'
+export { axisHasOuDimension } from './modules/layout/axisHasOuDimension'
 export { axisIsEmpty } from './modules/layout/axisIsEmpty'
 
 export {

--- a/src/modules/layout/__tests__/axisHasOuDimension.spec.js
+++ b/src/modules/layout/__tests__/axisHasOuDimension.spec.js
@@ -1,0 +1,10 @@
+import { TEST_AXIS_COLUMNS, TEST_AXIS_FILTERS } from '../testResources'
+import { axisHasOuDimension } from '../axisHasOuDimension'
+
+describe('axisHasOuDimension', () => {
+    it('should return true if the ou dimension is found in the axis', () => {
+        expect(axisHasOuDimension(TEST_AXIS_COLUMNS)).toBe(false)
+
+        expect(axisHasOuDimension(TEST_AXIS_FILTERS)).toBe(true)
+    })
+})

--- a/src/modules/layout/__tests__/layoutReplaceDimension.spec.js
+++ b/src/modules/layout/__tests__/layoutReplaceDimension.spec.js
@@ -1,0 +1,25 @@
+import { layoutReplaceDimension } from '../layoutReplaceDimension'
+import { TEST_LAYOUT, TEST_DIMENSION_4 } from '../testResources'
+import { DIMENSION_ID_ORGUNIT } from '../../fixedDimensions'
+
+const newOuDimensions = [
+    {
+        name: 'bob',
+        occupation: 'the builder',
+    },
+]
+
+describe('layoutReplaceDimension', () => {
+    it('replaces the dimension in the provided layout', () => {
+        const updatedLayout = layoutReplaceDimension(
+            TEST_LAYOUT,
+            DIMENSION_ID_ORGUNIT,
+            newOuDimensions
+        )
+
+        expect(updatedLayout.filters).toMatchObject([
+            { dimension: 'ou', items: newOuDimensions },
+            TEST_DIMENSION_4,
+        ])
+    })
+})

--- a/src/modules/layout/axisHasOuDimension.js
+++ b/src/modules/layout/axisHasOuDimension.js
@@ -1,0 +1,5 @@
+import { DIMENSION_ID_ORGUNIT } from '../fixedDimensions'
+import { axisHasDimension } from './axisHasDimension'
+
+export const axisHasOuDimension = axis =>
+    axisHasDimension(axis, DIMENSION_ID_ORGUNIT)

--- a/src/modules/layout/layoutReplaceDimension.js
+++ b/src/modules/layout/layoutReplaceDimension.js
@@ -1,0 +1,17 @@
+import { AXIS_NAMES } from './axis'
+import { axisHasDimension } from './axisHasDimension'
+
+export const layoutReplaceDimension = (layout, dimensionName, items) => {
+    const axisName = AXIS_NAMES.find(a =>
+        axisHasDimension(layout[a], dimensionName)
+    )
+
+    const newAxisDimensions = layout[axisName].map(dimension => {
+        if (dimension.dimension === dimensionName) {
+            return Object.assign({}, dimension, { items })
+        }
+        return dimension
+    })
+
+    return Object.assign({}, layout, { [axisName]: newAxisDimensions })
+}

--- a/src/modules/layout/layoutReplaceDimension.js
+++ b/src/modules/layout/layoutReplaceDimension.js
@@ -1,13 +1,13 @@
 import { AXIS_NAMES } from './axis'
 import { axisHasDimension } from './axisHasDimension'
 
-export const layoutReplaceDimension = (layout, dimensionName, items) => {
+export const layoutReplaceDimension = (layout, dimensionId, items) => {
     const axisName = AXIS_NAMES.find(a =>
-        axisHasDimension(layout[a], dimensionName)
+        axisHasDimension(layout[a], dimensionId)
     )
 
     const newAxisDimensions = layout[axisName].map(dimension => {
-        if (dimension.dimension === dimensionName) {
+        if (dimension.dimension === dimensionId) {
             return Object.assign({}, dimension, { items })
         }
         return dimension


### PR DESCRIPTION
The specific use case that caused the creation of this function:
- In the past, when a visualization layout is saved and it contains org unit levels, the level number (e.g., 1, 2, 3, 4) was saved. In the new DV, we now store the uid of the org unit level, but for historical data, the layout will still contain the numeric values. To soft-migrate old data to the uid, we need to replace the ou dimension in the layout.

An additional function was added: axisHasOuDimension, to parallel the other related functions (e.g., axisHasPeriodDimension).

[DHIS2-6990]