### PR TITLE
fix: loading spinner in ou dialog DHIS2-8360

### DIFF
--- a/src/components/OrgUnitDimension/styles/OrgUnitDimension.style.js
+++ b/src/components/OrgUnitDimension/styles/OrgUnitDimension.style.js
@@ -1,9 +1,9 @@
 export default {
     dialogContent: {
         width: 760,
+        minHeight: 48,
     },
     loader: {
-        marginTop: 40,
         marginLeft: 'auto',
         marginRight: 'auto',
         display: 'block',


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-8360

Screen recording before:
![spinner-before](https://user-images.githubusercontent.com/150978/75158556-a6f20f80-5716-11ea-8e21-d40aca047786.gif)

and after:
![spinner-after](https://user-images.githubusercontent.com/150978/75158645-d6a11780-5716-11ea-8a03-e9b0c79abe9b.gif)

Note: the buttons are different because I took the screen recording from both dashboards and DV.
