### PR TITLE
fix: dynamic axis names based on vis type

### DIFF
--- a/src/components/DimensionMenu.js
+++ b/src/components/DimensionMenu.js
@@ -12,10 +12,13 @@ import { getAvailableAxes } from '../modules/layoutUiRules'
 import { AXIS_ID_COLUMNS, AXIS_ID_FILTERS } from '../modules/layout/axis'
 import { DIMENSION_ID_DATA } from '../modules/predefinedDimensions'
 import { isDualAxisType, getDisplayNameByVisType } from '../modules/visTypes'
-import { getAxisNameByVisType } from '../modules/axis'
+import { getAxisNameByLayoutType } from '../modules/axis'
+import { getLayoutTypeByVisType } from '../modules/visTypeToLayoutType'
 
-const getAxisItemLabelPrefix = isDimensionInLayout =>
-    isDimensionInLayout ? 'Move to' : 'Add to'
+const getAxisItemLabel = (axisName, isDimensionInLayout) =>
+    isDimensionInLayout
+        ? i18n.t('Move to {{axisName}}', { axisName })
+        : i18n.t('Add to {{axisName}}', { axisName })
 
 const getRemoveMenuItem = onClick => (
     <MenuItem key="remove-menu-item" onClick={onClick}>
@@ -185,10 +188,12 @@ export class DimensionMenu extends Component {
                                             closeWholeMenu()
                                         }}
                                     >
-                                        {`${getAxisItemLabelPrefix()} ${getAxisNameByVisType(
-                                            destination,
-                                            visType
-                                        )}`}
+                                        {getAxisItemLabel(
+                                            getAxisNameByLayoutType(
+                                                destination,
+                                                getLayoutTypeByVisType(visType)
+                                            )
+                                        )}
                                     </MenuItem>
                                 )
                             )}
@@ -244,10 +249,12 @@ export class DimensionMenu extends Component {
                         closeWholeMenu()
                     }}
                 >
-                    {i18n.t(
-                        `${getAxisItemLabelPrefix(
-                            isDimensionInLayout
-                        )} ${getAxisNameByVisType(axisId, visType)}`
+                    {getAxisItemLabel(
+                        getAxisNameByLayoutType(
+                            axisId,
+                            getLayoutTypeByVisType(visType)
+                        ),
+                        isDimensionInLayout
                     )}
                 </MenuItem>
             ))

--- a/src/components/DimensionMenu.js
+++ b/src/components/DimensionMenu.js
@@ -26,8 +26,8 @@ const getRemoveMenuItem = onClick => (
 const getDividerItem = key => <Divider light key={key} />
 
 const getUnavailableLabel = visType =>
-    i18n.t('Not available for {{visType}}', {
-        visType: getDisplayNameByVisType(visType),
+    i18n.t('Not available for {{visualizationType}}', {
+        visualizationType: getDisplayNameByVisType(visType),
     })
 
 const getDualAxisMenuItemLabel = (
@@ -185,12 +185,10 @@ export class DimensionMenu extends Component {
                                             closeWholeMenu()
                                         }}
                                     >
-                                        {i18n.t(
-                                            `${getAxisItemLabelPrefix()} ${getAxisNameByVisType(
-                                                destination,
-                                                visType
-                                            )}`
-                                        )}
+                                        {`${getAxisItemLabelPrefix()} ${getAxisNameByVisType(
+                                            destination,
+                                            visType
+                                        )}`}
                                     </MenuItem>
                                 )
                             )}

--- a/src/components/DimensionMenu.js
+++ b/src/components/DimensionMenu.js
@@ -12,7 +12,7 @@ import { getAvailableAxes } from '../modules/layoutUiRules'
 import { AXIS_ID_COLUMNS, AXIS_ID_FILTERS } from '../modules/layout/axis'
 import { DIMENSION_ID_DATA } from '../modules/predefinedDimensions'
 import { isDualAxisType, getDisplayNameByVisType } from '../modules/visTypes'
-import { getAxisName } from '../modules/axis'
+import { getAxisNameByVisType } from '../modules/axis'
 
 const getAxisItemLabelPrefix = isDimensionInLayout =>
     isDimensionInLayout ? 'Move to' : 'Add to'
@@ -186,8 +186,9 @@ export class DimensionMenu extends Component {
                                         }}
                                     >
                                         {i18n.t(
-                                            `${getAxisItemLabelPrefix()} ${getAxisName(
-                                                destination
+                                            `${getAxisItemLabelPrefix()} ${getAxisNameByVisType(
+                                                destination,
+                                                visType
                                             )}`
                                         )}
                                     </MenuItem>
@@ -248,7 +249,7 @@ export class DimensionMenu extends Component {
                     {i18n.t(
                         `${getAxisItemLabelPrefix(
                             isDimensionInLayout
-                        )} ${getAxisName(axisId)}`
+                        )} ${getAxisNameByVisType(axisId, visType)}`
                     )}
                 </MenuItem>
             ))

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ export { apiFetchDimensions, apiFetchRecommendedIds } from './api/dimensions'
 
 // Modules: axis
 
-export { getAxisName } from './modules/axis'
+export { getAxisNameByVisType, getAxisNameByLayoutType } from './modules/axis'
 
 // Modules: predefined dimensions
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ export { apiFetchDimensions, apiFetchRecommendedIds } from './api/dimensions'
 
 // Modules: axis
 
-export { getAxisNameByVisType, getAxisNameByLayoutType } from './modules/axis'
+export { getAxisName, getAxisNameByLayoutType } from './modules/axis'
 
 // Modules: predefined dimensions
 

--- a/src/modules/axis.js
+++ b/src/modules/axis.js
@@ -6,7 +6,6 @@ import {
     LAYOUT_TYPE_YEAR_OVER_YEAR,
     LAYOUT_TYPE_PIVOT_TABLE,
 } from './layoutTypes'
-import { getLayoutTypeByVisType } from './visTypeToLayoutType'
 
 const getAxisNamesByLayoutType = layoutType => {
     switch (layoutType) {
@@ -37,5 +36,5 @@ export const getAxisNameByLayoutType = (axisId, layoutType) => {
     return name
 }
 
-export const getAxisNameByVisType = (axisId, visType) =>
-    getAxisNameByLayoutType(axisId, getLayoutTypeByVisType(visType))
+export const getAxisName = axisId =>
+    getAxisNameByLayoutType(axisId, LAYOUT_TYPE_DEFAULT)

--- a/src/modules/axis.js
+++ b/src/modules/axis.js
@@ -1,26 +1,41 @@
 import i18n from '@dhis2/d2-i18n'
+import { AXIS_ID_COLUMNS, AXIS_ID_ROWS, AXIS_ID_FILTERS } from './layout/axis'
 import {
-    AXIS_ID_COLUMNS,
-    AXIS_ID_ROWS,
-    AXIS_ID_FILTERS,
-    AXIS_ID_YEAR_OVER_YEAR_SERIES,
-    AXIS_ID_YEAR_OVER_YEAR_CATEGORY,
-} from './layout/axis'
+    LAYOUT_TYPE_DEFAULT,
+    LAYOUT_TYPE_PIE,
+    LAYOUT_TYPE_YEAR_OVER_YEAR,
+    LAYOUT_TYPE_PIVOT_TABLE,
+} from './layoutTypes'
+import { getLayoutTypeByVisType } from './visTypeToLayoutType'
 
-const axisNames = {
-    [AXIS_ID_COLUMNS]: i18n.t('Series'),
-    [AXIS_ID_ROWS]: i18n.t('Category'),
-    [AXIS_ID_FILTERS]: i18n.t('Filter'),
-    [AXIS_ID_YEAR_OVER_YEAR_SERIES]: i18n.t('Series'),
-    [AXIS_ID_YEAR_OVER_YEAR_CATEGORY]: i18n.t('Category'),
+const getAxisNamesByLayoutType = layoutType => {
+    switch (layoutType) {
+        case LAYOUT_TYPE_DEFAULT:
+        case LAYOUT_TYPE_PIE:
+        case LAYOUT_TYPE_YEAR_OVER_YEAR:
+        default:
+            return {
+                [AXIS_ID_COLUMNS]: i18n.t('Series'),
+                [AXIS_ID_ROWS]: i18n.t('Category'),
+                [AXIS_ID_FILTERS]: i18n.t('Filter'),
+            }
+        case LAYOUT_TYPE_PIVOT_TABLE:
+            return {
+                [AXIS_ID_COLUMNS]: i18n.t('Columns'),
+                [AXIS_ID_ROWS]: i18n.t('Rows'),
+                [AXIS_ID_FILTERS]: i18n.t('Filter'),
+            }
+    }
 }
 
-export const getAxisName = axisId => {
-    const name = axisNames[axisId]
-
+export const getAxisNameByLayoutType = (axisId, layoutType) => {
+    const name = getAxisNamesByLayoutType(layoutType)[axisId]
     if (!name) {
         throw new Error(`${axisId} is not a valid axis id`)
     }
 
     return name
 }
+
+export const getAxisNameByVisType = (axisId, visType) =>
+    getAxisNameByLayoutType(axisId, getLayoutTypeByVisType(visType))

--- a/src/visualizations/store/adapters/dhis_highcharts/index.js
+++ b/src/visualizations/store/adapters/dhis_highcharts/index.js
@@ -11,8 +11,6 @@ import {
     VIS_TYPE_GAUGE,
  } from '../../../../modules/visTypes'
 
-VIS_TYPE_GAUGE
-
 const VALUE_ID = 'value'
 
 function arrayNullsOnly(array) {


### PR DESCRIPTION
* Dynamically fetching axis names based on vis type or layout type

Note: `getAxisName` is deprecated but kept for backwards compatibility. It's replaced by `getAxisNameByLayoutType`