### PR TITLE
fix: don't sort total when hideEmptyRows, fix column subtotals

### DIFF
--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -513,7 +513,7 @@ export class PivotTableEngine {
             }
 
         const columnSubtotalSize = this.dimensionLookup.rows[0].size + 1
-        const columnSubtotal = this.options.showColumnSubtotals && {
+        const columnSubtotal = this.doColumnSubtotals && {
             row:
                 Math.ceil((row + 1) / columnSubtotalSize) * columnSubtotalSize -
                 1,
@@ -1094,16 +1094,10 @@ export class PivotTableEngine {
 
         const mappedColumn = this.columnMap[column]
         this.rowMap.sort((rowA, rowB) => {
-            if (
-                this.options.showColumnTotals &&
-                rowA === this.rowMap.length - 1
-            ) {
+            if (this.options.showColumnTotals && rowA === this.dataHeight - 1) {
                 return 1
             }
-            if (
-                this.options.showColumnTotals &&
-                rowB === this.rowMap.length - 1
-            ) {
+            if (this.options.showColumnTotals && rowB === this.dataHeight - 1) {
                 return -1
             }
             const valueA = this.getRaw({ row: rowA, column: mappedColumn })

--- a/stories/PivotTable.stories.js
+++ b/stories/PivotTable.stories.js
@@ -34,6 +34,10 @@ import degsDataResponse from './data/degs.data.json'
 import degsMetadataResponse from './data/degs.metadata.json'
 import degsVisualization from './data/degs.visualization.json'
 
+import diseaseWeeksDataResponse from './data/diseaseWeeks.data.json'
+import diseaseWeeksMetadataResponse from './data/diseaseWeeks.metadata.json'
+import diseaseWeeksVisualization from './data/diseaseWeeks.visualization.json'
+
 import underAbove100LegendSet from './data/under-above-100.legendSet.json'
 import { NUMBER_TYPE_COLUMN_PERCENTAGE, NUMBER_TYPE_ROW_PERCENTAGE } from '../src/modules/pivotTable/pivotTableConstants'
 
@@ -57,6 +61,7 @@ const targetData = combineDataWithMetadata(targetDataResponse, targetMetadataRes
 const hierarchyData = combineDataWithMetadata(hierarchyDataResponse, hierarchyMetadataResponse)
 const narrativeData = combineDataWithMetadata(narrativeDataResponse, narrativeMetadataResponse)
 const degsData = combineDataWithMetadata(degsDataResponse, degsMetadataResponse)
+const diseaseWeeksData = combineDataWithMetadata(diseaseWeeksDataResponse, diseaseWeeksMetadataResponse)
 
 
 storiesOf('PivotTable', module).add('simple', () => {
@@ -306,6 +311,41 @@ storiesOf('PivotTable', module).add('deep - all totals', () => {
     )
 })
 
+storiesOf('PivotTable', module).add('small empty rows - shown', () => {
+    const visualization = {
+        ...diseaseWeeksVisualization,
+        ...visualizationReset,
+        colTotals: true,
+        rowTotals: true,
+        colSubTotals: true,
+        rowSubTotals: true,
+    }
+
+    return (
+        <div style={{ width: 800, height: 600 }}>
+            <PivotTable data={diseaseWeeksData} visualization={visualization} />
+        </div>
+    )
+})
+
+storiesOf('PivotTable', module).add('small empty rows - hidden', () => {
+    const visualization = {
+        ...diseaseWeeksVisualization,
+        ...visualizationReset,
+        colTotals: true,
+        rowTotals: true,
+        colSubTotals: true,
+        rowSubTotals: true,
+        hideEmptyRows: true
+    }
+
+    return (
+        <div style={{ width: 800, height: 600 }}>
+            <PivotTable data={diseaseWeeksData} visualization={visualization} />
+        </div>
+    )
+})
+
 storiesOf('PivotTable', module).add('empty rows - shown', () => {
     const visualization = {
         ...emptyRowsVisualization,
@@ -357,19 +397,6 @@ storiesOf('PivotTable', module).add('empty columns + assigned cats (hidden)', ()
     return (
         <div style={{ width: 800, height: 600 }}>
             <PivotTable data={emptyColumnsData} visualization={visualization} />
-        </div>
-    )
-})
-
-storiesOf('PivotTable', module).add('empty rows - hidden', () => {
-    const visualization = {
-        ...emptyRowsVisualization,
-        ...visualizationReset,
-        hideEmptyRows: true,
-    }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={emptyRowsData} visualization={visualization} />
         </div>
     )
 })

--- a/stories/data/diseaseWeeks.data.json
+++ b/stories/data/diseaseWeeks.data.json
@@ -1,0 +1,323 @@
+{
+    "headers": [
+        {
+            "name": "dx",
+            "column": "Data",
+            "valueType": "TEXT",
+            "type": "java.lang.String",
+            "hidden": false,
+            "meta": true
+        },
+        {
+            "name": "pe",
+            "column": "Period",
+            "valueType": "TEXT",
+            "type": "java.lang.String",
+            "hidden": false,
+            "meta": true
+        },
+        {
+            "name": "value",
+            "column": "Value",
+            "valueType": "NUMBER",
+            "type": "java.lang.Double",
+            "hidden": false,
+            "meta": false
+        },
+        {
+            "name": "numerator",
+            "column": "Numerator",
+            "valueType": "NUMBER",
+            "type": "java.lang.Double",
+            "hidden": false,
+            "meta": false
+        },
+        {
+            "name": "denominator",
+            "column": "Denominator",
+            "valueType": "NUMBER",
+            "type": "java.lang.Double",
+            "hidden": false,
+            "meta": false
+        },
+        {
+            "name": "factor",
+            "column": "Factor",
+            "valueType": "NUMBER",
+            "type": "java.lang.Double",
+            "hidden": false,
+            "meta": false
+        },
+        {
+            "name": "multiplier",
+            "column": "Multiplier",
+            "valueType": "NUMBER",
+            "type": "java.lang.Double",
+            "hidden": false,
+            "meta": false
+        },
+        {
+            "name": "divisor",
+            "column": "Divisor",
+            "valueType": "NUMBER",
+            "type": "java.lang.Double",
+            "hidden": false,
+            "meta": false
+        }
+    ],
+    "width": 8,
+    "height": 25,
+    "rows": [
+        [
+            "HS9zqaBdOQ4",
+            "2020W11",
+            "441.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "HS9zqaBdOQ4",
+            "2020W12",
+            "427.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "noIzB569hTM",
+            "2020W4",
+            "320.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "noIzB569hTM",
+            "2020W6",
+            "460.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "noIzB569hTM",
+            "2020W2",
+            "264.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "HS9zqaBdOQ4",
+            "2020W2",
+            "275.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "UsSUX0cpKsH",
+            "2020W2",
+            "289.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "HS9zqaBdOQ4",
+            "2020W4",
+            "312.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "UsSUX0cpKsH",
+            "2020W4",
+            "297.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "HS9zqaBdOQ4",
+            "2020W6",
+            "466.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "UsSUX0cpKsH",
+            "2020W6",
+            "419.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "YazgqXbizv1",
+            "2020W11",
+            "409.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "YazgqXbizv1",
+            "2020W12",
+            "452.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "UsSUX0cpKsH",
+            "2020W11",
+            "430.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "vq2qO3eTrNi",
+            "2020W6",
+            "430.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "UsSUX0cpKsH",
+            "2020W12",
+            "457.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "vq2qO3eTrNi",
+            "2020W2",
+            "267.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "vq2qO3eTrNi",
+            "2020W4",
+            "320.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "noIzB569hTM",
+            "2020W12",
+            "420.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "YazgqXbizv1",
+            "2020W2",
+            "300.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "vq2qO3eTrNi",
+            "2020W12",
+            "505.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "noIzB569hTM",
+            "2020W11",
+            "433.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "vq2qO3eTrNi",
+            "2020W11",
+            "446.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "YazgqXbizv1",
+            "2020W6",
+            "437.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "YazgqXbizv1",
+            "2020W4",
+            "290.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ]
+    ],
+    "headerWidth": 8
+}

--- a/stories/data/diseaseWeeks.metadata.json
+++ b/stories/data/diseaseWeeks.metadata.json
@@ -1,0 +1,229 @@
+{
+    "metaData": {
+        "items": {
+            "vq2qO3eTrNi": {
+                "uid": "vq2qO3eTrNi",
+                "name": "IDSR Malaria",
+                "dimensionItemType": "DATA_ELEMENT",
+                "valueType": "NUMBER",
+                "aggregationType": "SUM",
+                "totalAggregationType": "SUM"
+            },
+            "ou": {
+                "uid": "ou",
+                "name": "Organisation unit",
+                "dimensionType": "ORGANISATION_UNIT"
+            },
+            "noIzB569hTM": {
+                "uid": "noIzB569hTM",
+                "name": "IDSR Yellow fever",
+                "dimensionItemType": "DATA_ELEMENT",
+                "valueType": "NUMBER",
+                "aggregationType": "SUM",
+                "totalAggregationType": "SUM"
+            },
+            "2020W12": {
+                "uid": "2020W12",
+                "code": "2020W12",
+                "name": "W12 2020",
+                "dimensionItemType": "PERIOD",
+                "valueType": "NUMBER",
+                "totalAggregationType": "SUM",
+                "startDate": "2020-03-16T00:00:00.000",
+                "endDate": "2020-03-22T00:00:00.000"
+            },
+            "2020W11": {
+                "uid": "2020W11",
+                "code": "2020W11",
+                "name": "W11 2020",
+                "dimensionItemType": "PERIOD",
+                "valueType": "NUMBER",
+                "totalAggregationType": "SUM",
+                "startDate": "2020-03-09T00:00:00.000",
+                "endDate": "2020-03-15T00:00:00.000"
+            },
+            "2020W10": {
+                "uid": "2020W10",
+                "code": "2020W10",
+                "name": "W10 2020",
+                "dimensionItemType": "PERIOD",
+                "valueType": "NUMBER",
+                "totalAggregationType": "SUM",
+                "startDate": "2020-03-02T00:00:00.000",
+                "endDate": "2020-03-08T00:00:00.000"
+            },
+            "UsSUX0cpKsH": {
+                "uid": "UsSUX0cpKsH",
+                "name": "IDSR Cholera",
+                "dimensionItemType": "DATA_ELEMENT",
+                "valueType": "NUMBER",
+                "aggregationType": "SUM",
+                "totalAggregationType": "SUM"
+            },
+            "HS9zqaBdOQ4": {
+                "uid": "HS9zqaBdOQ4",
+                "name": "IDSR Plague",
+                "dimensionItemType": "DATA_ELEMENT",
+                "valueType": "NUMBER",
+                "aggregationType": "SUM",
+                "totalAggregationType": "SUM"
+            },
+            "2020W9": {
+                "uid": "2020W9",
+                "code": "2020W9",
+                "name": "W9 2020",
+                "dimensionItemType": "PERIOD",
+                "valueType": "NUMBER",
+                "totalAggregationType": "SUM",
+                "startDate": "2020-02-24T00:00:00.000",
+                "endDate": "2020-03-01T00:00:00.000"
+            },
+            "ImspTQPwCqd": {
+                "uid": "ImspTQPwCqd",
+                "code": "OU_525",
+                "name": "Sierra Leone",
+                "dimensionItemType": "ORGANISATION_UNIT",
+                "valueType": "NUMBER",
+                "totalAggregationType": "SUM"
+            },
+            "2020W7": {
+                "uid": "2020W7",
+                "code": "2020W7",
+                "name": "W7 2020",
+                "dimensionItemType": "PERIOD",
+                "valueType": "NUMBER",
+                "totalAggregationType": "SUM",
+                "startDate": "2020-02-10T00:00:00.000",
+                "endDate": "2020-02-16T00:00:00.000"
+            },
+            "2020W8": {
+                "uid": "2020W8",
+                "code": "2020W8",
+                "name": "W8 2020",
+                "dimensionItemType": "PERIOD",
+                "valueType": "NUMBER",
+                "totalAggregationType": "SUM",
+                "startDate": "2020-02-17T00:00:00.000",
+                "endDate": "2020-02-23T00:00:00.000"
+            },
+            "dx": {
+                "uid": "dx",
+                "name": "Data",
+                "dimensionType": "DATA_X"
+            },
+            "2020W5": {
+                "uid": "2020W5",
+                "code": "2020W5",
+                "name": "W5 2020",
+                "dimensionItemType": "PERIOD",
+                "valueType": "NUMBER",
+                "totalAggregationType": "SUM",
+                "startDate": "2020-01-27T00:00:00.000",
+                "endDate": "2020-02-02T00:00:00.000"
+            },
+            "2020W6": {
+                "uid": "2020W6",
+                "code": "2020W6",
+                "name": "W6 2020",
+                "dimensionItemType": "PERIOD",
+                "valueType": "NUMBER",
+                "totalAggregationType": "SUM",
+                "startDate": "2020-02-03T00:00:00.000",
+                "endDate": "2020-02-09T00:00:00.000"
+            },
+            "pe": {
+                "uid": "pe",
+                "name": "Period",
+                "dimensionType": "PERIOD"
+            },
+            "2020W3": {
+                "uid": "2020W3",
+                "code": "2020W3",
+                "name": "W3 2020",
+                "dimensionItemType": "PERIOD",
+                "valueType": "NUMBER",
+                "totalAggregationType": "SUM",
+                "startDate": "2020-01-13T00:00:00.000",
+                "endDate": "2020-01-19T00:00:00.000"
+            },
+            "2020W4": {
+                "uid": "2020W4",
+                "code": "2020W4",
+                "name": "W4 2020",
+                "dimensionItemType": "PERIOD",
+                "valueType": "NUMBER",
+                "totalAggregationType": "SUM",
+                "startDate": "2020-01-20T00:00:00.000",
+                "endDate": "2020-01-26T00:00:00.000"
+            },
+            "HllvX50cXC0": {
+                "uid": "HllvX50cXC0",
+                "code": "default",
+                "name": "default",
+                "valueType": "NUMBER",
+                "totalAggregationType": "SUM"
+            },
+            "2020W1": {
+                "uid": "2020W1",
+                "code": "2020W1",
+                "name": "W1 2020",
+                "dimensionItemType": "PERIOD",
+                "valueType": "NUMBER",
+                "totalAggregationType": "SUM",
+                "startDate": "2019-12-30T00:00:00.000",
+                "endDate": "2020-01-05T00:00:00.000"
+            },
+            "2020W2": {
+                "uid": "2020W2",
+                "code": "2020W2",
+                "name": "W2 2020",
+                "dimensionItemType": "PERIOD",
+                "valueType": "NUMBER",
+                "totalAggregationType": "SUM",
+                "startDate": "2020-01-06T00:00:00.000",
+                "endDate": "2020-01-12T00:00:00.000"
+            },
+            "YazgqXbizv1": {
+                "uid": "YazgqXbizv1",
+                "name": "IDSR Measles",
+                "dimensionItemType": "DATA_ELEMENT",
+                "valueType": "NUMBER",
+                "aggregationType": "SUM",
+                "totalAggregationType": "SUM"
+            }
+        },
+        "dimensions": {
+            "dx": [
+                "UsSUX0cpKsH",
+                "vq2qO3eTrNi",
+                "YazgqXbizv1",
+                "HS9zqaBdOQ4",
+                "noIzB569hTM"
+            ],
+            "pe": [
+                "2020W12",
+                "2020W11",
+                "2020W10",
+                "2020W9",
+                "2020W8",
+                "2020W7",
+                "2020W6",
+                "2020W5",
+                "2020W4",
+                "2020W3",
+                "2020W2",
+                "2020W1"
+            ],
+            "ou": [
+                "ImspTQPwCqd"
+            ],
+            "co": [
+                "HllvX50cXC0"
+            ]
+        }
+    },
+    "width": 0,
+    "height": 0,
+    "rows": [],
+    "headerWidth": 0
+}

--- a/stories/data/diseaseWeeks.visualization.json
+++ b/stories/data/diseaseWeeks.visualization.json
@@ -1,0 +1,226 @@
+{
+    "lastUpdated": "2020-03-06T11:45:16.434",
+    "id": "hY0eM8AWg6k",
+    "created": "2017-05-30T14:29:44.670",
+    "name": "IDSR: Disease Week 1-12 Sierra Leone",
+    "publicAccess": "rw------",
+    "legendDisplayStyle": "FILL",
+    "type": "PIVOT_TABLE",
+    "hideEmptyColumns": false,
+    "subscribed": false,
+    "rowSubTotals": true,
+    "cumulativeValues": false,
+    "showDimensionLabels": true,
+    "sortOrder": 0,
+    "fontSize": "NORMAL",
+    "favorite": false,
+    "topLimit": 0,
+    "displayName": "IDSR: Disease Week 1-12 Sierra Leone",
+    "percentStackedValues": false,
+    "noSpaceBetweenColumns": false,
+    "showHierarchy": false,
+    "hideTitle": false,
+    "skipRounding": false,
+    "showData": false,
+    "numberType": "VALUE",
+    "hideEmptyRows": true,
+    "parentGraphMap": {
+        "ImspTQPwCqd": ""
+    },
+    "displayDensity": "NORMAL",
+    "regressionType": "NONE",
+    "completedOnly": false,
+    "colTotals": true,
+    "hideEmptyRowItems": "NONE",
+    "aggregationType": "DEFAULT",
+    "hideSubtitle": false,
+    "hideLegend": false,
+    "colSubTotals": true,
+    "legendDisplayStrategy": "FIXED",
+    "rowTotals": true,
+    "digitGroupSeparator": "SPACE",
+    "regression": false,
+    "access": {
+        "read": true,
+        "update": true,
+        "externalize": true,
+        "delete": true,
+        "write": true,
+        "manage": true,
+        "data": {
+            "read": true,
+            "write": true
+        }
+    },
+    "reportingParams": {
+        "parentOrganisationUnit": false,
+        "reportingPeriod": false,
+        "organisationUnit": false,
+        "grandParentOrganisationUnit": false
+    },
+    "lastUpdatedBy": {
+        "id": "GOLswS44mh8"
+    },
+    "user": {
+        "name": "Tom Wakiki",
+        "displayName": "Tom Wakiki",
+        "userCredentials": {
+            "username": "system"
+        }
+    },
+    "translations": [],
+    "yearlySeries": [],
+    "interpretations": [],
+    "userGroupAccesses": [],
+    "subscribers": [],
+    "optionalAxes": [],
+    "columns": [
+        {
+            "dimension": "dx",
+            "items": [
+                {
+                    "name": "IDSR Cholera",
+                    "id": "UsSUX0cpKsH",
+                    "displayName": "IDSR Cholera",
+                    "displayShortName": "Cholera",
+                    "dimensionItemType": "DATA_ELEMENT"
+                },
+                {
+                    "name": "IDSR Malaria",
+                    "id": "vq2qO3eTrNi",
+                    "displayName": "IDSR Malaria",
+                    "displayShortName": "Malaria",
+                    "dimensionItemType": "DATA_ELEMENT"
+                },
+                {
+                    "name": "IDSR Measles",
+                    "id": "YazgqXbizv1",
+                    "displayName": "IDSR Measles",
+                    "displayShortName": "Measles",
+                    "dimensionItemType": "DATA_ELEMENT"
+                },
+                {
+                    "name": "IDSR Plague",
+                    "id": "HS9zqaBdOQ4",
+                    "displayName": "IDSR Plague",
+                    "displayShortName": "Plague",
+                    "dimensionItemType": "DATA_ELEMENT"
+                },
+                {
+                    "name": "IDSR Yellow fever",
+                    "id": "noIzB569hTM",
+                    "displayName": "IDSR Yellow fever",
+                    "displayShortName": "Yellow fever",
+                    "dimensionItemType": "DATA_ELEMENT"
+                }
+            ]
+        }
+    ],
+    "userAccesses": [],
+    "favorites": [],
+    "filters": [
+        {
+            "dimension": "ou",
+            "items": [
+                {
+                    "name": "Sierra Leone",
+                    "id": "ImspTQPwCqd",
+                    "displayName": "Sierra Leone",
+                    "displayShortName": "Sierra Leone",
+                    "dimensionItemType": "ORGANISATION_UNIT"
+                }
+            ]
+        }
+    ],
+    "rows": [
+        {
+            "dimension": "pe",
+            "items": [
+                {
+                    "name": "W12 2020",
+                    "id": "2020W12",
+                    "displayName": "W12 2020",
+                    "displayShortName": "2020W12",
+                    "dimensionItemType": "PERIOD"
+                },
+                {
+                    "name": "W11 2020",
+                    "id": "2020W11",
+                    "displayName": "W11 2020",
+                    "displayShortName": "2020W11",
+                    "dimensionItemType": "PERIOD"
+                },
+                {
+                    "name": "W10 2020",
+                    "id": "2020W10",
+                    "displayName": "W10 2020",
+                    "displayShortName": "2020W10",
+                    "dimensionItemType": "PERIOD"
+                },
+                {
+                    "name": "W9 2020",
+                    "id": "2020W9",
+                    "displayName": "W9 2020",
+                    "displayShortName": "2020W9",
+                    "dimensionItemType": "PERIOD"
+                },
+                {
+                    "name": "W8 2020",
+                    "id": "2020W8",
+                    "displayName": "W8 2020",
+                    "displayShortName": "2020W8",
+                    "dimensionItemType": "PERIOD"
+                },
+                {
+                    "name": "W7 2020",
+                    "id": "2020W7",
+                    "displayName": "W7 2020",
+                    "displayShortName": "2020W7",
+                    "dimensionItemType": "PERIOD"
+                },
+                {
+                    "name": "W6 2020",
+                    "id": "2020W6",
+                    "displayName": "W6 2020",
+                    "displayShortName": "2020W6",
+                    "dimensionItemType": "PERIOD"
+                },
+                {
+                    "name": "W5 2020",
+                    "id": "2020W5",
+                    "displayName": "W5 2020",
+                    "displayShortName": "2020W5",
+                    "dimensionItemType": "PERIOD"
+                },
+                {
+                    "name": "W4 2020",
+                    "id": "2020W4",
+                    "displayName": "W4 2020",
+                    "displayShortName": "2020W4",
+                    "dimensionItemType": "PERIOD"
+                },
+                {
+                    "name": "W3 2020",
+                    "id": "2020W3",
+                    "displayName": "W3 2020",
+                    "displayShortName": "2020W3",
+                    "dimensionItemType": "PERIOD"
+                },
+                {
+                    "name": "W2 2020",
+                    "id": "2020W2",
+                    "displayName": "W2 2020",
+                    "displayShortName": "2020W2",
+                    "dimensionItemType": "PERIOD"
+                },
+                {
+                    "name": "W1 2020",
+                    "id": "2020W1",
+                    "displayName": "W1 2020",
+                    "displayShortName": "2020W1",
+                    "dimensionItemType": "PERIOD"
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
There were issues with the `hideEmptyRows` (some rows weren't hidden) and with column sorting (`total` column was sorted as if it were a value) found [here](https://verify.dhis2.org/2.34dev/dhis-web-data-visualizer/index.html#/hY0eM8AWg6k) by @janhenrikoverland -- this fixes those two issues and adds it this example as a story.

The issues were simple typos - we didn't take into account hidden rows when excluding the total row from a sort operation, and we were accidentally calculating column subtotals even if those subtotals were hidden (because there's only one row dimension)