### PR TITLE
fix: include legendSet in dx dimension lookup result, fix by-dx legends

### DIFF
--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -399,6 +399,7 @@ export class PivotTableEngine {
             return {
                 valueType: cellValue.valueType,
                 totalAggregationType: cellValue.totalAggregationType,
+                legendSet: undefined,
             }
         }
 
@@ -413,6 +414,7 @@ export class PivotTableEngine {
                 valueType: rowHeaders[dxRowIndex].valueType,
                 totalAggregationType:
                     rowHeaders[dxRowIndex].totalAggregationType,
+                legendSet: rowHeaders[dxRowIndex].legendSet,
             }
         }
 
@@ -424,6 +426,7 @@ export class PivotTableEngine {
                 valueType: columnHeaders[dxColumnIndex].valueType,
                 totalAggregationType:
                     columnHeaders[dxColumnIndex].totalAggregationType,
+                legendSet: columnHeaders[dxColumnIndex].legendSet,
             }
         }
 


### PR DESCRIPTION
By-DX legends broke a while back when we switched to explicitly returning the necessary properties when looking up the `dx` dimension for a cell.  This fixes that issue.