### PR TITLE
fix: apply legend to raw value, not percent value

### DIFF
--- a/src/components/PivotTable/PivotTableValueCell.js
+++ b/src/components/PivotTable/PivotTableValueCell.js
@@ -17,8 +17,8 @@ export const PivotTableValueCell = ({ row, column }) => {
         column,
     })
 
-    if (!cellContent) {
-        return <PivotTableEmptyCell />
+    if (!cellContent || cellContent.empty) {
+        return <PivotTableEmptyCell classes={cellContent?.cellType} />
     }
 
     // TODO: Add support for 'INTEGER' type (requires server changes)

--- a/src/components/PivotTable/PivotTableValueCell.js
+++ b/src/components/PivotTable/PivotTableValueCell.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { renderValue } from '../../modules/pivotTable/renderValue'
 import { applyLegendSet } from '../../modules/pivotTable/applyLegendSet'
 import { PivotTableCell } from './PivotTableCell'
 import { usePivotTableEngine } from './PivotTableEngineContext'
@@ -8,31 +7,29 @@ import {
     VALUE_TYPE_NUMBER,
     CELL_TYPE_VALUE,
 } from '../../modules/pivotTable/pivotTableConstants'
+import { PivotTableEmptyCell } from './PivotTableEmptyCell'
 
 export const PivotTableValueCell = ({ row, column }) => {
     const engine = usePivotTableEngine()
 
-    const rawValue = engine.get({
+    const cellContent = engine.get({
         row,
         column,
     })
 
-    const dxDimension = engine.getCellDxDimension({ row, column })
-
-    const value = renderValue(
-        rawValue,
-        dxDimension?.valueType,
-        engine.visualization
-    )
-    const type = engine.getCellType({
-        row,
-        column,
-    })
+    if (!cellContent) {
+        return <PivotTableEmptyCell />
+    }
 
     // TODO: Add support for 'INTEGER' type (requires server changes)
     const legendStyle =
-        type === CELL_TYPE_VALUE && dxDimension?.valueType === VALUE_TYPE_NUMBER
-            ? applyLegendSet(parseFloat(rawValue), dxDimension, engine)
+        cellContent.cellType === CELL_TYPE_VALUE &&
+        cellContent.valueType === VALUE_TYPE_NUMBER
+            ? applyLegendSet(
+                  cellContent.rawValue,
+                  cellContent.dxDimension,
+                  engine
+              )
             : undefined
 
     const width = engine.columnWidths[engine.columnMap[column]].width
@@ -46,11 +43,11 @@ export const PivotTableValueCell = ({ row, column }) => {
     return (
         <PivotTableCell
             key={column}
-            classes={[type, dxDimension?.valueType]}
-            title={value}
+            classes={[cellContent.cellType, cellContent.valueType]}
+            title={cellContent.renderedValue}
             style={style}
         >
-            {value ?? null}
+            {cellContent.renderedValue ?? null}
         </PivotTableCell>
     )
 }

--- a/src/components/PivotTable/styles/PivotTable.style.js
+++ b/src/components/PivotTable/styles/PivotTable.style.js
@@ -83,7 +83,6 @@ export const cell = css`
     }
     .value {
         background-color: #ffffff;
-        cursor: pointer;
     }
     .TEXT {
         text-align: left;

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -744,6 +744,24 @@ export class PivotTableEngine {
             }
         }
     }
+    finalizeTotal({ row, column }) {
+        if (!this.data[row]) {
+            return
+        }
+        const totalCell = this.data[row][column]
+        if (totalCell && totalCell.count) {
+            totalCell.value = applyTotalAggregationType(totalCell)
+            this.addCellForAdaptiveClipping(
+                { row, column },
+                renderValue(
+                    totalCell.value,
+                    totalCell.valueType,
+                    this.visualization
+                )
+            )
+        }
+    }
+
     finalizeTotals() {
         const columnSubtotalSize = this.dimensionLookup.rows[0]?.size + 1
         const rowSubtotalSize = this.dimensionLookup.columns[0]?.size + 1
@@ -761,23 +779,7 @@ export class PivotTableEngine {
                         !this.doColumnSubtotals ||
                         row % this.dimensionLookup.rows[0].count !== 0
                     ) {
-                        if (!this.data[row]) {
-                            return
-                        }
-                        const totalCell = this.data[row][column]
-                        if (totalCell && totalCell.count) {
-                            totalCell.value = applyTotalAggregationType(
-                                totalCell
-                            )
-                            this.addCellForAdaptiveClipping(
-                                { row, column },
-                                renderValue(
-                                    totalCell.value,
-                                    totalCell.valueType,
-                                    this.visualization
-                                )
-                            )
-                        }
+                        this.finalizeTotal({ row, column })
                     }
                 })
             })
@@ -793,23 +795,7 @@ export class PivotTableEngine {
                         !this.doRowSubtotals ||
                         column % this.dimensionLookup.columns[0].count !== 0
                     ) {
-                        if (!this.data[row]) {
-                            return
-                        }
-                        const totalCell = this.data[row][column]
-                        if (totalCell && totalCell.count) {
-                            totalCell.value = applyTotalAggregationType(
-                                totalCell
-                            )
-                            this.addCellForAdaptiveClipping(
-                                { row, column },
-                                renderValue(
-                                    totalCell.value,
-                                    totalCell.valueType,
-                                    this.visualization
-                                )
-                            )
-                        }
+                        this.finalizeTotal({ row, column })
                     }
                 })
             })
@@ -829,60 +815,21 @@ export class PivotTableEngine {
                     this.dimensionLookup.columns[0].count,
                     n => (n + 1) * rowSubtotalSize - 1
                 ).forEach(column => {
-                    if (!this.data[row]) {
-                        return
-                    }
-                    const totalCell = this.data[row][column]
-                    if (totalCell && totalCell.count) {
-                        totalCell.value = applyTotalAggregationType(totalCell)
-                        this.addCellForAdaptiveClipping(
-                            { row, column },
-                            renderValue(
-                                totalCell.value,
-                                totalCell.valueType,
-                                this.visualization
-                            )
-                        )
-                    }
+                    this.finalizeTotal({ row, column })
                 })
             })
         }
         if (this.doRowTotals) {
             const column = this.dataWidth - 1
             times(this.dataHeight, n => n).forEach(row => {
-                if (!this.data[row]) {
-                    return
-                }
-                const totalCell = this.data[row][column]
-                if (totalCell && totalCell.count) {
-                    totalCell.value = applyTotalAggregationType(totalCell)
-                    this.addCellForAdaptiveClipping(
-                        { row, column },
-                        renderValue(
-                            totalCell.value,
-                            totalCell.valueType,
-                            this.visualization
-                        )
-                    )
-                }
+                this.finalizeTotal({ row, column })
             })
         }
 
         if (this.doColumnTotals) {
             const row = this.dataHeight - 1
             times(this.dataWidth, n => n).forEach(column => {
-                const totalCell = this.data[row][column]
-                if (totalCell && totalCell.count) {
-                    totalCell.value = applyTotalAggregationType(totalCell)
-                    this.addCellForAdaptiveClipping(
-                        { row, column },
-                        renderValue(
-                            totalCell.value,
-                            totalCell.valueType,
-                            this.visualization
-                        )
-                    )
-                }
+                this.finalizeTotal({ row, column })
             })
         }
 

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -280,46 +280,49 @@ export class PivotTableEngine {
         const cellType = this.getRawCellType({ row, column })
         const dxDimension = this.getRawCellDxDimension({ row, column })
 
-        if (this.data[row]) {
-            const dataRow = this.data[row][column]
-            if (dataRow) {
-                let rawValue =
-                    cellType === CELL_TYPE_VALUE
-                        ? dataRow[this.dimensionLookup.dataHeaders.value]
-                        : dataRow.value
-                let renderedValue = rawValue
-                const valueType = dxDimension?.valueType || VALUE_TYPE_TEXT
-
-                if (valueType === VALUE_TYPE_NUMBER) {
-                    rawValue = parseValue(rawValue)
-                    switch (this.visualization.numberType) {
-                        case NUMBER_TYPE_ROW_PERCENTAGE:
-                            renderedValue =
-                                rawValue / this.percentageTotals[row].value
-                            break
-                        case NUMBER_TYPE_COLUMN_PERCENTAGE:
-                            renderedValue =
-                                rawValue / this.percentageTotals[column].value
-                            break
-                    }
-                }
-
-                renderedValue = renderValue(
-                    renderedValue,
-                    valueType,
-                    this.visualization
-                )
-
-                return {
-                    cellType,
-                    valueType,
-                    rawValue,
-                    renderedValue,
-                    dxDimension,
-                }
+        if (!this.data[row] || !this.data[row][column]) {
+            return {
+                cellType,
+                empty: true,
             }
         }
-        return undefined
+
+        const dataRow = this.data[row][column]
+
+        let rawValue =
+            cellType === CELL_TYPE_VALUE
+                ? dataRow[this.dimensionLookup.dataHeaders.value]
+                : dataRow.value
+        let renderedValue = rawValue
+        const valueType = dxDimension?.valueType || VALUE_TYPE_TEXT
+
+        if (valueType === VALUE_TYPE_NUMBER) {
+            rawValue = parseValue(rawValue)
+            switch (this.visualization.numberType) {
+                case NUMBER_TYPE_ROW_PERCENTAGE:
+                    renderedValue = rawValue / this.percentageTotals[row].value
+                    break
+                case NUMBER_TYPE_COLUMN_PERCENTAGE:
+                    renderedValue =
+                        rawValue / this.percentageTotals[column].value
+                    break
+            }
+        }
+
+        renderedValue = renderValue(
+            renderedValue,
+            valueType,
+            this.visualization
+        )
+
+        return {
+            cellType,
+            empty: false,
+            valueType,
+            rawValue,
+            renderedValue,
+            dxDimension,
+        }
     }
 
     get({ row, column }) {

--- a/src/modules/pivotTable/pivotTableConstants.js
+++ b/src/modules/pivotTable/pivotTableConstants.js
@@ -9,6 +9,7 @@ export const AGGREGATE_TYPE_SUM = 'SUM'
 export const AGGREGATE_TYPE_AVERAGE = 'AVERAGE'
 export const AGGREGATE_TYPE_NA = 'N/A'
 
+export const VALUE_TYPE_TEXT = 'TEXT'
 export const VALUE_TYPE_NUMBER = 'NUMBER'
 
 export const NUMBER_TYPE_VALUE = 'VALUE'

--- a/stories/PivotTable.stories.js
+++ b/stories/PivotTable.stories.js
@@ -470,6 +470,26 @@ storiesOf('PivotTable', module).add('legend - fixed (text)', () => {
     )
 })
 
+storiesOf('PivotTable', module).add('legend - fixed (% row)', () => {
+    const visualization = {
+        ...targetVisualization,
+        ...visualizationReset,
+        rowSubTotals: true,
+        colSubTotals: true,
+        numberType: NUMBER_TYPE_ROW_PERCENTAGE,
+        legendDisplayStyle: 'FILL',
+        legendSet: {
+            id: underAbove100LegendSet.id
+        },
+    }
+
+    return (
+        <div style={{ width: 800, height: 600 }}>
+            <PivotTable data={targetData} visualization={visualization} legendSets={[underAbove100LegendSet]} />
+        </div>
+    )
+})
+
 storiesOf('PivotTable', module).add('legend - by data item', () => {
     const visualization = {
         ...targetVisualization,
@@ -479,9 +499,7 @@ storiesOf('PivotTable', module).add('legend - by data item', () => {
         legendDisplayStrategy: 'BY_DATA_ITEM',
         legendSet: undefined
     }
-    const data = {
-        ...targetData
-    }
+    const data = cloneDeep(targetData)
 
     const customLegendSet = cloneDeep(underAbove100LegendSet)
     customLegendSet.id = 'TESTID'
@@ -493,7 +511,7 @@ storiesOf('PivotTable', module).add('legend - by data item', () => {
 
     return (
         <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={targetData} visualization={visualization} legendSets={[underAbove100LegendSet, customLegendSet]} />
+            <PivotTable data={data} visualization={visualization} legendSets={[underAbove100LegendSet, customLegendSet]} />
         </div>
     )
 })


### PR DESCRIPTION
When a legend is applied to a pivot table with `numberType` set to either `ROW_PERCENTAGE` or `COLUMN_PERCENTAGE`, the legend should be applied according to the **raw** value, not the **percentage** value.

This also does some cleanup refactoring to de-duplicate and simplify some engine code.

Finally, this removes the `cursor: pointer` style from value cells, since there's no click action (we won't have contextMenu in 2.34.0)