### PR TITLE
fix: correct calculation of row subtotal column totals

### DIFF
--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -510,11 +510,11 @@ export class PivotTableEngine {
                     1,
                 size: rowSubtotalSize - 1,
             }
-        const rowSubtotalColumnTotal = this.doColumnSubtotals &&
-            this.doRowTotals && {
+        const rowSubtotalColumnTotal = this.doRowSubtotals &&
+            this.doColumnTotals && {
                 row: this.dataHeight - 1,
                 column: rowSubtotal.column,
-                size: this.rawDataWidth,
+                size: this.rawDataHeight,
             }
 
         const columnSubtotalSize = this.dimensionLookup.rows[0]?.size + 1


### PR DESCRIPTION
There was a minor bug in column total calculations which skipped row subtotal columns - this fixes that issue