### PR TITLE
fix: align numbers right and text items left

### DIFF
--- a/src/components/PivotTable/styles/PivotTable.style.js
+++ b/src/components/PivotTable/styles/PivotTable.style.js
@@ -87,12 +87,13 @@ export const cell = css`
     }
     .value {
         background-color: #ffffff;
-        cursor: normal;
+        cursor: pointer;
+    }
+    .TEXT {
         text-align: left;
     }
-    .value.NUMBER {
-        text-align: center;
-        cursor: pointer;
+    .NUMBER {
+        text-align: right;
     }
 
     .value:hover {

--- a/stories/PivotTable.stories.js
+++ b/stories/PivotTable.stories.js
@@ -54,6 +54,20 @@ storiesOf('PivotTable', module).add('simple', () => {
     )
 })
 
+storiesOf('PivotTable', module).add('simple - title / subtitle / filter', () => {
+    const visualization = {
+        ...simpleVisualization,
+        ...visualizationReset,
+        title: 'This is a Table',
+        subtitle: 'It\'s not a very big table'
+    }
+    return (
+        <div style={{ width: 800, height: 600 }}>
+            <PivotTable data={simpleData} visualization={visualization} />
+        </div>
+    )
+})
+
 storiesOf('PivotTable', module).add('simple - column %', () => {
     const visualization = {
         ...simpleVisualization,


### PR DESCRIPTION
Tiny style fixes to:
1. Always show the pointer cursor on value cells
2. Align NUMBERs right and TEXT values left (headers are still centered)