### PR TITLE
fix: helpers for full axis, locked dimension, dimension can be added to axis

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -145,6 +145,7 @@ export {
     canDimensionBeAddedToAxis,
     isDimensionLocked,
     isAxisFull,
+    getTransferableDimension,
 } from './modules/layoutUiRules'
 
 // Visualizations

--- a/src/index.js
+++ b/src/index.js
@@ -142,6 +142,9 @@ export {
     hasAxisTooManyItems,
     getAxisPerLockedDimension,
     getAllLockedDimensionIds,
+    canDimensionBeAddedToAxis,
+    isDimensionLocked,
+    isAxisFull,
 } from './modules/layoutUiRules'
 
 // Visualizations

--- a/src/modules/layoutUiRules/index.js
+++ b/src/modules/layoutUiRules/index.js
@@ -10,8 +10,8 @@ export {
 
 export {
     hasAxisTooManyItemsByVisType as hasAxisTooManyItems,
-    isDimensionLocked,
-    isAxisFull,
-    canDimensionBeAddedToAxis,
+    isDimensionLockedByVisType as isDimensionLocked,
+    isAxisFullByVisType as isAxisFull,
+    canDimensionBeAddedToAxisByVisType as canDimensionBeAddedToAxis,
     getTransferableDimensionPerAxisByVisType as getTransferableDimension,
 } from './rulesUtils'

--- a/src/modules/layoutUiRules/index.js
+++ b/src/modules/layoutUiRules/index.js
@@ -7,4 +7,7 @@ export {
     hasAxisTooManyItemsByVisType as hasAxisTooManyItems,
     getAxisPerLockedDimByVisType as getAxisPerLockedDimension,
     getAllLockedDimIdsByVisType as getAllLockedDimensionIds,
+    isDimensionLocked,
+    isAxisFull,
+    canDimensionBeAddedToAxis,
 } from './rulesHelper'

--- a/src/modules/layoutUiRules/index.js
+++ b/src/modules/layoutUiRules/index.js
@@ -4,10 +4,14 @@ export {
     getAxisMaxNumberOfItemsByVisType as getAxisMaxNumberOfItems,
     getAxisMaxNumberOfDimsByVisType as getAxisMaxNumberOfDimensions,
     getAxisMinNumberOfDimsByVisType as getAxisMinNumberOfDimensions,
-    hasAxisTooManyItemsByVisType as hasAxisTooManyItems,
     getAxisPerLockedDimByVisType as getAxisPerLockedDimension,
     getAllLockedDimIdsByVisType as getAllLockedDimensionIds,
+} from './rulesHelper'
+
+export {
+    hasAxisTooManyItemsByVisType as hasAxisTooManyItems,
     isDimensionLocked,
     isAxisFull,
     canDimensionBeAddedToAxis,
-} from './rulesHelper'
+    getTransferableDimensionPerAxisByVisType as getTransferableDimension,
+} from './rulesUtils'

--- a/src/modules/layoutUiRules/rules.js
+++ b/src/modules/layoutUiRules/rules.js
@@ -70,6 +70,14 @@ const yearOverYearRules = {
     [RULE_PROP_DISALLOWED_DIMS]: [DIMENSION_ID_PERIOD],
 }
 
+const pivotTableRules = {
+    [RULE_PROP_AVAILABLE_AXES]: [
+        AXIS_ID_COLUMNS,
+        AXIS_ID_ROWS,
+        AXIS_ID_FILTERS,
+    ],
+}
+
 const visTypeToRules = {
     [VIS_TYPE_COLUMN]: defaultRules,
     [VIS_TYPE_STACKED_COLUMN]: defaultRules,
@@ -83,7 +91,7 @@ const visTypeToRules = {
     [VIS_TYPE_SINGLE_VALUE]: singleValueRules,
     [VIS_TYPE_YEAR_OVER_YEAR_LINE]: yearOverYearRules,
     [VIS_TYPE_YEAR_OVER_YEAR_COLUMN]: yearOverYearRules,
-    [VIS_TYPE_PIVOT_TABLE]: defaultRules,
+    [VIS_TYPE_PIVOT_TABLE]: pivotTableRules,
 }
 
 const getRulesByVisType = visType => {

--- a/src/modules/layoutUiRules/rulesHelper.js
+++ b/src/modules/layoutUiRules/rulesHelper.js
@@ -38,3 +38,25 @@ export const getAxisPerLockedDimByVisType = (visType, dimensionId) =>
 
 export const getAllLockedDimIdsByVisType = visType =>
     Object.keys(getLockedDimsByVisType(visType))
+
+export const isDimensionLocked = (visType, dimensionId) =>
+    getAllLockedDimIdsByVisType(visType).find(id => id === dimensionId)
+
+export const isAxisFull = (visType, axisId, axisDimensionsCount) =>
+    axisDimensionsCount === getAxisMaxNumberOfDimsByVisType(visType, axisId)
+
+export const canDimensionBeAddedToAxis = (visType, layout, axisId) => {
+    const axisIsFull = isAxisFull(visType, axisId, layout[axisId].length)
+    const dimensionIsLocked = isDimensionLocked(visType, layout[axisId][0])
+
+    // 1 dimension allowed in axis
+    // 1 dimension is already present and not locked
+    // the dragged one can be added and will cause the old one to be moved to filters
+    if (axisIsFull && !dimensionIsLocked) {
+        return true
+    } else if (!axisIsFull) {
+        return true
+    }
+
+    return false
+}

--- a/src/modules/layoutUiRules/rulesHelper.js
+++ b/src/modules/layoutUiRules/rulesHelper.js
@@ -18,45 +18,8 @@ export const getAxisMaxNumberOfDimsByVisType = (visType, axisId) =>
 export const getAxisMinNumberOfDimsByVisType = (visType, axisId) =>
     getMinNumberOfDimsPerAxisByVisType(visType)[axisId]
 
-export const hasAxisTooManyItemsByVisType = (
-    visType,
-    axisId,
-    numberOfItems
-) => {
-    const maxNumberOfItemsPerAxis = getAxisMaxNumberOfItemsByVisType(
-        visType,
-        axisId
-    )
-
-    return maxNumberOfItemsPerAxis
-        ? numberOfItems > maxNumberOfItemsPerAxis
-        : false
-}
-
 export const getAxisPerLockedDimByVisType = (visType, dimensionId) =>
     getLockedDimsByVisType(visType)[dimensionId]
 
 export const getAllLockedDimIdsByVisType = visType =>
     Object.keys(getLockedDimsByVisType(visType))
-
-export const isDimensionLocked = (visType, dimensionId) =>
-    getAllLockedDimIdsByVisType(visType).find(id => id === dimensionId)
-
-export const isAxisFull = (visType, axisId, axisDimensionsCount) =>
-    axisDimensionsCount === getAxisMaxNumberOfDimsByVisType(visType, axisId)
-
-export const canDimensionBeAddedToAxis = (visType, layout, axisId) => {
-    const axisIsFull = isAxisFull(visType, axisId, layout[axisId].length)
-    const dimensionIsLocked = isDimensionLocked(visType, layout[axisId][0])
-
-    // 1 dimension allowed in axis
-    // 1 dimension is already present and not locked
-    // the dragged one can be added and will cause the old one to be moved to filters
-    if (axisIsFull && !dimensionIsLocked) {
-        return true
-    } else if (!axisIsFull) {
-        return true
-    }
-
-    return false
-}

--- a/src/modules/layoutUiRules/rulesUtils.js
+++ b/src/modules/layoutUiRules/rulesUtils.js
@@ -22,7 +22,7 @@ export const hasAxisTooManyItemsByVisType = (
 }
 
 export const isDimensionLocked = (visType, dimensionId) =>
-    getAllLockedDimIdsByVisType(visType).find(id => id === dimensionId)
+    getAllLockedDimIdsByVisType(visType).includes(dimensionId)
 
 export const isAxisFull = (visType, axisId, axisDimensionsCount) =>
     axisDimensionsCount >= getAxisMaxNumberOfDimsByVisType(visType, axisId)

--- a/src/modules/layoutUiRules/rulesUtils.js
+++ b/src/modules/layoutUiRules/rulesUtils.js
@@ -1,0 +1,61 @@
+import { getLockedDimsByVisType } from './rules'
+
+import {
+    getAxisMaxNumberOfDimsByVisType,
+    getAxisMaxNumberOfItemsByVisType,
+    getAllLockedDimIdsByVisType,
+} from './rulesHelper'
+
+export const hasAxisTooManyItemsByVisType = (
+    visType,
+    axisId,
+    numberOfItems
+) => {
+    const maxNumberOfItemsPerAxis = getAxisMaxNumberOfItemsByVisType(
+        visType,
+        axisId
+    )
+
+    return maxNumberOfItemsPerAxis
+        ? numberOfItems > maxNumberOfItemsPerAxis
+        : false
+}
+
+export const isDimensionLocked = (visType, dimensionId) =>
+    getAllLockedDimIdsByVisType(visType).find(id => id === dimensionId)
+
+export const isAxisFull = (visType, axisId, axisDimensionsCount) =>
+    axisDimensionsCount === getAxisMaxNumberOfDimsByVisType(visType, axisId)
+
+export const canDimensionBeAddedToAxis = (visType, layout, axisId) => {
+    const axisIsFull = isAxisFull(visType, axisId, layout[axisId].length)
+    const transferableDimension = getTransferableDimensionPerAxisByVisType(
+        visType,
+        axisId,
+        layout
+    )
+
+    // 1 dimension allowed in axis
+    // 1 dimension is already present and not locked
+    // the dragged one can be added and will cause the old one to be moved to filters
+    // what happens with max limit > 1, axis full and 1 or more locked dimensions?
+    return !(axisIsFull && !transferableDimension)
+}
+
+export const getTransferableDimensionPerAxisByVisType = (
+    visType,
+    axisId,
+    layout
+) => {
+    const lockedDimsByVisType = getLockedDimsByVisType(visType)
+    const lockedDimIdsByAxis = Object.keys(lockedDimsByVisType).filter(
+        dimId => lockedDimsByVisType[dimId] === axisId
+    )
+
+    // return the last "transferable" dimension, this needs to be adjusted
+    // if we allow a defined max limit > 1 and the DND wants to drop the new
+    // dimension in a specific position
+    return layout[axisId]
+        .filter(dimId => !lockedDimIdsByAxis.includes(dimId))
+        .pop()
+}

--- a/src/modules/layoutUiRules/rulesUtils.js
+++ b/src/modules/layoutUiRules/rulesUtils.js
@@ -27,12 +27,12 @@ export const isDimensionLocked = (visType, dimensionId) =>
 export const isAxisFull = (visType, axisId, axisDimensionsCount) =>
     axisDimensionsCount >= getAxisMaxNumberOfDimsByVisType(visType, axisId)
 
-export const canDimensionBeAddedToAxis = (visType, layout, axisId) => {
-    const axisIsFull = isAxisFull(visType, axisId, layout[axisId].length)
+export const canDimensionBeAddedToAxis = (visType, axis, axisId) => {
+    const axisIsFull = isAxisFull(visType, axisId, axis.length)
     const transferableDimension = getTransferableDimensionPerAxisByVisType(
         visType,
         axisId,
-        layout
+        axis
     )
 
     // 1 dimension allowed in axis
@@ -45,7 +45,7 @@ export const canDimensionBeAddedToAxis = (visType, layout, axisId) => {
 export const getTransferableDimensionPerAxisByVisType = (
     visType,
     axisId,
-    layout
+    axis
 ) => {
     const lockedDimsByVisType = getLockedDimsByVisType(visType)
     const lockedDimIdsByAxis = Object.keys(lockedDimsByVisType).filter(
@@ -55,7 +55,5 @@ export const getTransferableDimensionPerAxisByVisType = (
     // return the last "transferable" dimension, this needs to be adjusted
     // if we allow a defined max limit > 1 and the DND wants to drop the new
     // dimension in a specific position
-    return layout[axisId]
-        .filter(dimId => !lockedDimIdsByAxis.includes(dimId))
-        .pop()
+    return axis.filter(dimId => !lockedDimIdsByAxis.includes(dimId)).pop()
 }

--- a/src/modules/layoutUiRules/rulesUtils.js
+++ b/src/modules/layoutUiRules/rulesUtils.js
@@ -25,7 +25,7 @@ export const isDimensionLocked = (visType, dimensionId) =>
     getAllLockedDimIdsByVisType(visType).find(id => id === dimensionId)
 
 export const isAxisFull = (visType, axisId, axisDimensionsCount) =>
-    axisDimensionsCount === getAxisMaxNumberOfDimsByVisType(visType, axisId)
+    axisDimensionsCount >= getAxisMaxNumberOfDimsByVisType(visType, axisId)
 
 export const canDimensionBeAddedToAxis = (visType, layout, axisId) => {
     const axisIsFull = isAxisFull(visType, axisId, layout[axisId].length)

--- a/src/modules/layoutUiRules/rulesUtils.js
+++ b/src/modules/layoutUiRules/rulesUtils.js
@@ -21,14 +21,14 @@ export const hasAxisTooManyItemsByVisType = (
         : false
 }
 
-export const isDimensionLocked = (visType, dimensionId) =>
+export const isDimensionLockedByVisType = (visType, dimensionId) =>
     getAllLockedDimIdsByVisType(visType).includes(dimensionId)
 
-export const isAxisFull = (visType, axisId, axisDimensionsCount) =>
+export const isAxisFullByVisType = (visType, axisId, axisDimensionsCount) =>
     axisDimensionsCount >= getAxisMaxNumberOfDimsByVisType(visType, axisId)
 
-export const canDimensionBeAddedToAxis = (visType, axis, axisId) => {
-    const axisIsFull = isAxisFull(visType, axisId, axis.length)
+export const canDimensionBeAddedToAxisByVisType = (visType, axis, axisId) => {
+    const axisIsFull = isAxisFullByVisType(visType, axisId, axis.length)
     const transferableDimension = getTransferableDimensionPerAxisByVisType(
         visType,
         axisId,


### PR DESCRIPTION
These are used when a dimension is added/moved/dragged in the layout.
It respects the layout rules by checking the current state of the destination axis (is full, the dimension already present is locked...) to avoid incorrectly adding a dimension.