### PR TITLE
fix: sort data when sorting org unit hierarchy headers (DHIS2-8486)

### DIFF
--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -148,7 +148,11 @@ const buildDimensionLookup = (visualization, metadata, headers) => {
 
     const ouDimension = allByDimension[DIMENSION_ID_ORGUNIT]
 
-    if (metadata.ouNameHierarchy && ouDimension) {
+    if (
+        visualization.showHierarchy &&
+        metadata.ouNameHierarchy &&
+        ouDimension
+    ) {
         ouDimension.items.forEach(ou => {
             const hierarchy = metadata.ouNameHierarchy[ou.uid]
             if (hierarchy) {
@@ -156,6 +160,7 @@ const buildDimensionLookup = (visualization, metadata, headers) => {
             }
         })
         sortByHierarchy(ouDimension.items)
+        ouDimension.itemIds = ouDimension.items.map(item => item.uid)
     }
 
     return {

--- a/stories/PivotTable.stories.js
+++ b/stories/PivotTable.stories.js
@@ -585,6 +585,23 @@ storiesOf('PivotTable', module).add('legend - by data item', () => {
     )
 })
 
+storiesOf('PivotTable', module).add('hierarchy - none', () => {
+    const visualization = {
+        ...hierarchyVisualization,
+        ...visualizationReset,
+        showHierarchy: false,
+        colTotals: true,
+        rowTotals: true,
+        colSubTotals: true,
+        rowSubTotals: true,
+    }
+
+    return (
+        <div style={{ width: 800, height: 600 }}>
+            <PivotTable data={hierarchyData} visualization={visualization} />
+        </div>
+    )
+})
 storiesOf('PivotTable', module).add('hierarchy - rows', () => {
     const visualization = {
         ...hierarchyVisualization,


### PR DESCRIPTION
This fixes a critical issue @janhenrikoverland found in Pivot Tables with the `Show Org Unit Hierarchy` option.  The row or column headers would be sorted alphabetically, but the data would not.

No hierarchy shown (unsorted)
<img width="1552" alt="Screen Shot 2020-03-18 at 11 51 40 AM" src="https://user-images.githubusercontent.com/947888/76953451-ffc85880-690e-11ea-84f4-39cbd92f8fee.png">

Before
<img width="1552" alt="Screen Shot 2020-03-18 at 11 52 20 AM" src="https://user-images.githubusercontent.com/947888/76953459-035bdf80-690f-11ea-9ad1-e43ebd7cbf42.png">

After
<img width="1552" alt="Screen Shot 2020-03-18 at 11 51 35 AM" src="https://user-images.githubusercontent.com/947888/76953437-fb03a480-690e-11ea-9eee-e3d1ffa91722.png">
