### PR TITLE
refactor: use context to propagate engine, clean up PivotTable.js

### DIFF
--- a/src/components/PivotTable/PivotTable.js
+++ b/src/components/PivotTable/PivotTable.js
@@ -1,30 +1,25 @@
-import React, { useRef, useMemo, useState } from 'react'
+import React, { useRef, useMemo } from 'react'
 import PropTypes from 'prop-types'
 
-import { table as tableStyle } from './styles/PivotTable.style'
-import {
-    PivotTableEngine,
-    SORT_ORDER_ASCENDING,
-    SORT_ORDER_DESCENDING,
-} from '../../modules/pivotTable/PivotTableEngine'
+import { PivotTableEngine } from '../../modules/pivotTable/PivotTableEngine'
 import { useParentSize } from '../../modules/pivotTable/useParentSize'
-import { PivotTableColumnHeaders } from './PivotTableColumnHeaders'
 import { useTableClipping } from '../../modules/pivotTable/useTableClipping'
-import { PivotTableRow } from './PivotTableRow'
-import { PivotTableClippedAxis } from './PivotTableClippedAxis'
-import { PivotTableTitleRow } from './PivotTableTitleRow'
-import { PivotTableEmptyRow } from './PivotTableEmptyRow'
-import getFilterText from '../../visualizations/util/getFilterText'
+import { Provider } from './PivotTableEngineContext'
+import { PivotTableContainer } from './PivotTableContainer'
+import { PivotTableHead } from './PivotTableHead'
+import { PivotTableBody } from './PivotTableBody'
+import { useSortableColumns } from '../../modules/pivotTable/useSortableColumns'
 
 const PivotTable = ({ visualization, data, legendSets }) => {
     const containerRef = useRef(undefined)
     const { width, height } = useParentSize(containerRef)
-    const [sortBy, setSortBy] = useState(null)
 
     const engine = useMemo(
         () => new PivotTableEngine(visualization, data, legendSets),
         [visualization, data, legendSets]
     )
+
+    const { sortBy, onSortByColumn } = useSortableColumns(engine)
 
     const clippingResult = useTableClipping({
         containerRef,
@@ -35,87 +30,21 @@ const PivotTable = ({ visualization, data, legendSets }) => {
     })
 
     return (
-        <div
-            className="pivot-table-container"
-            style={{ width, height }}
-            ref={containerRef}
-        >
-            <style jsx>{tableStyle}</style>
-            {width === 0 || height === 0 ? null : (
-                <table>
-                    <thead>
-                        {engine.options.title ? (
-                            <PivotTableTitleRow
-                                engine={engine}
-                                title={visualization.title}
-                                scrollPosition={clippingResult.scrollPosition}
-                                containerWidth={width}
-                            />
-                        ) : null}
-                        {engine.options.subtitle ? (
-                            <PivotTableTitleRow
-                                engine={engine}
-                                title={visualization.subtitle}
-                                scrollPosition={clippingResult.scrollPosition}
-                                containerWidth={width}
-                            />
-                        ) : null}
-                        {visualization.filters?.length ? (
-                            <PivotTableTitleRow
-                                engine={engine}
-                                title={getFilterText(
-                                    visualization.filters,
-                                    data.metaData
-                                )}
-                                scrollPosition={clippingResult.scrollPosition}
-                                containerWidth={width}
-                            />
-                        ) : null}
-                        <PivotTableColumnHeaders
-                            engine={engine}
-                            clippingResult={clippingResult}
-                            sortBy={sortBy}
-                            onSortByColumn={column => {
-                                let order = SORT_ORDER_ASCENDING
-                                if (sortBy && sortBy.column === column) {
-                                    if (sortBy.order === SORT_ORDER_ASCENDING) {
-                                        order = SORT_ORDER_DESCENDING
-                                    } else if (
-                                        sortBy.order === SORT_ORDER_DESCENDING
-                                    ) {
-                                        engine.clearSort()
-                                        setSortBy(null)
-                                        return
-                                    }
-                                }
-                                engine.sort(column, order)
-                                setSortBy({ column, order }) // Force a re-render
-                            }}
-                        />
-                    </thead>
-                    <tbody>
-                        <PivotTableClippedAxis
-                            axisClippingResult={clippingResult.rows}
-                            EmptyComponent={({ size }) => (
-                                <PivotTableEmptyRow
-                                    height={size}
-                                    engine={engine}
-                                    columns={clippingResult.columns.indices}
-                                />
-                            )}
-                            ItemComponent={({ index }) => (
-                                <PivotTableRow
-                                    key={index}
-                                    engine={engine}
-                                    clippingResult={clippingResult}
-                                    rowIndex={index}
-                                />
-                            )}
-                        />
-                    </tbody>
-                </table>
-            )}
-        </div>
+        <Provider engine={engine}>
+            <PivotTableContainer
+                ref={containerRef}
+                width={width}
+                height={height}
+            >
+                <PivotTableHead
+                    clippingResult={clippingResult}
+                    width={width}
+                    sortBy={sortBy}
+                    onSortByColumn={onSortByColumn}
+                />
+                <PivotTableBody clippingResult={clippingResult} />
+            </PivotTableContainer>
+        </Provider>
     )
 }
 

--- a/src/components/PivotTable/PivotTableBody.js
+++ b/src/components/PivotTable/PivotTableBody.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { PivotTableClippedAxis } from './PivotTableClippedAxis'
+import { PivotTableEmptyRow } from './PivotTableEmptyRow'
+import { PivotTableRow } from './PivotTableRow'
+
+export const PivotTableBody = ({ clippingResult }) => (
+    <tbody>
+        <PivotTableClippedAxis
+            axisClippingResult={clippingResult.rows}
+            EmptyComponent={({ size }) => (
+                <PivotTableEmptyRow
+                    height={size}
+                    columns={clippingResult.columns.indices}
+                />
+            )}
+            ItemComponent={({ index }) => (
+                <PivotTableRow
+                    key={index}
+                    clippingResult={clippingResult}
+                    rowIndex={index}
+                />
+            )}
+        />
+    </tbody>
+)
+
+PivotTableBody.propTypes = {
+    clippingResult: PropTypes.object.isRequired,
+}

--- a/src/components/PivotTable/PivotTableCell.js
+++ b/src/components/PivotTable/PivotTableCell.js
@@ -1,0 +1,45 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import classnames from 'classnames'
+import { cell as cellStyle } from './styles/PivotTable.style'
+import { usePivotTableEngine } from './PivotTableEngineContext'
+
+export const PivotTableCell = ({
+    classes,
+    isColumnHeader,
+    children,
+    ...props
+}) => {
+    const engine = usePivotTableEngine()
+
+    const className = classnames(
+        classes,
+        `fontsize-${engine.visualization.fontSize}`,
+        `displaydensity-${engine.visualization.displayDensity}`
+    )
+
+    return isColumnHeader ? (
+        <th className={className} {...props}>
+            <style jsx>{cellStyle}</style>
+            {children}
+        </th>
+    ) : (
+        <td className={className} {...props}>
+            <style jsx>{cellStyle}</style>
+            {children}
+        </td>
+    )
+}
+
+PivotTableCell.defaultProps = {
+    isColumnHeader: false,
+}
+PivotTableCell.propTypes = {
+    children: PropTypes.node,
+    classes: PropTypes.oneOfType([
+        PropTypes.array,
+        PropTypes.object,
+        PropTypes.string,
+    ]),
+    isColumnHeader: PropTypes.bool,
+}

--- a/src/components/PivotTable/PivotTableColumnHeaderCell.js
+++ b/src/components/PivotTable/PivotTableColumnHeaderCell.js
@@ -1,80 +1,73 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
 import { PivotTableHeaderCell } from './PivotTableHeaderCell'
 import { cell as cellStyle } from './styles/PivotTable.style'
-import { SORT_ORDER_ASCENDING } from '../../modules/pivotTable/PivotTableEngine'
 
-import { SortIconAscending } from './icons/SortIconAscending'
-import { SortIconDescending } from './icons/SortIconDescending'
-import { SortIconIdle } from './icons/SortIconIdle'
+import { PivotTableCell } from './PivotTableCell'
+import { usePivotTableEngine } from './PivotTableEngineContext'
+import { PivotTableSortIcon } from './PivotTableSortIcon'
 
 export const PivotTableColumnHeaderCell = ({
-    engine,
     clippingResult,
     index,
     level,
     onSortByColumn,
     sortBy,
-}) => (
-    <PivotTableHeaderCell
-        axisClippingResult={clippingResult.columns}
-        index={index}
-        level={level}
-        getHeader={idx => engine.getColumnHeader(idx)}
-        showHierarchy={engine.visualization.showHierarchy}
-        render={header => {
-            const isSortable =
-                level === engine.dimensionLookup.columns.length - 1 &&
-                header.span === 1 &&
-                engine.isSortable(index)
+}) => {
+    const engine = usePivotTableEngine()
 
-            const SortIcon =
-                isSortable &&
-                (sortBy?.column === index
-                    ? sortBy.order === SORT_ORDER_ASCENDING
-                        ? SortIconAscending
-                        : SortIconDescending
-                    : SortIconIdle)
-            return (
-                <th
-                    className={classnames(
-                        header.label &&
+    return (
+        <PivotTableHeaderCell
+            axisClippingResult={clippingResult.columns}
+            index={index}
+            level={level}
+            getHeader={idx => engine.getColumnHeader(idx)}
+            showHierarchy={engine.visualization.showHierarchy}
+            render={header => {
+                const isSortable =
+                    level === engine.dimensionLookup.columns.length - 1 &&
+                    header.span === 1 &&
+                    engine.isSortable(index)
+
+                return (
+                    <PivotTableCell
+                        isColumnHeader
+                        classes={
+                            header.label &&
                             header.label !== 'Total' &&
                             header.label !== 'Subtotal' // TODO: Actually look up the column type!
-                            ? 'column-header'
-                            : 'empty-header',
-                        `fontsize-${engine.visualization.fontSize}`,
-                        `displaydensity-${engine.visualization.displayDensity}`
-                    )}
-                    colSpan={header.span}
-                    title={header.label}
-                    style={{ cursor: isSortable ? 'pointer' : 'default' }}
-                    onClick={
-                        isSortable ? () => onSortByColumn(index) : undefined
-                    }
-                >
-                    <style jsx>{cellStyle}</style>
-                    <div className="column-header-inner">
-                        <span className="column-header-label">
-                            {header.label}
-                        </span>
-                        {isSortable ? (
-                            <span className="sort-icon">
-                                <SortIcon />
+                                ? 'column-header'
+                                : 'empty-header'
+                        }
+                        colSpan={header.span}
+                        title={header.label}
+                        style={{ cursor: isSortable ? 'pointer' : 'default' }}
+                        onClick={
+                            isSortable ? () => onSortByColumn(index) : undefined
+                        }
+                    >
+                        <style jsx>{cellStyle}</style>
+                        <div className="column-header-inner">
+                            <span className="column-header-label">
+                                {header.label}
                             </span>
-                        ) : null}
-                    </div>
-                </th>
-            )
-        }}
-    />
-)
+                            {isSortable ? (
+                                <PivotTableSortIcon
+                                    index={index}
+                                    sortBy={sortBy}
+                                />
+                            ) : null}
+                        </div>
+                    </PivotTableCell>
+                )
+            }}
+        />
+    )
+}
 
 PivotTableColumnHeaderCell.propTypes = {
     clippingResult: PropTypes.shape({ columns: PropTypes.object.isRequired })
         .isRequired,
-    engine: PropTypes.object.isRequired,
     index: PropTypes.number.isRequired,
     level: PropTypes.number.isRequired,
     onSortByColumn: PropTypes.func.isRequired,

--- a/src/components/PivotTable/PivotTableColumnHeaders.js
+++ b/src/components/PivotTable/PivotTableColumnHeaders.js
@@ -1,17 +1,17 @@
-import React, { useContext } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
 import { PivotTableClippedAxis } from './PivotTableClippedAxis'
 import { PivotTableColumnHeaderCell } from './PivotTableColumnHeaderCell'
 import { PivotTableDimensionLabelCell } from './PivotTableDimensionLabelCell'
 import { PivotTableEmptyCell } from './PivotTableEmptyCell'
-import { PivotTableEngineContext } from './PivotTableEngineContext'
+import { usePivotTableEngine } from './PivotTableEngineContext'
 
 export const PivotTableColumnHeaders = ({
     clippingResult,
     onSortByColumn,
     sortBy,
 }) => {
-    const engine = useContext(PivotTableEngineContext)
+    const engine = usePivotTableEngine()
 
     return engine.dimensionLookup.columns.map((_, columnLevel) => (
         <tr key={columnLevel}>

--- a/src/components/PivotTable/PivotTableColumnHeaders.js
+++ b/src/components/PivotTable/PivotTableColumnHeaders.js
@@ -1,16 +1,18 @@
-import React from 'react'
+import React, { useContext } from 'react'
 import PropTypes from 'prop-types'
 import { PivotTableClippedAxis } from './PivotTableClippedAxis'
 import { PivotTableColumnHeaderCell } from './PivotTableColumnHeaderCell'
 import { PivotTableDimensionLabelCell } from './PivotTableDimensionLabelCell'
 import { PivotTableEmptyCell } from './PivotTableEmptyCell'
+import { PivotTableEngineContext } from './PivotTableEngineContext'
 
 export const PivotTableColumnHeaders = ({
-    engine,
     clippingResult,
     onSortByColumn,
     sortBy,
 }) => {
+    const engine = useContext(PivotTableEngineContext)
+
     return engine.dimensionLookup.columns.map((_, columnLevel) => (
         <tr key={columnLevel}>
             {engine.dimensionLookup.rows.map((_, rowLevel) => (
@@ -18,7 +20,6 @@ export const PivotTableColumnHeaders = ({
                     key={rowLevel}
                     rowLevel={rowLevel}
                     columnLevel={columnLevel}
-                    engine={engine}
                 />
             ))}
             <PivotTableClippedAxis
@@ -31,7 +32,6 @@ export const PivotTableColumnHeaders = ({
                 )}
                 ItemComponent={({ index }) => (
                     <PivotTableColumnHeaderCell
-                        engine={engine}
                         clippingResult={clippingResult}
                         index={index}
                         level={columnLevel}
@@ -48,7 +48,6 @@ PivotTableColumnHeaders.propTypes = {
     clippingResult: PropTypes.shape({
         columns: PropTypes.object.isRequired,
     }).isRequired,
-    engine: PropTypes.object.isRequired,
     onSortByColumn: PropTypes.func.isRequired,
     sortBy: PropTypes.shape({
         column: PropTypes.number.isRequired,

--- a/src/components/PivotTable/PivotTableContainer.js
+++ b/src/components/PivotTable/PivotTableContainer.js
@@ -1,0 +1,24 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { table as tableStyle } from './styles/PivotTable.style'
+
+export const PivotTableContainer = React.forwardRef(
+    ({ width, height, children }, ref) => (
+        <div
+            className="pivot-table-container"
+            style={{ width, height }}
+            ref={ref}
+        >
+            <style jsx>{tableStyle}</style>
+            {width === 0 || height === 0 ? null : <table>{children}</table>}
+        </div>
+    )
+)
+
+PivotTableContainer.displayName = 'PivotTableContainer'
+
+PivotTableContainer.propTypes = {
+    children: PropTypes.node.isRequired,
+    height: PropTypes.number.isRequired,
+    width: PropTypes.number.isRequired,
+}

--- a/src/components/PivotTable/PivotTableDimensionLabelCell.js
+++ b/src/components/PivotTable/PivotTableDimensionLabelCell.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
-import { cell as cellStyle } from './styles/PivotTable.style'
+import { usePivotTableEngine } from './PivotTableEngineContext'
+import { PivotTableCell } from './PivotTableCell'
 
 const getDimensionLabel = (engine, rowLevel, columnLevel) => {
     const lastRowLevel = engine.dimensionLookup.rows.length - 1
@@ -21,71 +21,52 @@ const getDimensionLabel = (engine, rowLevel, columnLevel) => {
     }
 }
 
-export const PivotTableDimensionLabelCell = ({
-    engine,
-    rowLevel,
-    columnLevel,
-}) => {
+export const PivotTableDimensionLabelCell = ({ rowLevel, columnLevel }) => {
+    const engine = usePivotTableEngine()
+
     const colCount = engine.dimensionLookup.rows.length
     const rowCount = engine.dimensionLookup.columns.length
+
+    let colSpan = 1,
+        rowSpan = 1,
+        label
+
     if (!engine.visualization.showDimensionLabels) {
-        if (rowLevel === 0 && columnLevel === 0) {
-            return (
-                <td
-                    className={classnames(
-                        'empty-header',
-                        'column-header',
-                        `fontsize-${engine.visualization.fontSize}`,
-                        `displaydensity-${engine.visualization.displayDensity}`
-                    )}
-                    colSpan={colCount}
-                    rowSpan={rowCount}
-                >
-                    <style jsx>{cellStyle}</style>
-                </td>
-            )
+        if (rowLevel > 0 || columnLevel > 0) {
+            colSpan = rowSpan = 0
+        } else {
+            colSpan = colCount
+            rowSpan = rowCount
         }
+    } else {
+        label = getDimensionLabel(engine, rowLevel, columnLevel)
+        if (!label) {
+            if (rowLevel > 0 || columnLevel > 0) {
+                colSpan = rowSpan = 0
+            } else {
+                colSpan = colCount - 1
+                rowSpan = rowCount - 1
+            }
+        }
+    }
+
+    if (!colSpan || !rowSpan) {
         return null
     }
 
-    const dimensionLabel = getDimensionLabel(engine, rowLevel, columnLevel)
-    if (!dimensionLabel) {
-        if (rowLevel === 0 && columnLevel === 0) {
-            return (
-                <td
-                    className={classnames(
-                        'empty-header',
-                        'column-header',
-                        `fontsize-${engine.visualization.fontSize}`,
-                        `displaydensity-${engine.visualization.displayDensity}`
-                    )}
-                    colSpan={colCount - 1}
-                    rowSpan={rowCount - 1}
-                >
-                    <style jsx>{cellStyle}</style>
-                </td>
-            )
-        }
-        return null
-    }
     return (
-        <th
-            className={classnames(
-                'empty-header',
-                'column-header',
-                `fontsize-${engine.visualization.fontSize}`,
-                `displaydensity-${engine.visualization.displayDensity}`
-            )}
-            title={dimensionLabel}
+        <PivotTableCell
+            classes={['empty-header', 'column-header']}
+            colSpan={colSpan}
+            rowSpan={rowSpan}
+            title={label}
         >
-            <style jsx>{cellStyle}</style>
-            {dimensionLabel}
-        </th>
+            {label}
+        </PivotTableCell>
     )
 }
 
 PivotTableDimensionLabelCell.propTypes = {
     columnLevel: PropTypes.number.isRequired,
-    engine: PropTypes.object.isRequired,
     rowLevel: PropTypes.number.isRequired,
 }

--- a/src/components/PivotTable/PivotTableEmptyCell.js
+++ b/src/components/PivotTable/PivotTableEmptyCell.js
@@ -1,12 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { cell as cellStyle } from './styles/PivotTable.style'
+import { PivotTableCell } from './PivotTableCell'
 
 export const PivotTableEmptyCell = ({ type, ...props }) => {
     return (
-        <td className={type} {...props}>
+        <PivotTableCell className={type} {...props}>
             <style jsx>{cellStyle}</style>
-        </td>
+        </PivotTableCell>
     )
 }
 

--- a/src/components/PivotTable/PivotTableEmptyRow.js
+++ b/src/components/PivotTable/PivotTableEmptyRow.js
@@ -1,24 +1,26 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import { usePivotTableEngine } from './PivotTableEngineContext'
+import { PivotTableCell } from './PivotTableCell'
 
-import { cell as cellStyle } from './styles/PivotTable.style'
+export const PivotTableEmptyRow = ({ height, columns }) => {
+    const engine = usePivotTableEngine()
 
-export const PivotTableEmptyRow = ({ height, engine, columns }) => (
-    <tr>
-        <style jsx>{cellStyle}</style>
-        <td
-            colSpan={engine.dimensionLookup.rows.length}
-            style={{ height }}
-            className="row-header"
-        />
-        {columns.map(i => (
-            <td key={i} />
-        ))}
-    </tr>
-)
+    return (
+        <tr>
+            <PivotTableCell
+                colSpan={engine.dimensionLookup.rows.length}
+                style={{ height }}
+                classes="row-header"
+            />
+            {columns.map(i => (
+                <PivotTableCell key={i} />
+            ))}
+        </tr>
+    )
+}
 
 PivotTableEmptyRow.propTypes = {
     columns: PropTypes.array.isRequired,
-    engine: PropTypes.object.isRequired,
     height: PropTypes.number.isRequired,
 }

--- a/src/components/PivotTable/PivotTableEngineContext.js
+++ b/src/components/PivotTable/PivotTableEngineContext.js
@@ -1,0 +1,20 @@
+import React, { createContext, useContext } from 'react'
+import PropTypes from 'prop-types'
+
+export const PivotTableEngineContext = createContext(null)
+
+export const Provider = ({ engine, children }) => {
+    return (
+        <PivotTableEngineContext.Provider value={engine}>
+            {children}
+        </PivotTableEngineContext.Provider>
+    )
+}
+Provider.propTypes = {
+    engine: PropTypes.object.isRequired,
+    children: PropTypes.node,
+}
+
+export const usePivotTableEngine = () => {
+    return useContext(PivotTableEngineContext)
+}

--- a/src/components/PivotTable/PivotTableHead.js
+++ b/src/components/PivotTable/PivotTableHead.js
@@ -1,0 +1,27 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { PivotTableColumnHeaders } from './PivotTableColumnHeaders'
+import { PivotTableTitleRows } from './PivotTableTitleRows'
+
+export const PivotTableHead = ({
+    clippingResult,
+    width,
+    sortBy,
+    onSortByColumn,
+}) => (
+    <thead>
+        <PivotTableTitleRows clippingResult={clippingResult} width={width} />
+        <PivotTableColumnHeaders
+            clippingResult={clippingResult}
+            sortBy={sortBy}
+            onSortByColumn={onSortByColumn}
+        />
+    </thead>
+)
+
+PivotTableHead.propTypes = {
+    clippingResult: PropTypes.object.isRequired,
+    width: PropTypes.number.isRequired,
+    onSortByColumn: PropTypes.func.isRequired,
+    sortBy: PropTypes.object,
+}

--- a/src/components/PivotTable/PivotTableRow.js
+++ b/src/components/PivotTable/PivotTableRow.js
@@ -4,37 +4,35 @@ import { PivotTableClippedAxis } from './PivotTableClippedAxis'
 import { PivotTableRowHeaderCell } from './PivotTableRowHeaderCell'
 import { PivotTableValueCell } from './PivotTableValueCell'
 import { PivotTableEmptyCell } from './PivotTableEmptyCell'
+import { usePivotTableEngine } from './PivotTableEngineContext'
 
-export const PivotTableRow = ({ engine, clippingResult, rowIndex }) => (
-    <tr>
-        {engine.dimensionLookup.rows.map((_, rowLevel) => (
-            <PivotTableRowHeaderCell
-                key={rowLevel}
-                engine={engine}
-                clippingResult={clippingResult}
-                rowIndex={rowIndex}
-                rowLevel={rowLevel}
-            />
-        ))}
-        <PivotTableClippedAxis
-            axisClippingResult={clippingResult.columns}
-            EmptyComponent={() => <PivotTableEmptyCell type="value" />}
-            ItemComponent={({ index: columnIndex }) => (
-                <PivotTableValueCell
-                    engine={engine}
-                    row={rowIndex}
-                    column={columnIndex}
+export const PivotTableRow = ({ clippingResult, rowIndex }) => {
+    const engine = usePivotTableEngine()
+    return (
+        <tr>
+            {engine.dimensionLookup.rows.map((_, rowLevel) => (
+                <PivotTableRowHeaderCell
+                    key={rowLevel}
+                    clippingResult={clippingResult}
+                    rowIndex={rowIndex}
+                    rowLevel={rowLevel}
                 />
-            )}
-        />
-    </tr>
-)
+            ))}
+            <PivotTableClippedAxis
+                axisClippingResult={clippingResult.columns}
+                EmptyComponent={() => <PivotTableEmptyCell type="value" />}
+                ItemComponent={({ index: columnIndex }) => (
+                    <PivotTableValueCell row={rowIndex} column={columnIndex} />
+                )}
+            />
+        </tr>
+    )
+}
 
 PivotTableRow.propTypes = {
     clippingResult: PropTypes.shape({
         columns: PropTypes.object.isRequired,
         rows: PropTypes.object.isRequired,
     }).isRequired,
-    engine: PropTypes.object.isRequired,
     rowIndex: PropTypes.number.isRequired,
 }

--- a/src/components/PivotTable/PivotTableRowHeaderCell.js
+++ b/src/components/PivotTable/PivotTableRowHeaderCell.js
@@ -1,46 +1,45 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
 import { PivotTableHeaderCell } from './PivotTableHeaderCell'
-import { cell as cellStyle } from './styles/PivotTable.style'
+import { PivotTableCell } from './PivotTableCell'
+import { usePivotTableEngine } from './PivotTableEngineContext'
 
 export const PivotTableRowHeaderCell = ({
-    engine,
     clippingResult,
     rowIndex,
     rowLevel,
-}) => (
-    <PivotTableHeaderCell
-        axisClippingResult={clippingResult.rows}
-        index={rowIndex}
-        level={rowLevel}
-        getHeader={idx => engine.getRowHeader(idx)}
-        showHierarchy={engine.visualization.showHierarchy}
-        render={header => (
-            <td
-                className={classnames(
-                    header.label &&
+}) => {
+    const engine = usePivotTableEngine()
+
+    return (
+        <PivotTableHeaderCell
+            axisClippingResult={clippingResult.rows}
+            index={rowIndex}
+            level={rowLevel}
+            getHeader={idx => engine.getRowHeader(idx)}
+            showHierarchy={engine.visualization.showHierarchy}
+            render={header => (
+                <PivotTableCell
+                    classes={
+                        header.label &&
                         header.label !== 'Total' &&
                         header.label !== 'Subtotal'
-                        ? 'row-header'
-                        : 'empty-header',
-                    `fontsize-${engine.visualization.fontSize}`,
-                    `displaydensity-${engine.visualization.displayDensity}`
-                )}
-                rowSpan={header.span}
-                title={header.label}
-            >
-                <style jsx>{cellStyle}</style>
-                {header.label}
-            </td>
-        )}
-    />
-)
+                            ? 'row-header'
+                            : 'empty-header'
+                    }
+                    rowSpan={header.span}
+                    title={header.label}
+                >
+                    {header.label}
+                </PivotTableCell>
+            )}
+        />
+    )
+}
 
 PivotTableRowHeaderCell.propTypes = {
     clippingResult: PropTypes.shape({ rows: PropTypes.object.isRequired })
         .isRequired,
-    engine: PropTypes.object.isRequired,
     rowIndex: PropTypes.number.isRequired,
     rowLevel: PropTypes.number.isRequired,
 }

--- a/src/components/PivotTable/PivotTableSortIcon.js
+++ b/src/components/PivotTable/PivotTableSortIcon.js
@@ -1,0 +1,31 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { usePivotTableEngine } from './PivotTableEngineContext'
+import { SORT_ORDER_ASCENDING } from '../../modules/pivotTable/PivotTableEngine'
+import { sortIcon as sortIconStyle } from './styles/PivotTable.style'
+import { SortIconAscending } from './icons/SortIconAscending'
+import { SortIconDescending } from './icons/SortIconDescending'
+import { SortIconIdle } from './icons/SortIconIdle'
+
+export const PivotTableSortIcon = ({ index, sortBy }) => {
+    const engine = usePivotTableEngine()
+
+    const SortIcon =
+        sortBy?.column === index
+            ? sortBy.order === SORT_ORDER_ASCENDING
+                ? SortIconAscending
+                : SortIconDescending
+            : SortIconIdle
+
+    return (
+        <span className={`fontsize-${engine.visualization.fontSize}`}>
+            <style jsx>{sortIconStyle}</style>
+            <SortIcon />
+        </span>
+    )
+}
+
+PivotTableSortIcon.propTypes = {
+    index: PropTypes.number.isRequired,
+    sortBy: PropTypes.object,
+}

--- a/src/components/PivotTable/PivotTableSortIcon.js
+++ b/src/components/PivotTable/PivotTableSortIcon.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import { usePivotTableEngine } from './PivotTableEngineContext'
-import { SORT_ORDER_ASCENDING } from '../../modules/pivotTable/PivotTableEngine'
+import { SORT_ORDER_ASCENDING } from '../../modules/pivotTable/pivotTableConstants'
 import { sortIcon as sortIconStyle } from './styles/PivotTable.style'
 import { SortIconAscending } from './icons/SortIconAscending'
 import { SortIconDescending } from './icons/SortIconDescending'

--- a/src/components/PivotTable/PivotTableTitleRow.js
+++ b/src/components/PivotTable/PivotTableTitleRow.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { cell as cellStyle } from './styles/PivotTable.style'
 import { usePivotTableEngine } from './PivotTableEngineContext'
 import { PivotTableCell } from './PivotTableCell'
+import { CLIPPED_CELL_WIDTH } from '../../modules/pivotTable/pivotTableConstants'
 
 export const PivotTableTitleRow = ({
     title,
@@ -20,12 +21,15 @@ export const PivotTableTitleRow = ({
             >
                 <div
                     style={{
-                        marginLeft: Math.floor(scrollPosition.x / 150) * 150,
+                        marginLeft:
+                            Math.floor(scrollPosition.x / CLIPPED_CELL_WIDTH) *
+                            CLIPPED_CELL_WIDTH,
                         width:
                             Math.min(
                                 columnCount,
-                                Math.ceil(containerWidth / 150) + 1
-                            ) * 150,
+                                Math.ceil(containerWidth / CLIPPED_CELL_WIDTH) +
+                                    1
+                            ) * CLIPPED_CELL_WIDTH,
                         textAlign: 'center',
                     }}
                 >

--- a/src/components/PivotTable/PivotTableTitleRow.js
+++ b/src/components/PivotTable/PivotTableTitleRow.js
@@ -1,25 +1,21 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
 import { cell as cellStyle } from './styles/PivotTable.style'
+import { usePivotTableEngine } from './PivotTableEngineContext'
+import { PivotTableCell } from './PivotTableCell'
 
 export const PivotTableTitleRow = ({
     title,
     scrollPosition,
     containerWidth,
-    engine,
 }) => {
+    const engine = usePivotTableEngine()
     const columnCount = engine.width + engine.dimensionLookup.rows.length
     return (
         <tr>
             <style jsx>{cellStyle}</style>
-            <td
-                className={classnames(
-                    'column-header',
-                    'title',
-                    `fontsize-${engine.visualization.fontSize}`,
-                    `displaydensity-${engine.visualization.displayDensity}`
-                )}
+            <PivotTableCell
+                classes={['column-header', 'title']}
                 colSpan={columnCount}
             >
                 <div
@@ -35,14 +31,13 @@ export const PivotTableTitleRow = ({
                 >
                     {title}
                 </div>
-            </td>
+            </PivotTableCell>
         </tr>
     )
 }
 
 PivotTableTitleRow.propTypes = {
     containerWidth: PropTypes.number.isRequired,
-    engine: PropTypes.object.isRequired,
     scrollPosition: PropTypes.shape({ x: PropTypes.number.isRequired })
         .isRequired,
     title: PropTypes.string.isRequired,

--- a/src/components/PivotTable/PivotTableTitleRows.js
+++ b/src/components/PivotTable/PivotTableTitleRows.js
@@ -1,11 +1,11 @@
-import React, { useContext } from 'react'
+import React from 'react'
 import PropTypes from 'prop-types'
-import { PivotTableEngineContext } from './PivotTableEngineContext'
+import { usePivotTableEngine } from './PivotTableEngineContext'
 import { PivotTableTitleRow } from './PivotTableTitleRow'
 import getFilterText from '../../visualizations/util/getFilterText'
 
 export const PivotTableTitleRows = ({ clippingResult, width }) => {
-    const engine = useContext(PivotTableEngineContext)
+    const engine = usePivotTableEngine()
     return (
         <>
             {engine.options.title ? (

--- a/src/components/PivotTable/PivotTableTitleRows.js
+++ b/src/components/PivotTable/PivotTableTitleRows.js
@@ -1,0 +1,45 @@
+import React, { useContext } from 'react'
+import PropTypes from 'prop-types'
+import { PivotTableEngineContext } from './PivotTableEngineContext'
+import { PivotTableTitleRow } from './PivotTableTitleRow'
+import getFilterText from '../../visualizations/util/getFilterText'
+
+export const PivotTableTitleRows = ({ clippingResult, width }) => {
+    const engine = useContext(PivotTableEngineContext)
+    return (
+        <>
+            {engine.options.title ? (
+                <PivotTableTitleRow
+                    engine={engine}
+                    title={engine.options.title}
+                    scrollPosition={clippingResult.scrollPosition}
+                    containerWidth={width}
+                />
+            ) : null}
+            {engine.options.subtitle ? (
+                <PivotTableTitleRow
+                    engine={engine}
+                    title={engine.options.subtitle}
+                    scrollPosition={clippingResult.scrollPosition}
+                    containerWidth={width}
+                />
+            ) : null}
+            {engine.visualization.filters?.length ? (
+                <PivotTableTitleRow
+                    engine={engine}
+                    title={getFilterText(
+                        engine.visualization.filters,
+                        engine.rawData.metaData
+                    )}
+                    scrollPosition={clippingResult.scrollPosition}
+                    containerWidth={width}
+                />
+            ) : null}
+        </>
+    )
+}
+
+PivotTableTitleRows.propTypes = {
+    clippingResult: PropTypes.object.isRequired,
+    width: PropTypes.number.isRequired,
+}

--- a/src/components/PivotTable/PivotTableValueCell.js
+++ b/src/components/PivotTable/PivotTableValueCell.js
@@ -1,11 +1,13 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import classnames from 'classnames'
-import { cell as cellStyle } from './styles/PivotTable.style'
 import { renderValue } from '../../modules/pivotTable/renderValue'
 import { applyLegendSet } from '../../modules/pivotTable/applyLegendSet'
+import { PivotTableCell } from './PivotTableCell'
+import { usePivotTableEngine } from './PivotTableEngineContext'
 
-export const PivotTableValueCell = ({ engine, row, column }) => {
+export const PivotTableValueCell = ({ row, column }) => {
+    const engine = usePivotTableEngine()
+
     const rawValue = engine.get({
         row,
         column,
@@ -30,25 +32,18 @@ export const PivotTableValueCell = ({ engine, row, column }) => {
             : undefined
 
     return (
-        <td
+        <PivotTableCell
             key={column}
-            className={classnames(
-                type,
-                dxDimension.valueType,
-                `fontsize-${engine.visualization.fontSize}`,
-                `displaydensity-${engine.visualization.displayDensity}`
-            )}
+            classes={[type, dxDimension.valueType]}
             title={value}
             style={style}
         >
-            <style jsx>{cellStyle}</style>
-            {value || null}
-        </td>
+            {value ?? null}
+        </PivotTableCell>
     )
 }
 
 PivotTableValueCell.propTypes = {
     column: PropTypes.number.isRequired,
-    engine: PropTypes.object.isRequired,
     row: PropTypes.number.isRequired,
 }

--- a/src/components/PivotTable/styles/PivotTable.style.js
+++ b/src/components/PivotTable/styles/PivotTable.style.js
@@ -1,5 +1,15 @@
 import css from 'styled-jsx/css'
 import { colors } from '@dhis2/ui-core'
+import {
+    DISPLAY_DENSITY_PADDING_COMPACT,
+    DISPLAY_DENSITY_PADDING_NORMAL,
+    DISPLAY_DENSITY_PADDING_COMFORTABLE,
+    FONT_SIZE_SMALL,
+    FONT_SIZE_NORMAL,
+    FONT_SIZE_LARGE,
+    CLIPPED_CELL_WIDTH,
+    CLIPPED_CELL_HEIGHT,
+} from '../../../modules/pivotTable/pivotTableConstants'
 
 export const table = css`
     div.pivot-table-container {
@@ -25,32 +35,32 @@ export const cell = css`
         overflow: hidden;
         text-overflow: ellipsis;
         border: 1px solid #b2b2b2;
-        min-width: 150px;
-        width: 150px;
-        max-width: 150px;
-        min-height: 25px;
-        height: 25px;
+        min-width: ${CLIPPED_CELL_WIDTH}px;
+        width: ${CLIPPED_CELL_WIDTH}px;
+        max-width: ${CLIPPED_CELL_WIDTH}px;
+        min-height: ${CLIPPED_CELL_HEIGHT}px;
+        height: ${CLIPPED_CELL_HEIGHT}px;
         cursor: default;
     }
 
     .fontsize-SMALL {
-        font-size: 10px;
+        font-size: ${FONT_SIZE_SMALL}px;
     }
     .fontsize-NORMAL {
-        font-size: 11px;
+        font-size: ${FONT_SIZE_NORMAL}px;
     }
     .fontsize-LARGE {
-        font-size: 13px;
+        font-size: ${FONT_SIZE_LARGE}px;
     }
 
     .displaydensity-COMPACT {
-        padding: 4px;
+        padding: ${DISPLAY_DENSITY_PADDING_COMPACT}px;
     }
     .displaydensity-NORMAL {
-        padding: 5px;
+        padding: ${DISPLAY_DENSITY_PADDING_NORMAL}px;
     }
     .displaydensity-COMFORTABLE {
-        padding: 7px;
+        padding: ${DISPLAY_DENSITY_PADDING_COMFORTABLE}px;
     }
 
     .column-header {
@@ -104,20 +114,20 @@ export const cell = css`
 
 export const sortIcon = css`
     .fontsize-SMALL {
-        height: 10px;
+        height: ${FONT_SIZE_SMALL}px;
         margin-bottom: 1px;
         margin-left: 5px;
     }
 
     .fontsize-NORMAL {
-        height: 11px;
+        height: ${FONT_SIZE_NORMAL}px;
         max-height: 11px;
         margin-bottom: 2px;
         margin-left: 6px;
     }
 
     .fontsize-LARGE {
-        height: 13px;
+        height: ${FONT_SIZE_LARGE}px;
         margin-bottom: 2px;
         margin-left: 7px;
     }

--- a/src/components/PivotTable/styles/PivotTable.style.js
+++ b/src/components/PivotTable/styles/PivotTable.style.js
@@ -100,20 +100,23 @@ export const cell = css`
         overflow: hidden;
         text-overflow: ellipsis;
     }
+`
 
-    .fontsize-SMALL .sort-icon {
+export const sortIcon = css`
+    .fontsize-SMALL {
         height: 10px;
         margin-bottom: 1px;
         margin-left: 5px;
     }
 
-    .fontsize-NORMAL .sort-icon {
+    .fontsize-NORMAL {
         height: 11px;
+        max-height: 11px;
         margin-bottom: 2px;
         margin-left: 6px;
     }
 
-    .fontsize-LARGE .sort-icon {
+    .fontsize-LARGE {
         height: 13px;
         margin-bottom: 2px;
         margin-left: 7px;

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -5,9 +5,16 @@ import {
     DIMENSION_ID_PERIOD,
     DIMENSION_ID_ORGUNIT,
 } from '../predefinedDimensions'
-
-export const SORT_ORDER_ASCENDING = 1
-export const SORT_ORDER_DESCENDING = -1
+import {
+    AGGREGATE_TYPE_NA,
+    AGGREGATE_TYPE_AVERAGE,
+    AGGREGATE_TYPE_SUM,
+    CELL_TYPE_VALUE,
+    CELL_TYPE_TOTAL,
+    CELL_TYPE_SUBTOTAL,
+    SORT_ORDER_ASCENDING,
+    SORT_ORDER_DESCENDING,
+} from './pivotTableConstants'
 
 const dataFields = [
     'value',
@@ -17,11 +24,6 @@ const dataFields = [
     'multiplier',
     'divisor',
 ]
-
-const CELL_TYPE_VALUE = 'value'
-const CELL_TYPE_SUBTOTAL = 'subtotal'
-const CELL_TYPE_TOTAL = 'total'
-
 const defaultOptions = {
     hideEmptyColumns: false,
     hideEmptyRows: false,
@@ -29,12 +31,7 @@ const defaultOptions = {
     showColumnTotals: false,
     showRowSubtotals: false,
     showColumnSubtotals: false,
-    aggregateType: 'count',
 }
-
-const AGGREGATE_TYPE_SUM = 'SUM'
-const AGGREGATE_TYPE_AVERAGE = 'AVERAGE'
-const AGGREGATE_TYPE_NA = 'N/A'
 
 const countFromDisaggregates = list => {
     if (list.length === 0) {

--- a/src/modules/pivotTable/pivotTableConstants.js
+++ b/src/modules/pivotTable/pivotTableConstants.js
@@ -1,0 +1,21 @@
+export const SORT_ORDER_ASCENDING = 1
+export const SORT_ORDER_DESCENDING = -1
+
+export const CELL_TYPE_VALUE = 'value'
+export const CELL_TYPE_SUBTOTAL = 'subtotal'
+export const CELL_TYPE_TOTAL = 'total'
+
+export const AGGREGATE_TYPE_SUM = 'SUM'
+export const AGGREGATE_TYPE_AVERAGE = 'AVERAGE'
+export const AGGREGATE_TYPE_NA = 'N/A'
+
+export const FONT_SIZE_SMALL = 10
+export const FONT_SIZE_NORMAL = 11
+export const FONT_SIZE_LARGE = 13
+
+export const DISPLAY_DENSITY_PADDING_COMPACT = 4
+export const DISPLAY_DENSITY_PADDING_NORMAL = 5
+export const DISPLAY_DENSITY_PADDING_COMFORTABLE = 7
+
+export const CLIPPED_CELL_WIDTH = 150
+export const CLIPPED_CELL_HEIGHT = 25

--- a/src/modules/pivotTable/useSortableColumns.js
+++ b/src/modules/pivotTable/useSortableColumns.js
@@ -1,0 +1,26 @@
+import { useState } from 'react'
+import { SORT_ORDER_ASCENDING, SORT_ORDER_DESCENDING } from './PivotTableEngine'
+
+export const useSortableColumns = engine => {
+    const [sortBy, setSortBy] = useState(null)
+
+    const onSortByColumn = column => {
+        let order = SORT_ORDER_ASCENDING
+        if (sortBy && sortBy.column === column) {
+            if (sortBy.order === SORT_ORDER_ASCENDING) {
+                order = SORT_ORDER_DESCENDING
+            } else if (sortBy.order === SORT_ORDER_DESCENDING) {
+                engine.clearSort()
+                setSortBy(null)
+                return
+            }
+        }
+        engine.sort(column, order)
+        setSortBy({ column, order }) // Force a re-render
+    }
+
+    return {
+        sortBy,
+        onSortByColumn,
+    }
+}

--- a/src/modules/pivotTable/useSortableColumns.js
+++ b/src/modules/pivotTable/useSortableColumns.js
@@ -1,5 +1,8 @@
 import { useState } from 'react'
-import { SORT_ORDER_ASCENDING, SORT_ORDER_DESCENDING } from './PivotTableEngine'
+import {
+    SORT_ORDER_ASCENDING,
+    SORT_ORDER_DESCENDING,
+} from './pivotTableConstants'
 
 export const useSortableColumns = engine => {
     const [sortBy, setSortBy] = useState(null)

--- a/src/modules/pivotTable/useTableClipping.js
+++ b/src/modules/pivotTable/useTableClipping.js
@@ -1,6 +1,7 @@
 import { useMemo } from 'react'
 import { useScrollPosition } from './useScrollPosition'
 import { clipAxis } from './clipAxis'
+import { CLIPPED_CELL_WIDTH, CLIPPED_CELL_HEIGHT } from './pivotTableConstants'
 
 export const useTableClipping = ({
     containerRef,
@@ -15,7 +16,7 @@ export const useTableClipping = ({
             clipAxis({
                 position: scrollPosition.y,
                 size: height,
-                step: 25,
+                step: CLIPPED_CELL_HEIGHT,
                 totalCount: engine.height,
                 headerCount:
                     visualization.columns.length +
@@ -36,7 +37,7 @@ export const useTableClipping = ({
             clipAxis({
                 position: scrollPosition.x,
                 size: width,
-                step: 150,
+                step: CLIPPED_CELL_WIDTH,
                 totalCount: engine.width,
                 headerCount: visualization.rows.length,
             }),


### PR DESCRIPTION
This is a many-line but non-functional change which has three main effects:

1. PivotTable.js is [MUCH cleaner](https://github.com/dhis2/analytics/pull/330/files#diff-7f528c12fab1c5699621ae66bcedbd13R33-R47) and all the logic has been moved to helpers or child components (`PivotTableContainer`, `PivotTableHead`, and `PivotTableBody`)
2. The engine was previously passed around the entire component tree as a prop - now we access it from a new `PivotTableEngineContext`, so prop-forwarding is no longer required.
3. Added `PivotTableCell.js` to avoid duplication of fontSize and density classes.  Combined with the `PivotTableEngineContext` change this will also allow us to MUCH more easily turn clipping on/off with a simple className switch.