### PR TITLE
fix: only run empty check after all values have been added

### DIFF
--- a/src/visualizations/store/adapters/dhis_highcharts/index.js
+++ b/src/visualizations/store/adapters/dhis_highcharts/index.js
@@ -4,14 +4,12 @@ import arrayUnique from 'd2-utilizr/lib/arrayUnique'
 import getYearOnYear from './yearOnYear'
 import getPie from './pie'
 import getGauge from './gauge'
-import { 
+import {
     VIS_TYPE_YEAR_OVER_YEAR_COLUMN,
     VIS_TYPE_YEAR_OVER_YEAR_LINE,
     VIS_TYPE_PIE,
     VIS_TYPE_GAUGE,
  } from '../../../../modules/visTypes'
-
-VIS_TYPE_GAUGE
 
 const VALUE_ID = 'value'
 
@@ -66,13 +64,13 @@ function getDefault(acc, seriesIds, categoryIds, idValueMap, metaData) {
             // in that case null is returned as value in the serie
             // this is to keep the correct indexes for the values within the serie array
             serieData.push(value == undefined ? null : parseFloat(value))
-
-            // if the whole serie has no data, do not return a list of null values
-            // otherwise Highcharts thinks that data is available and does not show the "No data to display" message
-            if (arrayNullsOnly(serieData)) {
-                serieData.length = 0
-            }
         })
+
+        // if the whole serie has no data, do not return a list of null values
+        // otherwise Highcharts thinks that data is available and does not show the "No data to display" message
+        if (arrayNullsOnly(serieData)) {
+            serieData.length = 0
+        }
 
         acc.push({
             id: seriesId,


### PR DESCRIPTION
Data array was attempted emptied on every iteration, causing a mismatch between data/categories when there were initial empty values. Moving the empty check out of the loop.