### PR TITLE
fix: avoid value overlapping title/subtitle in dashboard

### DIFF
--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -1,8 +1,61 @@
-export default function(config, parentEl, { dashboard }) {
-    parentEl.style.overflow = 'hidden'
-    parentEl.style.display = 'flex'
-    parentEl.style.justifyContent = 'center'
+const svgNS = 'http://www.w3.org/2000/svg'
 
+const generateValueSVG = (value, y) => {
+    const textSize = 300
+
+    const svgValue = document.createElementNS(svgNS, 'svg')
+    svgValue.setAttribute('xmlns', svgNS)
+    svgValue.setAttribute(
+        'viewBox',
+        `0 -${textSize} ${textSize * 0.56 * value.length} ${textSize + 50}`
+    )
+
+    if (y) {
+        svgValue.setAttribute('y', y)
+    }
+
+    const text = document.createElementNS(svgNS, 'text')
+    text.setAttribute('text-anchor', 'middle')
+    text.setAttribute('font-size', textSize)
+    text.setAttribute('x', '50%')
+    text.appendChild(document.createTextNode(value))
+
+    svgValue.appendChild(text)
+
+    return svgValue
+}
+
+const generateDashboardItem = config => {
+    const container = document.createElement('div')
+    container.setAttribute(
+        'style',
+        'display: flex; flex-direction: column; align-items: center; width: 100%; height: 100%'
+    )
+
+    const titleSubtitleStyle = 'font-size: 12px; color: #666'
+
+    const title = document.createElement('span')
+    title.setAttribute('style', titleSubtitleStyle)
+    if (config.title) {
+        title.appendChild(document.createTextNode(config.title))
+
+        container.appendChild(title)
+    }
+
+    const subtitle = document.createElement('span')
+    subtitle.setAttribute('style', titleSubtitleStyle)
+    if (config.subtitle) {
+        subtitle.appendChild(document.createTextNode(config.subtitle))
+
+        container.appendChild(subtitle)
+    }
+
+    container.appendChild(generateValueSVG(config.value))
+
+    return container
+}
+
+const generateDVItem = (config, parentEl) => {
     const parentElBBox = parentEl.getBoundingClientRect()
 
     const width = parentElBBox.width
@@ -16,52 +69,42 @@ export default function(config, parentEl, { dashboard }) {
     svg.setAttribute('width', '100%')
     svg.setAttribute('height', '100%')
 
-    const titleFontSize = dashboard ? '0.8em' : '18px'
     const title = document.createElementNS(svgNS, 'text')
     title.setAttribute('x', '50%')
-    title.setAttribute('y', dashboard ? 15 : 48)
+    title.setAttribute('y', 28)
     title.setAttribute('text-anchor', 'middle')
-    title.setAttribute('font-size', titleFontSize)
-    title.setAttribute('fill', '#666')
+    title.setAttribute('font-size', '18px')
+    title.setAttribute('fill', '#111')
     if (config.title) {
         title.appendChild(document.createTextNode(config.title))
+
+        svg.appendChild(title)
     }
 
-    const subtitleFontSize = dashboard ? '0.8em' : '14px'
     const subtitle = document.createElementNS(svgNS, 'text')
     subtitle.setAttribute('x', '50%')
-    subtitle.setAttribute('y', dashboard ? 15 : 48)
-    subtitle.setAttribute('dy', dashboard ? 16 : 22)
+    subtitle.setAttribute('y', 28)
+    subtitle.setAttribute('dy', 22)
     subtitle.setAttribute('text-anchor', 'middle')
-    subtitle.setAttribute('font-size', subtitleFontSize)
-    subtitle.setAttribute('fill', '#666')
+    subtitle.setAttribute('font-size', '14px')
+    subtitle.setAttribute('fill', '#111')
     if (config.subtitle) {
         subtitle.appendChild(document.createTextNode(config.subtitle))
+
+        svg.appendChild(subtitle)
     }
 
-    const scale = width / (200 * config.value.length)
-
-    // The group here is used to keep the value centered within the SVG viewport.
-    // Because scale is used on the text node, it turned out to be difficult to center the text node itself.
-    // transform-origin does not work consistently across browsers.
-    // g is taking care of centering
-    // text node is only caring about scaling and always having origin at 0,0 of the parent node (g)
-    // with vertical offset to compensate for the dominant-baseline (which does not work in Edge)
-    const gValue = document.createElementNS(svgNS, 'g')
-    gValue.setAttribute('transform', `translate(${width / 2} ${height / 2})`)
-
-    const valueVertOffset =
-        dashboard && (config.title || config.subtitle) ? 160 : 100
-    const value = document.createElementNS(svgNS, 'text')
-    value.setAttribute('text-anchor', 'middle')
-    value.setAttribute('dy', valueVertOffset)
-    value.setAttribute('font-size', '20em')
-    value.setAttribute('transform', `scale(${scale})`)
-    value.appendChild(document.createTextNode(config.value))
-
-    gValue.appendChild(value)
-
-    svg.append(title, subtitle, gValue)
+    svg.appendChild(generateValueSVG(config.value, 20))
 
     return svg
+}
+
+export default function(config, parentEl, { dashboard }) {
+    parentEl.style.overflow = 'hidden'
+    parentEl.style.display = 'flex'
+    parentEl.style.justifyContent = 'center'
+
+    return dashboard
+        ? generateDashboardItem(config)
+        : generateDVItem(config, parentEl)
 }

--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -29,13 +29,13 @@ const generateDashboardItem = config => {
     const container = document.createElement('div')
     container.setAttribute(
         'style',
-        'display: flex; flex-direction: column; align-items: center; width: 100%; height: 100%'
+        'display: flex; flex-direction: column; align-items: center; justify-content: center; width: 100%; height: 100%'
     )
 
-    const titleSubtitleStyle = 'font-size: 12px; color: #666'
+    const titleStyle = 'font-size: 12px; color: #666;'
 
     const title = document.createElement('span')
-    title.setAttribute('style', titleSubtitleStyle)
+    title.setAttribute('style', titleStyle)
     if (config.title) {
         title.appendChild(document.createTextNode(config.title))
 
@@ -43,7 +43,7 @@ const generateDashboardItem = config => {
     }
 
     const subtitle = document.createElement('span')
-    subtitle.setAttribute('style', titleSubtitleStyle)
+    subtitle.setAttribute('style', titleStyle + ' margin-top: 4px')
     if (config.subtitle) {
         subtitle.appendChild(document.createTextNode(config.subtitle))
 


### PR DESCRIPTION
For dashboard an html node is rendered with svg used only for the value.
For DV app, everything is SVG to allow for PNG/PDF download with the existing
backend solution.