### PR TITLE
fix: support deep-single-axis tables with dimension labels

### DIFF
--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -378,13 +378,18 @@ export class PivotTableEngine {
     }
 
     getDimensionLabel(rowLevel, columnLevel) {
-        const lastRowLevel = this.dimensionLookup.rows.length - 1
-        const lastColumnLevel = this.dimensionLookup.columns.length - 1
+        const lastRowLevel = this.rowDepth - 1
+        const lastColumnLevel = this.columnDepth - 1
 
         if (rowLevel !== lastRowLevel && columnLevel !== lastColumnLevel) {
             return null
         }
-        if (rowLevel === lastRowLevel && columnLevel === lastColumnLevel) {
+        if (
+            rowLevel === lastRowLevel &&
+            this.dimensionLookup.rows[lastRowLevel] &&
+            columnLevel === lastColumnLevel &&
+            this.dimensionLookup.columns[lastColumnLevel]
+        ) {
             return `${this.dimensionLookup.rows[lastRowLevel].meta.name} / ${this.dimensionLookup.columns[lastColumnLevel].meta.name}`
         }
 
@@ -395,10 +400,16 @@ export class PivotTableEngine {
             return this.dimensionLookup.rows[rowLevel].meta.name
         }
 
-        if (rowLevel === lastRowLevel) {
+        if (
+            rowLevel === lastRowLevel &&
+            this.dimensionLookup.columns[columnLevel]
+        ) {
             return this.dimensionLookup.columns[columnLevel].meta.name
         }
-        if (columnLevel === lastColumnLevel) {
+        if (
+            columnLevel === lastColumnLevel &&
+            this.dimensionLookup.rows[rowLevel]
+        ) {
             return this.dimensionLookup.rows[rowLevel].meta.name
         }
     }

--- a/stories/PivotTable.stories.js
+++ b/stories/PivotTable.stories.js
@@ -152,6 +152,23 @@ storiesOf('PivotTable', module).add('simple - no columns (single cell)', () => {
     )
 })
 
+storiesOf('PivotTable', module).add('simple - no columns (deep)', () => {
+    const visualization = {
+        ...simpleVisualization,
+        ...visualizationReset,
+        showDimensionLabels: true,
+        title: 'Deep row headers',
+        columns: [],
+        rows: [simpleVisualization.columns[0], simpleVisualization.rows[0]],
+        filters: []
+    }
+    return (
+        <div style={{ width: 800, height: 600 }}>
+            <PivotTable data={simpleData} visualization={visualization} />
+        </div>
+    )
+})
+
 storiesOf('PivotTable', module).add('simple - no columns (label)', () => {
     const visualization = {
         ...simpleVisualization,


### PR DESCRIPTION
There was a minor bug in single-axis (row) tables with multiple row dimensions and dimension labels displayed.  Fixed here.