### PR TITLE
fix: use optimizeForSpeed mode for styled-jsx

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -18,7 +18,7 @@ module.exports = function(api) {
     if (api.env(['test'])) {
         styledJsxPlugin = 'styled-jsx/babel-test'
     } else {
-        styledJsxPlugin = 'styled-jsx/babel'
+        styledJsxPlugin = ['styled-jsx/babel', { optimizeForSpeed: true }]
     }
 
     return {
@@ -29,6 +29,7 @@ module.exports = function(api) {
             '@babel/plugin-transform-react-constant-elements',
             '@babel/plugin-transform-shorthand-properties',
             '@babel/plugin-transform-runtime',
-        ].concat(styledJsxPlugin),
+            styledJsxPlugin,
+        ],
     }
 }


### PR DESCRIPTION
Styled-jsx must be compiled with `optimizeForSpeed: true` in libraries, otherwise it only works if the app's instance of `styled-jsx` happens to be running in development mode.  This fixes the ItemSelector issue in the dimension dialog.

We should really build this library with the platform library compiler, to ensure the configuration is correct and up-to-date.  I'm making this smaller change for now, since there are some open questions about how to configure Storybook in a Platform library.