### PR TITLE
fix: gauge range bug

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/yAxis/gauge.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/yAxis/gauge.js
@@ -40,6 +40,9 @@ export default function(layout, series, legendSet) {
         minorTickInterval: null,
         tickLength: 0,
         tickAmount: 0,
+        tickPositioner: function() {
+            return [this.min, this.max];
+        }, 
         minColor: fillColor,
         maxColor: fillColor,
         labels: {


### PR DESCRIPTION
https://jira.dhis2.org/browse/DHIS2-7887 contains a bug which makes the min / max range display a different value than the one selected.

Example: Selected 250, shows up as 320.
![image](https://user-images.githubusercontent.com/12590483/75248373-5a6d0980-57d4-11ea-9dde-9b2d252b11cc.png)

With the fix:
![image](https://user-images.githubusercontent.com/12590483/75248401-65c03500-57d4-11ea-98f6-ffe0eb4385f3.png)
