### PR TITLE
fix: lock icon horizontal alignment

### DIFF
--- a/src/components/DimensionsPanel/List/__tests__/__snapshots__/DimensionItem.spec.js.snap
+++ b/src/components/DimensionsPanel/List/__tests__/__snapshots__/DimensionItem.spec.js.snap
@@ -147,6 +147,7 @@ exports[`DimensionItem matches the snapshot with locked 1`] = `
         style={
           Object {
             "fontSize": "14px",
+            "marginTop": "1px",
           }
         }
       />

--- a/src/components/DimensionsPanel/List/styles/DimensionItem.style.js
+++ b/src/components/DimensionsPanel/List/styles/DimensionItem.style.js
@@ -43,6 +43,7 @@ export const styles = {
     },
     lockIcon: {
         fontSize: '14px',
+        marginTop: '1px',
     },
     optionsWrapper: {
         position: 'relative',


### PR DESCRIPTION
The 🔒 icon that's shown on Data for e.g. Single Value visualizations was misaligned horizontally, see screenshots below:

Before
![image](https://user-images.githubusercontent.com/12590483/74537119-c11f3700-4f39-11ea-8c17-e853bb99c4f3.png)

After
![image](https://user-images.githubusercontent.com/12590483/74537152-d2684380-4f39-11ea-86f9-c40c27c20ca8.png)
