### PR TITLE
fix: broken array contains/includes check

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/series/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/index.js
@@ -90,7 +90,7 @@ function getDefault(series, layout, isStacked, extraOptions) {
         if (layout.noSpaceBetweenColumns) {
             const seriesType = getType(layout.type).type
 
-            if (arrayContains(epiCurveTypes, seriesType)) {
+            if (epiCurveTypes.includes(seriesType)) {
                 seriesObj.pointPadding = 0
                 seriesObj.groupPadding = 0
             }


### PR DESCRIPTION
Broken due to missing import. Fix by changing from deprecated lib to ES6. 