### PR TITLE
fix: legends for gauge

### DIFF
--- a/src/modules/legends.js
+++ b/src/modules/legends.js
@@ -15,5 +15,5 @@ export const getColorByValueFromLegendSet = (legendSet, value) => {
     const legend = legendSet.legends.find(
         legend => value >= legend.startValue && value < legend.endValue // TODO: Confirm inclusive/exclusive bounds
     )
-    return legend ? legend.color : undefined
+    return legend && legend.color
 }

--- a/src/modules/legends.js
+++ b/src/modules/legends.js
@@ -4,6 +4,13 @@ export const LEGEND_DISPLAY_STRATEGY_FIXED = 'FIXED'
 export const LEGEND_DISPLAY_STYLE_FILL = 'FILL'
 export const LEGEND_DISPLAY_STYLE_TEXT = 'TEXT'
 
+export const getLegendSetById = (legendSets, id) => {
+    if (!legendSets || !id) {
+        return {}
+    }
+    return legendSets.find(legendSet => legendSet.id === id)
+}
+
 export const getColorByValueFromLegendSet = (legendSet, value) => {
     const legend = legendSet.legends.find(
         legend => value >= legend.startValue && value < legend.endValue // TODO: Confirm inclusive/exclusive bounds

--- a/src/modules/legends.js
+++ b/src/modules/legends.js
@@ -1,3 +1,9 @@
+export const LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM = 'BY_DATA_ITEM'
+export const LEGEND_DISPLAY_STRATEGY_FIXED = 'FIXED'
+
+export const LEGEND_DISPLAY_STYLE_FILL = 'FILL'
+export const LEGEND_DISPLAY_STYLE_TEXT = 'TEXT'
+
 export const getColorByValueFromLegendSet = (legendSet, value) => {
     const legend = legendSet.legends.find(
         legend => value >= legend.startValue && value < legend.endValue // TODO: Confirm inclusive/exclusive bounds

--- a/src/modules/legends.js
+++ b/src/modules/legends.js
@@ -1,0 +1,6 @@
+export const getColorByValueFromLegendSet = (legendSet, value) => {
+    const legend = legendSet.legends.find(
+        legend => value >= legend.startValue && value < legend.endValue // TODO: Confirm inclusive/exclusive bounds
+    )
+    return legend ? legend.color : undefined
+}

--- a/src/modules/legends.js
+++ b/src/modules/legends.js
@@ -4,13 +4,6 @@ export const LEGEND_DISPLAY_STRATEGY_FIXED = 'FIXED'
 export const LEGEND_DISPLAY_STYLE_FILL = 'FILL'
 export const LEGEND_DISPLAY_STYLE_TEXT = 'TEXT'
 
-export const getLegendSetById = (legendSets, id) => {
-    if (!legendSets || !id) {
-        return {}
-    }
-    return legendSets.find(legendSet => legendSet.id === id)
-}
-
 export const getColorByValueFromLegendSet = (legendSet, value) => {
     const legend = legendSet.legends.find(
         legend => value >= legend.startValue && value < legend.endValue // TODO: Confirm inclusive/exclusive bounds

--- a/src/modules/pivotTable/applyLegendSet.js
+++ b/src/modules/pivotTable/applyLegendSet.js
@@ -31,7 +31,6 @@ const buildStyleObject = (legendColor, engine) => {
     switch (engine.visualization.legendDisplayStyle) {
         case LEGEND_DISPLAY_STYLE_TEXT:
             style.color = legendColor
-            // TODO: Adapt background color for light text colors
             break
         case LEGEND_DISPLAY_STYLE_FILL:
         default:

--- a/src/modules/pivotTable/applyLegendSet.js
+++ b/src/modules/pivotTable/applyLegendSet.js
@@ -57,6 +57,9 @@ export const applyLegendSet = (value, engine) => {
     }
 
     const legendColor = getColorByValueFromLegendSet(legendSet, value)
+    if (!legendColor) {
+        return {}
+    }
 
     return buildStyleObject(legendColor, engine)
 }

--- a/src/modules/pivotTable/applyLegendSet.js
+++ b/src/modules/pivotTable/applyLegendSet.js
@@ -1,14 +1,12 @@
 import { isColorBright } from './isColorBright'
 import { colors } from '@dhis2/ui-core'
+import { getColorByValueFromLegendSet } from '../legends'
 
 const LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM = 'BY_DATA_ITEM'
 const LEGEND_DISPLAY_STRATEGY_FIXED = 'FIXED'
 
 const LEGEND_DISPLAY_STYLE_FILL = 'FILL'
 const LEGEND_DISPLAY_STYLE_TEXT = 'TEXT'
-
-const valueFitsLegend = (value, legend) =>
-    legend.startValue <= value && legend.endValue > value // TODO: Confirm inclusive/exclusive bounds
 
 const getLegendSet = engine => {
     let legendSetId
@@ -28,17 +26,17 @@ const getLegendSet = engine => {
     return engine.legendSets[legendSetId]
 }
 
-const buildStyleObject = (legend, engine) => {
+const buildStyleObject = (legendColor, engine) => {
     const style = {}
     switch (engine.visualization.legendDisplayStyle) {
         case LEGEND_DISPLAY_STYLE_TEXT:
-            style.color = legend.color
+            style.color = legendColor
             // TODO: Adapt background color for light text colors
             break
         case LEGEND_DISPLAY_STYLE_FILL:
         default:
-            style.backgroundColor = legend.color
-            if (isColorBright(legend.color)) {
+            style.backgroundColor = legendColor
+            if (isColorBright(legendColor)) {
                 style.color = colors.grey900
             } else {
                 style.color = colors.white
@@ -58,12 +56,7 @@ export const applyLegendSet = (value, engine) => {
         return {}
     }
 
-    const legend = legendSet.legends.find(legend =>
-        valueFitsLegend(value, legend)
-    )
-    if (!legend) {
-        return {}
-    }
+    const legendColor = getColorByValueFromLegendSet(legendSet, value)
 
-    return buildStyleObject(legend, engine)
+    return buildStyleObject(legendColor, engine)
 }

--- a/src/modules/pivotTable/applyLegendSet.js
+++ b/src/modules/pivotTable/applyLegendSet.js
@@ -1,12 +1,12 @@
 import { isColorBright } from './isColorBright'
 import { colors } from '@dhis2/ui-core'
-import { getColorByValueFromLegendSet } from '../legends'
-
-const LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM = 'BY_DATA_ITEM'
-const LEGEND_DISPLAY_STRATEGY_FIXED = 'FIXED'
-
-const LEGEND_DISPLAY_STYLE_FILL = 'FILL'
-const LEGEND_DISPLAY_STYLE_TEXT = 'TEXT'
+import {
+    getColorByValueFromLegendSet,
+    LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM,
+    LEGEND_DISPLAY_STRATEGY_FIXED,
+    LEGEND_DISPLAY_STYLE_TEXT,
+    LEGEND_DISPLAY_STYLE_FILL,
+} from '../legends'
 
 const getLegendSet = engine => {
     let legendSetId

--- a/src/visualizations/config/adapters/dhis_highcharts/series/gauge.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/gauge.js
@@ -3,7 +3,7 @@ import { getColorByValueFromLegendSet, LEGEND_DISPLAY_STYLE_TEXT } from "../../.
 const DEFAULT_FONT_SIZE = '34px'
 const DASHBOARD_FONT_SIZE = '24px'
 
-export default function(series, layout, extraOptions) {
+export default function(series, layout, legendSet, dashboard) {
     return [
         {
             name: series[0].name,
@@ -14,8 +14,8 @@ export default function(series, layout, extraOptions) {
                 borderWidth: 0,
                 verticalAlign: 'bottom',
                 style: {
-                    fontSize: extraOptions.dashboard ? DASHBOARD_FONT_SIZE : DEFAULT_FONT_SIZE,
-                    color: (layout.legendDisplayStyle === LEGEND_DISPLAY_STYLE_TEXT && extraOptions.legendSet) ? getColorByValueFromLegendSet(extraOptions.legendSet, series[0].data) : undefined,
+                    fontSize: dashboard ? DASHBOARD_FONT_SIZE : DEFAULT_FONT_SIZE,
+                    color: (layout.legendDisplayStyle === LEGEND_DISPLAY_STYLE_TEXT && legendSet) ? getColorByValueFromLegendSet(legendSet, series[0].data) : undefined,
                 },
             },
         },

--- a/src/visualizations/config/adapters/dhis_highcharts/series/gauge.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/gauge.js
@@ -3,7 +3,7 @@ import { getColorByValueFromLegendSet, LEGEND_DISPLAY_STYLE_TEXT } from "../../.
 const DEFAULT_FONT_SIZE = '34px'
 const DASHBOARD_FONT_SIZE = '24px'
 
-export default function(series, layout, legendSet, dashboard) {
+export default function(series, dashboard, layout, legendSet) {
     return [
         {
             name: series[0].name,

--- a/src/visualizations/config/adapters/dhis_highcharts/series/gauge.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/gauge.js
@@ -1,9 +1,14 @@
 const DEFAULT_FONT_SIZE = '34px'
 const DASHBOARD_FONT_SIZE = '24px'
 
-export default function(series, dashboard) {
-    const fontSize = dashboard ? DASHBOARD_FONT_SIZE : DEFAULT_FONT_SIZE
+const getColorByValueFromLegendSet = (legendSet, value) => {
+    const legend = legendSet.legends.find(legend =>
+        value >= legend.startValue && value < legend.endValue 
+    )    
+    return legend ? legend.color : undefined
+}
 
+export default function(series, layout, extraOptions) {
     return [
         {
             name: series[0].name,
@@ -14,7 +19,8 @@ export default function(series, dashboard) {
                 borderWidth: 0,
                 verticalAlign: 'bottom',
                 style: {
-                    fontSize: fontSize,
+                    fontSize: extraOptions.dashboard ? DASHBOARD_FONT_SIZE : DEFAULT_FONT_SIZE,
+                    color: (layout.legendDisplayStyle === "TEXT" && extraOptions.legendSet) ? getColorByValueFromLegendSet(extraOptions.legendSet, series[0].data) : undefined,
                 },
             },
         },

--- a/src/visualizations/config/adapters/dhis_highcharts/series/gauge.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/gauge.js
@@ -1,12 +1,7 @@
+import { getColorByValueFromLegendSet } from "../../../../../modules/legends"
+
 const DEFAULT_FONT_SIZE = '34px'
 const DASHBOARD_FONT_SIZE = '24px'
-
-const getColorByValueFromLegendSet = (legendSet, value) => {
-    const legend = legendSet.legends.find(legend =>
-        value >= legend.startValue && value < legend.endValue 
-    )    
-    return legend ? legend.color : undefined
-}
 
 export default function(series, layout, extraOptions) {
     return [

--- a/src/visualizations/config/adapters/dhis_highcharts/series/gauge.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/gauge.js
@@ -1,4 +1,4 @@
-import { getColorByValueFromLegendSet } from "../../../../../modules/legends"
+import { getColorByValueFromLegendSet, LEGEND_DISPLAY_STYLE_TEXT } from "../../../../../modules/legends"
 
 const DEFAULT_FONT_SIZE = '34px'
 const DASHBOARD_FONT_SIZE = '24px'
@@ -15,7 +15,7 @@ export default function(series, layout, extraOptions) {
                 verticalAlign: 'bottom',
                 style: {
                     fontSize: extraOptions.dashboard ? DASHBOARD_FONT_SIZE : DEFAULT_FONT_SIZE,
-                    color: (layout.legendDisplayStyle === "TEXT" && extraOptions.legendSet) ? getColorByValueFromLegendSet(extraOptions.legendSet, series[0].data) : undefined,
+                    color: (layout.legendDisplayStyle === LEGEND_DISPLAY_STYLE_TEXT && extraOptions.legendSet) ? getColorByValueFromLegendSet(extraOptions.legendSet, series[0].data) : undefined,
                 },
             },
         },

--- a/src/visualizations/config/adapters/dhis_highcharts/series/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/index.js
@@ -132,7 +132,7 @@ export default function(series, store, layout, isStacked, extraOptions) {
             )
             break
         case VIS_TYPE_GAUGE:
-            series = getGauge(series, extraOptions.dashboard)
+            series = getGauge(series, layout, extraOptions)
             break
         default:
             series = getDefault(series, layout, isStacked, extraOptions)

--- a/src/visualizations/config/adapters/dhis_highcharts/series/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/index.js
@@ -10,7 +10,6 @@ import {
     isDualAxisType,
     isYearOverYear,
 } from '../../../../../modules/visTypes'
-import { getLegendSetById } from '../../../../../modules/legends'
 
 const DEFAULT_ANIMATION_DURATION = 200
 
@@ -133,8 +132,7 @@ export default function(series, store, layout, isStacked, extraOptions) {
             )
             break
         case VIS_TYPE_GAUGE:
-            const legendSet = layout.legendSet ? getLegendSetById(extraOptions.legendSets, layout.legendSet.id) : undefined
-            series = getGauge(series, extraOptions.dashboard, layout, legendSet)
+            series = getGauge(series, extraOptions.dashboard, layout, extraOptions.legendSets[0])
             break
         default:
             series = getDefault(series, layout, isStacked, extraOptions)

--- a/src/visualizations/config/adapters/dhis_highcharts/series/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/index.js
@@ -134,7 +134,7 @@ export default function(series, store, layout, isStacked, extraOptions) {
             break
         case VIS_TYPE_GAUGE:
             const legendSet = layout.legendSet ? getLegendSetById(extraOptions.legendSets, layout.legendSet.id) : undefined
-            series = getGauge(series, layout, legendSet, extraOptions.dashboard)
+            series = getGauge(series, extraOptions.dashboard, layout, legendSet)
             break
         default:
             series = getDefault(series, layout, isStacked, extraOptions)

--- a/src/visualizations/config/adapters/dhis_highcharts/series/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/index.js
@@ -10,6 +10,7 @@ import {
     isDualAxisType,
     isYearOverYear,
 } from '../../../../../modules/visTypes'
+import { getLegendSetById } from '../../../../../modules/legends'
 
 const DEFAULT_ANIMATION_DURATION = 200
 
@@ -132,7 +133,8 @@ export default function(series, store, layout, isStacked, extraOptions) {
             )
             break
         case VIS_TYPE_GAUGE:
-            series = getGauge(series, layout, extraOptions)
+            const legendSet = layout.legendSet ? getLegendSetById(extraOptions.legendSets, layout.legendSet.id) : undefined
+            series = getGauge(series, layout, legendSet, extraOptions.dashboard)
             break
         default:
             series = getDefault(series, layout, isStacked, extraOptions)

--- a/src/visualizations/config/adapters/dhis_highcharts/yAxis/gauge.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/yAxis/gauge.js
@@ -2,7 +2,7 @@ import arrayClean from 'd2-utilizr/lib/arrayClean'
 import isNumber from 'd2-utilizr/lib/isNumber'
 import objectClean from 'd2-utilizr/lib/objectClean'
 import i18n from '@dhis2/d2-i18n'
-import { getColorByValueFromLegendSet } from '../../../../../modules/legends'
+import { getColorByValueFromLegendSet, LEGEND_DISPLAY_STYLE_FILL } from '../../../../../modules/legends'
 
 const DEFAULT_MAX_VALUE = 100
 
@@ -32,7 +32,7 @@ export default function(layout, series, legendSet) {
         isNumber(layout.baseLineValue) ? getPlotLine(layout.baseLineValue, layout.baseLineLabel || DEFAULT_BASE_LINE_LABEL) : null,
         isNumber(layout.targetLineValue) ? getPlotLine(layout.targetLineValue, layout.targetLineLabel || DEFAULT_TARGET_LINE_LABEL) : null
     ])
-    const fillColor = (layout.legendDisplayStyle === "FILL" && legendSet) ? getColorByValueFromLegendSet(legendSet, series[0].data) : undefined
+    const fillColor = (layout.legendDisplayStyle === LEGEND_DISPLAY_STYLE_FILL && legendSet) ? getColorByValueFromLegendSet(legendSet, series[0].data) : undefined
     return objectClean({
         min: isNumber(layout.rangeAxisMinValue) ? layout.rangeAxisMinValue : 0,
         max: isNumber(layout.rangeAxisMaxValue) ? layout.rangeAxisMaxValue : DEFAULT_MAX_VALUE,

--- a/src/visualizations/config/adapters/dhis_highcharts/yAxis/gauge.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/yAxis/gauge.js
@@ -1,7 +1,5 @@
 import arrayClean from 'd2-utilizr/lib/arrayClean'
-import arraySort from 'd2-utilizr/lib/arraySort'
 import isNumber from 'd2-utilizr/lib/isNumber'
-import isObject from 'd2-utilizr/lib/isObject'
 import objectClean from 'd2-utilizr/lib/objectClean'
 import i18n from '@dhis2/d2-i18n'
 
@@ -16,15 +14,6 @@ const DEFAULT_PLOT_LINE_STYLE = {
 const DEFAULT_TARGET_LINE_LABEL = i18n.t('Target')
 const DEFAULT_BASE_LINE_LABEL = i18n.t('Base')
 
-function getStopsByLegendSet(legendSet) {
-    return isObject(legendSet)
-        ? arraySort(legendSet.legends, 'ASC', 'endValue').map(legend => [
-              parseFloat(legend.endValue) / DEFAULT_MAX_VALUE,
-              legend.color,
-          ])
-        : undefined
-}
-
 function getPlotLine(value, label) {
     return {
         value,
@@ -37,11 +26,19 @@ function getPlotLine(value, label) {
     }
 }
 
+const getColorByValueFromLegendSet = (legendSet, value) => {
+        const legend = legendSet.legends.find(legend =>
+            value >= legend.startValue && value < legend.endValue 
+        )    
+        return legend ? legend.color : undefined
+}
+
 export default function(layout, series, legendSet) {
     const plotLines = arrayClean([
         isNumber(layout.baseLineValue) ? getPlotLine(layout.baseLineValue, layout.baseLineLabel || DEFAULT_BASE_LINE_LABEL) : null,
         isNumber(layout.targetLineValue) ? getPlotLine(layout.targetLineValue, layout.targetLineLabel || DEFAULT_TARGET_LINE_LABEL) : null
     ])
+    const fillColor = (layout.legendDisplayStyle === "FILL" && legendSet) ? getColorByValueFromLegendSet(legendSet, series[0].data) : undefined
     return objectClean({
         min: isNumber(layout.rangeAxisMinValue) ? layout.rangeAxisMinValue : 0,
         max: isNumber(layout.rangeAxisMaxValue) ? layout.rangeAxisMaxValue : DEFAULT_MAX_VALUE,
@@ -49,6 +46,8 @@ export default function(layout, series, legendSet) {
         minorTickInterval: null,
         tickLength: 0,
         tickAmount: 0,
+        minColor: fillColor,
+        maxColor: fillColor,
         labels: {
             y: 18,
             style: {
@@ -58,7 +57,6 @@ export default function(layout, series, legendSet) {
         title: {
             text: series[0].name,
         },
-        stops: getStopsByLegendSet(legendSet),
         ...(plotLines.length && {
             plotLines
         })

--- a/src/visualizations/config/adapters/dhis_highcharts/yAxis/gauge.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/yAxis/gauge.js
@@ -2,6 +2,7 @@ import arrayClean from 'd2-utilizr/lib/arrayClean'
 import isNumber from 'd2-utilizr/lib/isNumber'
 import objectClean from 'd2-utilizr/lib/objectClean'
 import i18n from '@dhis2/d2-i18n'
+import { getColorByValueFromLegendSet } from '../../../../../modules/legends'
 
 const DEFAULT_MAX_VALUE = 100
 
@@ -24,13 +25,6 @@ function getPlotLine(value, label) {
             }
         })
     }
-}
-
-const getColorByValueFromLegendSet = (legendSet, value) => {
-        const legend = legendSet.legends.find(legend =>
-            value >= legend.startValue && value < legend.endValue 
-        )    
-        return legend ? legend.color : undefined
 }
 
 export default function(layout, series, legendSet) {

--- a/src/visualizations/config/adapters/dhis_highcharts/yAxis/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/yAxis/index.js
@@ -6,7 +6,6 @@ import getAxisTitle from '../getAxisTitle'
 import getGauge from './gauge'
 import { isStacked, VIS_TYPE_GAUGE } from '../../../../../modules/visTypes'
 import { hasOptionalAxis } from '../optionalAxes'
-import { getLegendSetById } from '../../../../../modules/legends'
 
 const DEFAULT_MIN_VALUE = 0
 
@@ -148,8 +147,7 @@ export default function(layout, series, extraOptions) {
     let yAxis
     switch (layout.type) {
         case VIS_TYPE_GAUGE:
-            const legendSet = layout.legendSet ? getLegendSetById(extraOptions.legendSets, layout.legendSet.id) : undefined
-            yAxis = getGauge(layout, series, legendSet)
+            yAxis = getGauge(layout, series, extraOptions.legendSets[0])
             break
         default:
             yAxis = getDefault(layout, extraOptions)

--- a/src/visualizations/config/adapters/dhis_highcharts/yAxis/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/yAxis/index.js
@@ -6,6 +6,7 @@ import getAxisTitle from '../getAxisTitle'
 import getGauge from './gauge'
 import { isStacked, VIS_TYPE_GAUGE } from '../../../../../modules/visTypes'
 import { hasOptionalAxis } from '../optionalAxes'
+import { getLegendSetById } from '../../../../../modules/legends'
 
 const DEFAULT_MIN_VALUE = 0
 
@@ -145,10 +146,10 @@ function getDefault(layout, extraOptions) {
 
 export default function(layout, series, extraOptions) {
     let yAxis
-
     switch (layout.type) {
         case VIS_TYPE_GAUGE:
-            yAxis = getGauge(layout, series, extraOptions.legendSet)
+            const legendSet = layout.legendSet ? getLegendSetById(extraOptions.legendSets, layout.legendSet.id) : undefined
+            yAxis = getGauge(layout, series, legendSet)
             break
         default:
             yAxis = getDefault(layout, extraOptions)


### PR DESCRIPTION
Enables Gauge to display custom colors based on legends, either for the fill color or the text color.

Text color:
![image](https://user-images.githubusercontent.com/12590483/74947319-f5439d80-53fa-11ea-9881-61166f98ac57.png)

Fill color:
![image](https://user-images.githubusercontent.com/12590483/74947427-21f7b500-53fb-11ea-827b-1346c4c9fff7.png)
