### PR TITLE
fix: dimensions panel style prop

### DIFF
--- a/src/components/DimensionsPanel/DimensionsPanel.js
+++ b/src/components/DimensionsPanel/DimensionsPanel.js
@@ -27,10 +27,11 @@ export class DimensionsPanel extends Component {
             onDimensionClick,
             onDimensionOptionsClick,
             onDimensionDragStart,
+            style,
         } = this.props
 
         return (
-            <div style={styles.divContainer}>
+            <div style={{ ...styles.divContainer, ...style }}>
                 <Filter
                     style={styles.textField}
                     placeholder={i18n.t('Filter dimensions')}
@@ -60,6 +61,7 @@ DimensionsPanel.propTypes = {
     lockedDimension: PropTypes.func,
     recommendedDimension: PropTypes.func,
     selectedIds: PropTypes.array,
+    style: PropTypes.object,
     onDimensionClick: PropTypes.func,
     onDimensionDragStart: PropTypes.func,
     onDimensionOptionsClick: PropTypes.func,

--- a/src/components/DimensionsPanel/DimensionsPanel.js
+++ b/src/components/DimensionsPanel/DimensionsPanel.js
@@ -69,6 +69,7 @@ DimensionsPanel.propTypes = {
 
 DimensionsPanel.defaultProps = {
     selectedIds: [],
+    style: {},
     onDimensionClick: Function.prototype,
 }
 

--- a/src/components/DimensionsPanel/List/__tests__/__snapshots__/DimensionItem.spec.js.snap
+++ b/src/components/DimensionsPanel/List/__tests__/__snapshots__/DimensionItem.spec.js.snap
@@ -42,8 +42,7 @@ exports[`DimensionItem matches the snapshot 1`] = `
     <div
       style={
         Object {
-          "maxWidth": "174px",
-          "padding": "2px 0",
+          "padding": "2px 5px 2px 0",
         }
       }
     >
@@ -111,8 +110,7 @@ exports[`DimensionItem matches the snapshot with locked 1`] = `
     <div
       style={
         Object {
-          "maxWidth": "174px",
-          "padding": "2px 0",
+          "padding": "2px 5px 2px 0",
         }
       }
     >
@@ -198,8 +196,7 @@ exports[`DimensionItem matches the snapshot with onOptionsClick 1`] = `
     <div
       style={
         Object {
-          "maxWidth": "174px",
-          "padding": "2px 0",
+          "padding": "2px 5px 2px 0",
         }
       }
     >
@@ -228,6 +225,7 @@ exports[`DimensionItem matches the snapshot with onOptionsClick 1`] = `
         "alignSelf": "start",
         "height": "24px",
         "left": "5px",
+        "minWidth": "22px",
         "position": "relative",
       }
     }
@@ -277,8 +275,7 @@ exports[`DimensionItem matches the snapshot with recommended 1`] = `
     <div
       style={
         Object {
-          "maxWidth": "174px",
-          "padding": "2px 0",
+          "padding": "2px 5px 2px 0",
         }
       }
     >
@@ -348,8 +345,7 @@ exports[`DimensionItem matches the snapshot with selected 1`] = `
     <div
       style={
         Object {
-          "maxWidth": "174px",
-          "padding": "2px 0",
+          "padding": "2px 5px 2px 0",
         }
       }
     >

--- a/src/components/DimensionsPanel/List/styles/DimensionItem.style.js
+++ b/src/components/DimensionsPanel/List/styles/DimensionItem.style.js
@@ -2,8 +2,7 @@ import { colors } from '../../../../modules/colors'
 
 export const styles = {
     labelWrapper: {
-        maxWidth: '174px',
-        padding: '2px 0',
+        padding: '2px 5px 2px 0',
     },
     text: {
         color: colors.black,
@@ -48,6 +47,7 @@ export const styles = {
     optionsWrapper: {
         position: 'relative',
         height: '24px',
+        minWidth: '22px',
         left: '5px',
         alignSelf: 'start',
     },


### PR DESCRIPTION
Adds a `style` prop to `DimensionsPanel` for dependants to pass in a custom style.

Removes the hardcoded maxWidth for DimensionItem in favour of a minWidth on the ... menu, to solve a visual bug with the item width.

Linked to: https://github.com/dhis2/dashboards-app/pull/567