### PR TITLE
fix: download for Single Value visualization

### DIFF
--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -6,6 +6,7 @@ export default function(config, parentEl) {
     const svgNS = 'http://www.w3.org/2000/svg'
 
     const svg = document.createElementNS(svgNS, 'svg')
+    svg.setAttribute('xmlns', svgNS)
     svg.setAttribute('viewBox', `0 0 ${width} ${height}`)
     svg.setAttribute('width', '100%')
     svg.setAttribute('height', '100%')


### PR DESCRIPTION
The missing xmlns attribute at the root svg node is causing the download
as pdf/png to fail due to the server not being able to correctly process
the SVG content.

Fixes DHIS2-7462.