### PR TITLE
fix: wrong export for default vis type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -122,7 +122,7 @@ export {
     visTypeDisplayNames,
     visTypeIcons,
     getDisplayNameByVisType,
-    defaultChartType,
+    defaultVisType,
     isStacked,
     isYearOverYear,
     isDualAxisType,


### PR DESCRIPTION
`defaultChartType` was the old export name.

`defaultVisType` is already in use in DV, but without the correct export it was `undefined`.