### PR TITLE
fix: ui glitch for data dim groups DHIS2-7907

### DIFF
--- a/src/components/DataDimension/styles/Groups.style.js
+++ b/src/components/DataDimension/styles/Groups.style.js
@@ -4,7 +4,7 @@ export const styles = {
     container: {
         border: `1px solid ${colors.greyLight}`,
         display: 'flex',
-        flexFlow: 'column',
+        flexDirection: 'column',
         height: '53px',
         borderRight: '0px',
         borderLeft: '0px',
@@ -14,7 +14,7 @@ export const styles = {
     },
     groupContainer: {
         display: 'flex',
-        flexFlow: 'column',
+        flexDirection: 'column',
         width: 'inherit',
         minWidth: '316px',
     },

--- a/src/components/DataDimension/styles/Groups.style.js
+++ b/src/components/DataDimension/styles/Groups.style.js
@@ -4,18 +4,19 @@ export const styles = {
     container: {
         border: `1px solid ${colors.greyLight}`,
         display: 'flex',
+        flexFlow: 'column',
         height: '53px',
-        width: '420px',
         borderRight: '0px',
         borderLeft: '0px',
         paddingTop: '5px',
+        paddingLeft: '5px',
+        paddingRight: '5px',
     },
     groupContainer: {
         display: 'flex',
         flexFlow: 'column',
         width: 'inherit',
         minWidth: '316px',
-        paddingLeft: '5px',
     },
     titleText: {
         color: colors.greyDark,


### PR DESCRIPTION
* Fixes UI glitch for the data dimension group item selector which was misaligned with the container element (specified here: https://jira.dhis2.org/browse/DHIS2-7907)