### PR TITLE
fix: unimported code

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/series/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/index.js
@@ -86,7 +86,7 @@ function getDefault(series, layout, isStacked, extraOptions) {
         if (layout.noSpaceBetweenColumns) {
             const seriesType = getType(layout.type).type
 
-            if (arrayContains(epiCurveTypes, seriesType)) {
+            if (epiCurveTypes.includes(seriesType)) {
                 seriesObj.pointPadding = 0
                 seriesObj.groupPadding = 0
             }


### PR DESCRIPTION
arrayContains was not imported, fixing by using Array.includes instead as d2-utilizr is deprecated.