### PR TITLE
feat: support fixed legends and fix floating-point totals bug

### DIFF
--- a/src/components/PivotTable/PivotTable.js
+++ b/src/components/PivotTable/PivotTable.js
@@ -11,14 +11,14 @@ import { PivotTableClippedAxis } from './PivotTableClippedAxis'
 import { PivotTableTitleRow } from './PivotTableTitleRow'
 import { PivotTableEmptyRow } from './PivotTableEmptyRow'
 
-const PivotTable = ({ visualization, data }) => {
+const PivotTable = ({ visualization, data, legendSets }) => {
     const containerRef = useRef(undefined)
     const { width, height } = useParentSize(containerRef)
 
-    const engine = useMemo(() => new PivotTableEngine(visualization, data), [
-        visualization,
-        data,
-    ])
+    const engine = useMemo(
+        () => new PivotTableEngine(visualization, data, legendSets),
+        [visualization, data, legendSets]
+    )
 
     const clippingResult = useTableClipping({
         containerRef,
@@ -88,6 +88,7 @@ const PivotTable = ({ visualization, data }) => {
 PivotTable.propTypes = {
     data: PropTypes.object.isRequired,
     visualization: PropTypes.object.isRequired,
+    legendSets: PropTypes.arrayOf(PropTypes.object),
 }
 
 export default PivotTable

--- a/src/components/PivotTable/PivotTableValueCell.js
+++ b/src/components/PivotTable/PivotTableValueCell.js
@@ -2,21 +2,27 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { cell as cellStyle } from './styles/PivotTable.style'
 import { renderValue } from '../../modules/pivotTable/renderValue'
+import { applyLegendSet } from '../../modules/pivotTable/applyLegendSet'
 
 export const PivotTableValueCell = ({ engine, row, column }) => {
-    const value = renderValue(
-        engine.get({
-            row,
-            column,
-        }),
-        engine.visualization
-    )
+    const rawValue = engine.get({
+        row,
+        column,
+    })
+
+    const value = renderValue(rawValue, engine.visualization)
     const type = engine.getCellType({
         row,
         column,
     })
+
+    const style =
+        type === 'value'
+            ? applyLegendSet(parseFloat(rawValue), engine)
+            : undefined
+
     return (
-        <td key={column} className={type} title={value}>
+        <td key={column} className={type} title={value} style={style}>
             <style jsx>{cellStyle}</style>
             {value || null}
         </td>

--- a/src/components/PivotTable/styles/PivotTable.style.js
+++ b/src/components/PivotTable/styles/PivotTable.style.js
@@ -1,9 +1,11 @@
 import css from 'styled-jsx/css'
+import { colors } from '@dhis2/ui-core'
 
 export const table = css`
     div.pivot-table-container {
         overflow: auto;
         font-size: 10px;
+        color: ${colors.grey900};
     }
     div.pivot-table-container::-webkit-scrollbar {
         -webkit-appearance: none;

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -152,6 +152,7 @@ export class PivotTableEngine {
     visualization
     rawData
     options
+    legendSets
 
     dimensionLookup
 
@@ -165,8 +166,12 @@ export class PivotTableEngine {
     rowMap = []
     columnMap = []
 
-    constructor(visualization, data) {
+    constructor(visualization, data, legendSets) {
         this.visualization = visualization
+        this.legendSets = (legendSets || []).reduce((sets, set) => {
+            sets[set.id] = set
+            return sets
+        }, {})
         this.rawData = data
         this.options = {
             ...defaultOptions,

--- a/src/modules/pivotTable/applyLegendSet.js
+++ b/src/modules/pivotTable/applyLegendSet.js
@@ -1,0 +1,68 @@
+import { isColorBright } from './isColorBright'
+
+const LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM = 'BY_DATA_ITEM'
+const LEGEND_DISPLAY_STRATEGY_FIXED = 'FIXED'
+
+const LEGEND_DISPLAY_STYLE_FILL = 'FILL'
+const LEGEND_DISPLAY_STYLE_TEXT = 'TEXT'
+
+const valueFitsLegend = (value, legend) =>
+    legend.startValue <= value && legend.endValue > value // TODO: Confirm inclusive/exclusive bounds
+
+const getLegendSet = engine => {
+    let legendSetId
+    switch (engine.visualization.legendDisplayStrategy) {
+        case LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM:
+            legendSetId = undefined // TODO: ByDXID LegendSet
+            //engine.rawData.metaData.items[dxId].legendSet
+            break
+        case LEGEND_DISPLAY_STRATEGY_FIXED:
+        default:
+            legendSetId = engine.visualization.legendSet
+                ? engine.visualization.legendSet.id
+                : undefined
+            break
+    }
+
+    return engine.legendSets[legendSetId]
+}
+
+const buildStyleObject = (legend, engine) => {
+    const style = {}
+    switch (engine.visualization.legendDisplayStyle) {
+        case LEGEND_DISPLAY_STYLE_TEXT:
+            style.color = legend.color
+            // TODO: Adapt background color for light text colors
+            break
+        case LEGEND_DISPLAY_STYLE_FILL:
+        default:
+            style.backgroundColor = legend.color
+            if (isColorBright(legend.color)) {
+                style.color = '#000000' // TODO: Don't hard-code color here!
+            } else {
+                style.color = '#FFFFFF' // TODO: Don't hard-code color here!
+            }
+            break
+    }
+    return style
+}
+
+export const applyLegendSet = (value, engine) => {
+    if (isNaN(value) || !engine.legendSets) {
+        return {}
+    }
+
+    const legendSet = getLegendSet(engine)
+    if (!legendSet) {
+        return {}
+    }
+
+    const legend = legendSet.legends.find(legend =>
+        valueFitsLegend(value, legend)
+    )
+    if (!legend) {
+        return {}
+    }
+
+    return buildStyleObject(legend, engine)
+}

--- a/src/modules/pivotTable/applyLegendSet.js
+++ b/src/modules/pivotTable/applyLegendSet.js
@@ -1,4 +1,5 @@
 import { isColorBright } from './isColorBright'
+import { colors } from '@dhis2/ui-core'
 
 const LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM = 'BY_DATA_ITEM'
 const LEGEND_DISPLAY_STRATEGY_FIXED = 'FIXED'
@@ -38,9 +39,9 @@ const buildStyleObject = (legend, engine) => {
         default:
             style.backgroundColor = legend.color
             if (isColorBright(legend.color)) {
-                style.color = '#000000' // TODO: Don't hard-code color here!
+                style.color = colors.grey900
             } else {
-                style.color = '#FFFFFF' // TODO: Don't hard-code color here!
+                style.color = colors.white
             }
             break
     }

--- a/src/modules/pivotTable/isColorBright.js
+++ b/src/modules/pivotTable/isColorBright.js
@@ -1,0 +1,32 @@
+const calculateColorBrightness = function(rgb) {
+    return Math.round(
+        (parseInt(rgb[0]) * 299 +
+            parseInt(rgb[1]) * 587 +
+            parseInt(rgb[2]) * 114) /
+            1000
+    )
+}
+
+const isHex = color => {
+    return typeof color === 'string' && color.charAt(0) === '#'
+}
+
+const hexToRgb = hex => {
+    const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex)
+
+    return result
+        ? [
+              parseInt(result[1], 16),
+              parseInt(result[2], 16),
+              parseInt(result[3], 16),
+          ]
+        : null
+}
+
+export const isColorBright = color => {
+    if (isHex(color)) {
+        color = hexToRgb(color)
+    }
+
+    return calculateColorBrightness(color) > 125
+}

--- a/src/modules/pivotTable/renderValue.js
+++ b/src/modules/pivotTable/renderValue.js
@@ -35,12 +35,31 @@ const getSeparator = visualization => {
     }
 }
 
+const toFixedPrecisionString = (value, skipRounding) => {
+    if (typeof value !== 'number') {
+        // Values returned from the server should keep their string representation
+        return value
+    }
+
+    const precision = skipRounding ? 10 : value > -1 && value < 1 ? 2 : 1
+
+    return value.toFixed(precision)
+}
+
 export const renderValue = (value, visualization) => {
+    const stringValue = toFixedPrecisionString(
+        value,
+        visualization.skipRounding
+    )
+
     // TODO: check dataType in header instead of parsing here
     if (isNaN(parseFloat(value))) {
         return value
     }
 
-    const digitGroups = separateDigitGroups(value, defaultDecimalSeparator)
+    const digitGroups = separateDigitGroups(
+        stringValue,
+        defaultDecimalSeparator
+    )
     return digitGroups.join(getSeparator(visualization))
 }

--- a/stories/PivotTable.stories.js
+++ b/stories/PivotTable.stories.js
@@ -1,10 +1,12 @@
 import React, { useState, useEffect } from 'react'
 import { storiesOf } from '@storybook/react'
+import cloneDeep from 'lodash/cloneDeep'
 
 import PivotTable from '../src/components/PivotTable/PivotTable'
 
 import deepData from './data/deep.data.json'
 import deepVisualization from './data/deep.visualization.json'
+import deepLegendSet from './data/deep.legendSet.json'
 
 import emptyRowsData from './data/emptyRows.data.json'
 import emptyRowsVisualization from './data/emptyRows.visualization.json'
@@ -112,6 +114,87 @@ storiesOf('PivotTable', module).add('empty rows (hidden)', () => {
     return (
         <div style={{ width: 800, height: 600 }}>
             <PivotTable data={emptyRowsData} visualization={visualization} />
+        </div>
+    )
+})
+
+storiesOf('PivotTable', module).add('Fixed legendSet (light fill)', () => {
+    const visualization = {
+        ...deepVisualization,
+        ...visualizationReset,
+        rowSubTotals: true,
+        colSubTotals: true,
+        legendDisplayStyle: 'FILL',
+        legendSet: {
+            id: deepLegendSet.id
+        },
+    }
+    return (
+        <div style={{ width: 800, height: 600 }}>
+            <PivotTable data={deepData} visualization={visualization} legendSets={[deepLegendSet]} />
+        </div>
+    )
+})
+
+storiesOf('PivotTable', module).add('Fixed legendSet (dark fill)', () => {
+    const visualization = {
+        ...deepVisualization,
+        ...visualizationReset,
+        rowSubTotals: true,
+        colSubTotals: true,
+        legendDisplayStyle: 'FILL',
+        legendSet: {
+            id: deepLegendSet.id
+        },
+    }
+
+    const legendSet = cloneDeep(deepLegendSet)
+    legendSet.legends[0].color = '#000000'
+    legendSet.legends[1].color = '#666666'
+
+    return (
+        <div style={{ width: 800, height: 600 }}>
+            <PivotTable data={deepData} visualization={visualization} legendSets={[legendSet]} />
+        </div>
+    )
+})
+
+storiesOf('PivotTable', module).add('Fixed legendSet (text)', () => {
+    const visualization = {
+        ...deepVisualization,
+        ...visualizationReset,
+        rowSubTotals: true,
+        colSubTotals: true,
+        legendDisplayStyle: 'TEXT',
+        legendSet: {
+            id: deepLegendSet.id
+        },
+    }
+    return (
+        <div style={{ width: 800, height: 600 }}>
+            <PivotTable data={deepData} visualization={visualization} legendSets={[deepLegendSet]} />
+        </div>
+    )
+})
+
+storiesOf('PivotTable', module).add('By DX legendSet !!UNIMPLEMENTED!!', () => {
+    const visualization = {
+        ...deepVisualization,
+        ...visualizationReset,
+        rowSubTotals: true,
+        colSubTotals: true,
+    }
+    const data = {
+        ...deepData
+    }
+
+    data.metaData.items[visualization.rows[0].items[1].id].legendSet = {
+        id: deepLegendSet.id
+    }
+
+    return (
+        <div style={{ width: 800, height: 600 }}>
+            <PivotTable data={deepData} visualization={visualization} legendSets={[deepLegendSet]} />
         </div>
     )
 })

--- a/stories/data/deep.legendSet.json
+++ b/stories/data/deep.legendSet.json
@@ -1,0 +1,113 @@
+{
+    "code": "UA100",
+    "created": "2017-05-19T15:43:40.983",
+    "lastUpdated": "2017-05-19T15:43:40.983",
+    "name": "Under or above 100%",
+    "href": "http://localhost:8080/api/32/legendSets/gFJUXah1uRH",
+    "id": "gFJUXah1uRH",
+    "displayName": "Under or above 100%",
+    "publicAccess": "rw------",
+    "externalAccess": false,
+    "favorite": false,
+    "lastUpdatedBy": {
+      "id": "GOLswS44mh8"
+    },
+    "access": {
+      "read": true,
+      "update": true,
+      "externalize": false,
+      "delete": true,
+      "write": true,
+      "manage": true
+    },
+    "user": {
+      "id": "GOLswS44mh8"
+    },
+    "favorites": [
+      
+    ],
+    "userGroupAccesses": [
+      
+    ],
+    "attributeValues": [
+      
+    ],
+    "legends": [
+      {
+        "lastUpdated": "2017-05-19T15:43:40.983",
+        "id": "I0lBkYHTjPw",
+        "created": "2017-05-19T15:43:40.983",
+        "name": "Above 100%",
+        "endValue": 900.0,
+        "color": "#B4F3BD",
+        "displayName": "Above 100%",
+        "externalAccess": false,
+        "startValue": 100.0,
+        "favorite": false,
+        "access": {
+          "read": true,
+          "update": true,
+          "externalize": false,
+          "delete": true,
+          "write": true,
+          "manage": true
+        },
+        "favorites": [
+          
+        ],
+        "translations": [
+          
+        ],
+        "userGroupAccesses": [
+          
+        ],
+        "attributeValues": [
+          
+        ],
+        "userAccesses": [
+          
+        ]
+      },
+      {
+        "lastUpdated": "2017-05-19T15:43:40.984",
+        "id": "qCU0BSbmwjX",
+        "created": "2017-05-19T15:43:40.984",
+        "name": "Under 100%",
+        "endValue": 100.0,
+        "color": "#FF9C89",
+        "displayName": "Under 100%",
+        "externalAccess": false,
+        "startValue": 0.0,
+        "favorite": false,
+        "access": {
+          "read": true,
+          "update": true,
+          "externalize": false,
+          "delete": true,
+          "write": true,
+          "manage": true
+        },
+        "favorites": [
+          
+        ],
+        "translations": [
+          
+        ],
+        "userGroupAccesses": [
+          
+        ],
+        "attributeValues": [
+          
+        ],
+        "userAccesses": [
+          
+        ]
+      }
+    ],
+    "translations": [
+      
+    ],
+    "userAccesses": [
+      
+    ]
+  }

--- a/stories/data/deep.visualization.json
+++ b/stories/data/deep.visualization.json
@@ -17,7 +17,7 @@
   "showHierarchy": false,
   "cumulative": false,
   "hideTitle": false,
-  "skipRounding": true,
+  "skipRounding": false,
   "hideEmptyRows": false,
   "parentGraphMap": {
     "jUb8gELQApl": "ImspTQPwCqd",


### PR DESCRIPTION
This PR adds support for a new `legendSets` prop which can be passed to the `PivotTable` component.  This is an array of legendSets which have been fetched from the server - the caller (DV plugin) should fetch all required legendSets before rendering the PivotTable component.

This includes support for only FIXED legends, not BY_DATA_ITEM legends (coming soon) and also supports FILL/TEXT legend styling and automatic text color contrast for dark background colors.

Finally, this fixes a bug which would often cause a crash (trying to render a number when expecting a string) and another issue where floating-point total values were rendered without regard to precision (i.e. `15.000000003`).  I've re-introduced fixed-point conversion to address this.

There are several TODOs remaining (in comments), but I'd like to get this feature in to increase feature coverage incrementally rather than in a large PR.