### PR TITLE
fix: reflow pivot table when interpretations panel is toggled

### DIFF
--- a/src/components/PivotTable/PivotTable.js
+++ b/src/components/PivotTable/PivotTable.js
@@ -16,9 +16,9 @@ import { PivotTableTitleRow } from './PivotTableTitleRow'
 import { PivotTableEmptyRow } from './PivotTableEmptyRow'
 import getFilterText from '../../visualizations/util/getFilterText'
 
-const PivotTable = ({ visualization, data, legendSets, renderId }) => {
+const PivotTable = ({ visualization, data, legendSets, renderCounter }) => {
     const containerRef = useRef(undefined)
-    const { width, height } = useParentSize(containerRef, renderId)
+    const { width, height } = useParentSize(containerRef, renderCounter)
     const [sortBy, setSortBy] = useState(null)
 
     const engine = useMemo(
@@ -123,7 +123,7 @@ PivotTable.propTypes = {
     data: PropTypes.object.isRequired,
     visualization: PropTypes.object.isRequired,
     legendSets: PropTypes.arrayOf(PropTypes.object),
-    renderId: PropTypes.string,
+    renderCounter: PropTypes.number,
 }
 
 export default PivotTable

--- a/src/components/PivotTable/PivotTable.js
+++ b/src/components/PivotTable/PivotTable.js
@@ -16,9 +16,9 @@ import { PivotTableTitleRow } from './PivotTableTitleRow'
 import { PivotTableEmptyRow } from './PivotTableEmptyRow'
 import getFilterText from '../../visualizations/util/getFilterText'
 
-const PivotTable = ({ visualization, data, legendSets }) => {
+const PivotTable = ({ visualization, data, legendSets, renderId }) => {
     const containerRef = useRef(undefined)
-    const { width, height } = useParentSize(containerRef)
+    const { width, height } = useParentSize(containerRef, renderId)
     const [sortBy, setSortBy] = useState(null)
 
     const engine = useMemo(
@@ -123,6 +123,7 @@ PivotTable.propTypes = {
     data: PropTypes.object.isRequired,
     visualization: PropTypes.object.isRequired,
     legendSets: PropTypes.arrayOf(PropTypes.object),
+    renderId: PropTypes.string,
 }
 
 export default PivotTable

--- a/src/modules/pivotTable/useParentSize.js
+++ b/src/modules/pivotTable/useParentSize.js
@@ -3,6 +3,7 @@ import ResizeObserver from 'resize-observer-polyfill'
 
 export const useParentSize = (
     elementRef,
+    renderId,
     initialSize = { width: 0, height: 0 }
 ) => {
     const [size, setSize] = useState({
@@ -20,13 +21,18 @@ export const useParentSize = (
                 height: el.clientHeight,
             })
         }
+
         onResize(el)
+
+        if (renderId) {
+            setSize({ width: 0 })
+        }
 
         const observer = new ResizeObserver(onResize)
         observer.observe(el)
 
         return () => observer.disconnect()
-    }, [elementRef])
+    }, [elementRef, renderId])
 
     return size
 }

--- a/src/modules/pivotTable/useParentSize.js
+++ b/src/modules/pivotTable/useParentSize.js
@@ -1,10 +1,12 @@
 import { useState, useEffect } from 'react'
 import ResizeObserver from 'resize-observer-polyfill'
 
+const initialState = { width: 0, height: 0 }
+
 export const useParentSize = (
     elementRef,
     renderCounter,
-    initialSize = { width: 0, height: 0 }
+    initialSize = initialState
 ) => {
     const [size, setSize] = useState({
         width: initialSize.width || 0,
@@ -25,7 +27,7 @@ export const useParentSize = (
         onResize(el)
 
         if (renderCounter) {
-            setSize({ width: undefined })
+            setSize(initialState)
         }
 
         const observer = new ResizeObserver(onResize)

--- a/src/modules/pivotTable/useParentSize.js
+++ b/src/modules/pivotTable/useParentSize.js
@@ -3,7 +3,7 @@ import ResizeObserver from 'resize-observer-polyfill'
 
 export const useParentSize = (
     elementRef,
-    renderId,
+    renderCounter,
     initialSize = { width: 0, height: 0 }
 ) => {
     const [size, setSize] = useState({
@@ -24,15 +24,15 @@ export const useParentSize = (
 
         onResize(el)
 
-        if (renderId) {
-            setSize({ width: 0 })
+        if (renderCounter) {
+            setSize({ width: undefined })
         }
 
         const observer = new ResizeObserver(onResize)
         observer.observe(el)
 
         return () => observer.disconnect()
-    }, [elementRef, renderId])
+    }, [elementRef, renderCounter])
 
     return size
 }


### PR DESCRIPTION
Probably not the prettiest solution, but when I noticed that disabling
the width via DevTools caused the table to reflow and the panel to show,
I thought to set the width to 0 when the interpretations panel toggles
and the resize observer will then trigger and get the correct size
presumably because the panel has then a chance to show and the flex to
work.