### PR TITLE
fix: fix Dimension Panel styles after ui-core update

### DIFF
--- a/src/components/DimensionsPanel/List/styles/DimensionList.style.js
+++ b/src/components/DimensionsPanel/List/styles/DimensionList.style.js
@@ -14,5 +14,6 @@ export const styles = {
         height: '100%',
         overflow: 'auto',
         marginTop: '0px',
+        padding: 0,
     },
 }

--- a/src/components/DimensionsPanel/styles/DimensionsPanel.style.js
+++ b/src/components/DimensionsPanel/styles/DimensionsPanel.style.js
@@ -7,6 +7,7 @@ export const styles = {
         flexDirection: 'column',
         backgroundColor: colors.snow,
         padding: '8px',
+        overflow: 'hidden',
     },
     textField: {
         paddingBottom: '6px',


### PR DESCRIPTION
This is the left padding of the dimensions list and the overflow of the
parent container to avoid showing a double scrolling bar.