### PR TITLE
fix: support single-axis tables

### DIFF
--- a/src/components/PivotTable/PivotTableColumnHeaders.js
+++ b/src/components/PivotTable/PivotTableColumnHeaders.js
@@ -13,9 +13,16 @@ export const PivotTableColumnHeaders = ({
 }) => {
     const engine = usePivotTableEngine()
 
-    return engine.dimensionLookup.columns.map((_, columnLevel) => (
+    const columns = engine.dimensionLookup.columns.length
+        ? engine.dimensionLookup.columns
+        : [0]
+    const rows = engine.dimensionLookup.rows.length
+        ? engine.dimensionLookup.rows
+        : [0]
+
+    return columns.map((_, columnLevel) => (
         <tr key={columnLevel}>
-            {engine.dimensionLookup.rows.map((_, rowLevel) => (
+            {rows.map((_, rowLevel) => (
                 <PivotTableDimensionLabelCell
                     key={rowLevel}
                     rowLevel={rowLevel}

--- a/src/components/PivotTable/PivotTableDimensionLabelCell.js
+++ b/src/components/PivotTable/PivotTableDimensionLabelCell.js
@@ -6,8 +6,8 @@ import { PivotTableCell } from './PivotTableCell'
 export const PivotTableDimensionLabelCell = ({ rowLevel, columnLevel }) => {
     const engine = usePivotTableEngine()
 
-    const colCount = engine.dimensionLookup.rows.length
-    const rowCount = engine.dimensionLookup.columns.length
+    const colCount = engine.dimensionLookup.rows.length || 1
+    const rowCount = engine.dimensionLookup.columns.length || 1
 
     let colSpan = 1,
         rowSpan = 1,

--- a/src/components/PivotTable/PivotTableRow.js
+++ b/src/components/PivotTable/PivotTableRow.js
@@ -10,6 +10,9 @@ export const PivotTableRow = ({ clippingResult, rowIndex }) => {
     const engine = usePivotTableEngine()
     return (
         <tr>
+            {engine.dimensionLookup.rows.length === 0 && (
+                <PivotTableEmptyCell type="row-header" />
+            )}
             {engine.dimensionLookup.rows.map((_, rowLevel) => (
                 <PivotTableRowHeaderCell
                     key={rowLevel}

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -501,12 +501,15 @@ export class PivotTableEngine {
 
     getDependantTotalCells({ row, column }) {
         const rowSubtotalSize = this.dimensionLookup.columns[0]?.size + 1
-        const rowSubtotal = this.doRowSubtotals && {
-            row,
-            column:
-                Math.ceil((column + 1) / rowSubtotalSize) * rowSubtotalSize - 1,
-            size: rowSubtotalSize - 1,
-        }
+        const rowSubtotal = rowSubtotalSize &&
+            this.doRowSubtotals && {
+                row,
+                column:
+                    Math.ceil((column + 1) / rowSubtotalSize) *
+                        rowSubtotalSize -
+                    1,
+                size: rowSubtotalSize - 1,
+            }
         const rowSubtotalColumnTotal = this.doColumnSubtotals &&
             this.doRowTotals && {
                 row: this.dataHeight - 1,
@@ -515,13 +518,15 @@ export class PivotTableEngine {
             }
 
         const columnSubtotalSize = this.dimensionLookup.rows[0]?.size + 1
-        const columnSubtotal = this.doColumnSubtotals && {
-            row:
-                Math.ceil((row + 1) / columnSubtotalSize) * columnSubtotalSize -
-                1,
-            column,
-            size: columnSubtotalSize - 1,
-        }
+        const columnSubtotal = columnSubtotalSize &&
+            this.doColumnSubtotals && {
+                row:
+                    Math.ceil((row + 1) / columnSubtotalSize) *
+                        columnSubtotalSize -
+                    1,
+                column,
+                size: columnSubtotalSize - 1,
+            }
 
         const columnSubtotalRowTotal = this.doColumnSubtotals &&
             this.doRowTotals && {
@@ -530,7 +535,9 @@ export class PivotTableEngine {
                 size: this.rawDataWidth,
             }
 
-        const combinedSubtotal = this.doColumnSubtotals &&
+        const combinedSubtotal = rowSubtotalSize &&
+            columnSubtotalSize &&
+            this.doColumnSubtotals &&
             this.doRowSubtotals && {
                 row: columnSubtotal.row,
                 column: rowSubtotal.column,
@@ -736,7 +743,7 @@ export class PivotTableEngine {
 
         // TODO: consolidate total lookup and aggregate calculation logics
 
-        if (this.doRowSubtotals) {
+        if (this.doRowSubtotals && rowSubtotalSize) {
             times(
                 this.dimensionLookup.columns[0].count,
                 n => (n + 1) * rowSubtotalSize - 1
@@ -765,7 +772,7 @@ export class PivotTableEngine {
                 })
             })
         }
-        if (this.doColumnSubtotals) {
+        if (this.doColumnSubtotals && columnSubtotalSize) {
             times(
                 this.dimensionLookup.rows[0].count,
                 n => (n + 1) * columnSubtotalSize - 1
@@ -795,7 +802,12 @@ export class PivotTableEngine {
             })
         }
 
-        if (this.doRowSubtotals && this.doColumnSubtotals) {
+        if (
+            this.doRowSubtotals &&
+            this.doColumnSubtotals &&
+            rowSubtotalSize &&
+            columnSubtotalSize
+        ) {
             times(
                 this.dimensionLookup.rows[0].count,
                 n => (n + 1) * columnSubtotalSize - 1

--- a/src/modules/pivotTable/clipPartitionedAxis.js
+++ b/src/modules/pivotTable/clipPartitionedAxis.js
@@ -10,7 +10,11 @@ export const clipPartitionedAxis = ({
     const partition = Math.floor(viewportPosition / partitionSize)
 
     if (partitions[partition] === undefined) {
-        throw new Error('Failed to clip partitioned axis!')
+        return {
+            indices: [0],
+            pre: 0,
+            post: 0,
+        }
     }
 
     let start = partitions[partition]

--- a/stories/PivotTable.stories.js
+++ b/stories/PivotTable.stories.js
@@ -122,6 +122,11 @@ storiesOf('PivotTable', module).add('simple - no columns', () => {
     const visualization = {
         ...simpleVisualization,
         ...visualizationReset,
+        showDimensionLabels: true,
+        colTotals: true,
+        colSubTotals: true,
+        rowTotals: true,
+        rowSubTotals: true,
         columns: [],
         filters: simpleVisualization.columns
     }
@@ -136,8 +141,13 @@ storiesOf('PivotTable', module).add('simple - no rows', () => {
     const visualization = {
         ...simpleVisualization,
         ...visualizationReset,
+        showDimensionLabels: true,
+        colTotals: true,
+        colSubTotals: true,
+        rowTotals: true,
+        rowSubTotals: true,
         rows: [],
-        columns: simpleVisualization.filters,
+        columns: simpleVisualization.rows,
         filters: simpleVisualization.columns
     }
     return (


### PR DESCRIPTION
This allows table without either a row or column axis to be rendered, and should support visualization type-switching from gauge or single value (specifically on the dashboard)