### PR TITLE
fix: make the gauge use more viewport space (DHIS2-8412)

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/index.js
@@ -88,7 +88,7 @@ export default function({ store, layout, el, extraConfig, extraOptions }) {
         legend: getLegend(_layout, _extraOptions.dashboard),
 
         // pane
-        pane: getPane(_layout.type),
+        pane: getPane(_layout.type, _extraOptions),
 
         // no data
         lang: {

--- a/src/visualizations/config/adapters/dhis_highcharts/pane/gauge.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/pane/gauge.js
@@ -1,7 +1,7 @@
 export default function() {
     return {
         center: ['50%', '85%'],
-        size: '90%',
+        size: '140%',
         startAngle: -90,
         endAngle: 90,
         background: {

--- a/src/visualizations/config/adapters/dhis_highcharts/pane/gauge.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/pane/gauge.js
@@ -1,7 +1,10 @@
-export default function() {
+const DEFAULT_PANE_SIZE = '140%'
+const DASHBOARD_PANE_SIZE = '100%'
+
+export default function(dashboard) {
     return {
         center: ['50%', '85%'],
-        size: '140%',
+        size: dashboard ? DASHBOARD_PANE_SIZE : DEFAULT_PANE_SIZE,
         startAngle: -90,
         endAngle: 90,
         background: {

--- a/src/visualizations/config/adapters/dhis_highcharts/pane/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/pane/index.js
@@ -1,10 +1,10 @@
 import getGauge from './gauge'
 import { VIS_TYPE_GAUGE } from '../../../../../modules/visTypes'
 
-export default function(type) {
+export default function(type, extraOptions) {
     switch (type) {
         case VIS_TYPE_GAUGE:
-            return getGauge()
+            return getGauge(extraOptions.dashboard)
         default:
             return undefined
     }

--- a/src/visualizations/config/adapters/dhis_highcharts/series/gauge.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/gauge.js
@@ -1,7 +1,10 @@
-import { getColorByValueFromLegendSet, LEGEND_DISPLAY_STYLE_TEXT } from "../../../../../modules/legends"
+import {
+    getColorByValueFromLegendSet,
+    LEGEND_DISPLAY_STYLE_TEXT,
+} from '../../../../../modules/legends'
 
-const DEFAULT_FONT_SIZE = '34px'
-const DASHBOARD_FONT_SIZE = '24px'
+const DEFAULT_FONT_SIZE = '60px'
+const DASHBOARD_FONT_SIZE = '28px'
 
 export default function(series, dashboard, layout, legendSet) {
     return [
@@ -14,8 +17,17 @@ export default function(series, dashboard, layout, legendSet) {
                 borderWidth: 0,
                 verticalAlign: 'bottom',
                 style: {
-                    fontSize: dashboard ? DASHBOARD_FONT_SIZE : DEFAULT_FONT_SIZE,
-                    color: (layout.legendDisplayStyle === LEGEND_DISPLAY_STYLE_TEXT && legendSet) ? getColorByValueFromLegendSet(legendSet, series[0].data) : undefined,
+                    fontSize: dashboard
+                        ? DASHBOARD_FONT_SIZE
+                        : DEFAULT_FONT_SIZE,
+                    color:
+                        layout.legendDisplayStyle ===
+                            LEGEND_DISPLAY_STYLE_TEXT && legendSet
+                            ? getColorByValueFromLegendSet(
+                                  legendSet,
+                                  series[0].data
+                              )
+                            : undefined,
                 },
             },
         },


### PR DESCRIPTION
The value for `pane.size` passed to Highcharts controls the amount of viewport that the gauge uses.
Increased to 140% as seen on Highcharts demo examples for DV and 100% (was 90%) for dashboards.

Also increase the font size used for the value.
It's not possible to find a fixed font-size that works well with all lengths of values.
Depending on the number of digits and the size of the container, there is a limit on which values can fit under the arch.

Fixes: https://jira.dhis2.org/browse/DHIS2-8412

Before DV:
<img width="1440" alt="Screenshot 2020-03-09 at 14 34 06" src="https://user-images.githubusercontent.com/150978/76217934-9dd36900-6213-11ea-9402-74ca6c3a88bf.png">

After DV:
![Screenshot 2020-03-10 at 13 53 10](https://user-images.githubusercontent.com/150978/76314126-8610e900-62d6-11ea-9b12-7238bad37506.png)

Before dashboards:
![Screenshot 2020-03-10 at 13 59 48](https://user-images.githubusercontent.com/150978/76314630-7f36a600-62d7-11ea-9a73-3f014dc37c6f.png)

After dashboards:
![Screenshot 2020-03-10 at 14 00 13](https://user-images.githubusercontent.com/150978/76314637-81990000-62d7-11ea-8435-ffc95be04229.png)

