### PR TITLE
fix: fix gauge size to avoid clipping (DHIS2-8412)

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/index.js
@@ -88,7 +88,7 @@ export default function({ store, layout, el, extraConfig, extraOptions }) {
         legend: getLegend(_layout, _extraOptions.dashboard),
 
         // pane
-        pane: getPane(_layout.type, _extraOptions),
+        pane: getPane(_layout.type),
 
         // no data
         lang: {

--- a/src/visualizations/config/adapters/dhis_highcharts/pane/gauge.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/pane/gauge.js
@@ -1,10 +1,9 @@
-const DEFAULT_PANE_SIZE = '140%'
-const DASHBOARD_PANE_SIZE = '100%'
+const DEFAULT_PANE_SIZE = '100%'
 
-export default function(dashboard) {
+export default function() {
     return {
         center: ['50%', '85%'],
-        size: dashboard ? DASHBOARD_PANE_SIZE : DEFAULT_PANE_SIZE,
+        size: DEFAULT_PANE_SIZE,
         startAngle: -90,
         endAngle: 90,
         background: {

--- a/src/visualizations/config/adapters/dhis_highcharts/pane/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/pane/index.js
@@ -1,10 +1,10 @@
 import getGauge from './gauge'
 import { VIS_TYPE_GAUGE } from '../../../../../modules/visTypes'
 
-export default function(type, extraOptions) {
+export default function(type) {
     switch (type) {
         case VIS_TYPE_GAUGE:
-            return getGauge(extraOptions.dashboard)
+            return getGauge()
         default:
             return undefined
     }

--- a/src/visualizations/config/adapters/dhis_highcharts/series/gauge.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/gauge.js
@@ -3,8 +3,7 @@ import {
     LEGEND_DISPLAY_STYLE_TEXT,
 } from '../../../../../modules/legends'
 
-const DEFAULT_FONT_SIZE = '60px'
-const DASHBOARD_FONT_SIZE = '28px'
+const DEFAULT_FONT_SIZE = '28px'
 
 export default function(series, dashboard, layout, legendSet) {
     return [
@@ -17,9 +16,7 @@ export default function(series, dashboard, layout, legendSet) {
                 borderWidth: 0,
                 verticalAlign: 'bottom',
                 style: {
-                    fontSize: dashboard
-                        ? DASHBOARD_FONT_SIZE
-                        : DEFAULT_FONT_SIZE,
+                    fontSize: DEFAULT_FONT_SIZE,
                     color:
                         layout.legendDisplayStyle ===
                             LEGEND_DISPLAY_STYLE_TEXT && legendSet

--- a/src/visualizations/config/adapters/dhis_highcharts/series/gauge.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/gauge.js
@@ -5,7 +5,7 @@ import {
 
 const DEFAULT_FONT_SIZE = '28px'
 
-export default function(series, dashboard, layout, legendSet) {
+export default function(series, layout, legendSet) {
     return [
         {
             name: series[0].name,

--- a/src/visualizations/config/adapters/dhis_highcharts/series/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/index.js
@@ -2,7 +2,11 @@ import getCumulativeData from './../getCumulativeData'
 import getPie from './pie'
 import getGauge from './gauge'
 import getType from '../type'
-import { getFullIdAxisMap, getAxisIdsMap, hasOptionalAxis } from '../optionalAxes'
+import {
+    getFullIdAxisMap,
+    getAxisIdsMap,
+    hasOptionalAxis,
+} from '../optionalAxes'
 import { generateColors } from '../../../../util/colors/gradientColorGenerator'
 import {
     VIS_TYPE_PIE,
@@ -132,7 +136,7 @@ export default function(series, store, layout, isStacked, extraOptions) {
             )
             break
         case VIS_TYPE_GAUGE:
-            series = getGauge(series, extraOptions.dashboard, layout, extraOptions.legendSets[0])
+            series = getGauge(series, layout, extraOptions.legendSets[0])
             break
         default:
             series = getDefault(series, layout, isStacked, extraOptions)


### PR DESCRIPTION
Cannot go over 100% as it causes a bad clipping when the container size is smaller than the minimum width of the chart.
Other vis types resize only to a certain point, after that no resize happens.
With 100% size for the pane the same happens.

JIRA: https://jira.dhis2.org/browse/DHIS2-8412

Example of bad clipping.
Before:
<img width="618" alt="Screenshot 2020-03-13 at 14 51 07" src="https://user-images.githubusercontent.com/150978/76631744-7990c880-6542-11ea-8009-9536622414e4.png">

After:
<img width="614" alt="Screenshot 2020-03-13 at 14 52 16" src="https://user-images.githubusercontent.com/150978/76631760-7e557c80-6542-11ea-94d9-5d342da4c1cc.png">
