### PR TITLE
fix: left-align org-unit hierarchies in row headers

### DIFF
--- a/src/components/PivotTable/PivotTableRowHeaderCell.js
+++ b/src/components/PivotTable/PivotTableRowHeaderCell.js
@@ -21,13 +21,14 @@ export const PivotTableRowHeaderCell = ({
             showHierarchy={engine.visualization.showHierarchy}
             render={header => (
                 <PivotTableCell
-                    classes={
+                    classes={[
                         header.label &&
                         header.label !== 'Total' &&
                         header.label !== 'Subtotal'
                             ? 'row-header'
-                            : 'empty-header'
-                    }
+                            : 'empty-header',
+                        header.includesHierarchy && 'row-header-hierarchy',
+                    ]}
                     rowSpan={header.span}
                     title={header.label}
                     style={{ width, maxWidth: width, minWidth: width }}

--- a/src/components/PivotTable/styles/PivotTable.style.js
+++ b/src/components/PivotTable/styles/PivotTable.style.js
@@ -75,6 +75,9 @@ export const cell = css`
     .row-header {
         background-color: #dae6f8;
     }
+    .row-header-hierarchy {
+        text-align: left;
+    }
     .empty-header {
         background-color: #cddaed;
     }

--- a/src/modules/pivotTable/getHeaderForDisplay.js
+++ b/src/modules/pivotTable/getHeaderForDisplay.js
@@ -33,13 +33,15 @@ export const getHeaderForDisplay = ({
 
     const currentHeader = header[dimensionLevel]
 
-    const label =
-        showHierarchy && currentHeader?.hierarchy
-            ? currentHeader.hierarchy.join(' / ')
-            : currentHeader?.name
+    const includesHierarchy = showHierarchy && currentHeader?.hierarchy
+
+    const label = includesHierarchy
+        ? currentHeader.hierarchy.join(' / ')
+        : currentHeader?.name
 
     return {
         span,
         label,
+        includesHierarchy,
     }
 }


### PR DESCRIPTION
This left-aligns the OU hierarchy labels when they appear in the **row axis** - they are still centered when in the column axis.

Before
![Screen Shot 2020-03-16 at 3 57 31 PM](https://user-images.githubusercontent.com/947888/76771007-fe781e00-679e-11ea-97fe-5891e277b728.png)

After
![Screen Shot 2020-03-16 at 3 56 56 PM](https://user-images.githubusercontent.com/947888/76771013-01730e80-679f-11ea-98e3-cf160fae566b.png)
