### PR TITLE
fix: correctly finalize combined subtotals and totals

### DIFF
--- a/src/components/PivotTable/PivotTableValueCell.js
+++ b/src/components/PivotTable/PivotTableValueCell.js
@@ -18,7 +18,7 @@ export const PivotTableValueCell = ({ row, column }) => {
     })
 
     if (!cellContent || cellContent.empty) {
-        return <PivotTableEmptyCell classes={cellContent?.cellType} />
+        return <PivotTableEmptyCell type={cellContent?.cellType} />
     }
 
     // TODO: Add support for 'INTEGER' type (requires server changes)


### PR DESCRIPTION
There was a bug in the finalization (average and column width calculation) for combined subtotals - this fixes that issue

Before:
<img width="561" alt="Screen Shot 2020-03-12 at 1 39 25 PM" src="https://user-images.githubusercontent.com/947888/76522499-f64e7480-6466-11ea-8861-be994940919b.png">

After:
<img width="573" alt="Screen Shot 2020-03-12 at 1 37 51 PM" src="https://user-images.githubusercontent.com/947888/76522509-fc445580-6466-11ea-9644-d5bccd09099f.png">