### PR TITLE
fix: skip superfluous data rows which don't match table headers (DHIS2-8497)

### DIFF
--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -180,26 +180,35 @@ const lookup = (
     { doColumnSubtotals, doRowSubtotals }
 ) => {
     let row = 0
-    dimensionLookup.rowHeaders.forEach(headerIndex => {
+    for (const headerIndex of dimensionLookup.rowHeaders) {
         const idx = dimensionLookup.headerDimensions[
             headerIndex
         ].itemIds.indexOf(dataRow[headerIndex])
+
+        if (idx === -1) {
+            return undefined
+        }
+
         const size = dimensionLookup.headerDimensions[headerIndex].size
         row += idx * size
-    })
+    }
 
     if (doColumnSubtotals) {
         row += Math.floor(row / dimensionLookup.rows[0].size)
     }
 
     let column = 0
-    dimensionLookup.columnHeaders.forEach(headerIndex => {
+    for (const headerIndex of dimensionLookup.columnHeaders) {
         const idx = dimensionLookup.headerDimensions[
             headerIndex
         ].itemIds.indexOf(dataRow[headerIndex])
+
+        if (idx === -1) {
+            return undefined
+        }
         const size = dimensionLookup.headerDimensions[headerIndex].size
         column += idx * size
-    })
+    }
 
     if (doRowSubtotals) {
         column += Math.floor(column / dimensionLookup.columns[0].size)
@@ -1081,17 +1090,25 @@ export class PivotTableEngine {
 
         this.rawData.rows.forEach(dataRow => {
             const pos = lookup(dataRow, this.dimensionLookup, this)
-            this.data[pos.row] = this.data[pos.row] || []
-            this.data[pos.row][pos.column] = dataRow
 
-            this.addCellValueToTotals(pos, dataRow)
+            if (pos) {
+                this.data[pos.row] = this.data[pos.row] || []
+                this.data[pos.row][pos.column] = dataRow
+
+                this.addCellValueToTotals(pos, dataRow)
+            }
         })
 
         this.finalizeTotals()
 
         this.rawData.rows.forEach(dataRow => {
             const pos = lookup(dataRow, this.dimensionLookup, this)
-            this.addCellForAdaptiveClipping(pos, this.getRaw(pos).renderedValue)
+            if (pos) {
+                this.addCellForAdaptiveClipping(
+                    pos,
+                    this.getRaw(pos).renderedValue
+                )
+            }
         })
 
         this.resetRowMap()

--- a/stories/data/simple.data.json
+++ b/stories/data/simple.data.json
@@ -86,7 +86,7 @@
             ""
         ],
         [
-            "fbfJHSPpUQDx",
+            "testing-extraneous-data",
             "201907",
             "ImspTQPwCqd",
             "22356.0",

--- a/stories/data/simple.data.json
+++ b/stories/data/simple.data.json
@@ -1,1 +1,224 @@
-{"headers":[{"name":"dx","column":"Data","valueType":"TEXT","type":"java.lang.String","hidden":false,"meta":true},{"name":"pe","column":"Period","valueType":"TEXT","type":"java.lang.String","hidden":false,"meta":true},{"name":"ou","column":"Organisation unit","valueType":"TEXT","type":"java.lang.String","hidden":false,"meta":true},{"name":"value","column":"Value","valueType":"NUMBER","type":"java.lang.Double","hidden":false,"meta":false},{"name":"numerator","column":"Numerator","valueType":"NUMBER","type":"java.lang.Double","hidden":false,"meta":false},{"name":"denominator","column":"Denominator","valueType":"NUMBER","type":"java.lang.Double","hidden":false,"meta":false},{"name":"factor","column":"Factor","valueType":"NUMBER","type":"java.lang.Double","hidden":false,"meta":false},{"name":"multiplier","column":"Multiplier","valueType":"NUMBER","type":"java.lang.Double","hidden":false,"meta":false},{"name":"divisor","column":"Divisor","valueType":"NUMBER","type":"java.lang.Double","hidden":false,"meta":false}],"rows":[["fbfJHSPpUQD","201907","ImspTQPwCqd","22356.0","","","","",""],["fbfJHSPpUQD","201905","ImspTQPwCqd","29461.0","","","","",""],["fbfJHSPpUQD","201904","ImspTQPwCqd","18576.0","","","","",""],["fbfJHSPpUQD","201908","ImspTQPwCqd","22004.0","","","","",""],["fbfJHSPpUQD","201912","ImspTQPwCqd","16445.0","","","","",""],["fbfJHSPpUQD","201903","ImspTQPwCqd","21877.0","","","","",""],["fbfJHSPpUQD","201909","ImspTQPwCqd","22308.0","","","","",""],["fbfJHSPpUQD","201902","ImspTQPwCqd","18786.0","","","","",""],["fbfJHSPpUQD","201910","ImspTQPwCqd","17926.0","","","","",""],["fbfJHSPpUQD","201911","ImspTQPwCqd","19691.0","","","","",""],["fbfJHSPpUQD","202001","ImspTQPwCqd","20020.0","","","","",""],["fbfJHSPpUQD","201906","ImspTQPwCqd","23813.0","","","","",""]],"height":12,"width":9,"headerWidth":9}
+{
+    "headers": [
+        {
+            "name": "dx",
+            "column": "Data",
+            "valueType": "TEXT",
+            "type": "java.lang.String",
+            "hidden": false,
+            "meta": true
+        },
+        {
+            "name": "pe",
+            "column": "Period",
+            "valueType": "TEXT",
+            "type": "java.lang.String",
+            "hidden": false,
+            "meta": true
+        },
+        {
+            "name": "ou",
+            "column": "Organisation unit",
+            "valueType": "TEXT",
+            "type": "java.lang.String",
+            "hidden": false,
+            "meta": true
+        },
+        {
+            "name": "value",
+            "column": "Value",
+            "valueType": "NUMBER",
+            "type": "java.lang.Double",
+            "hidden": false,
+            "meta": false
+        },
+        {
+            "name": "numerator",
+            "column": "Numerator",
+            "valueType": "NUMBER",
+            "type": "java.lang.Double",
+            "hidden": false,
+            "meta": false
+        },
+        {
+            "name": "denominator",
+            "column": "Denominator",
+            "valueType": "NUMBER",
+            "type": "java.lang.Double",
+            "hidden": false,
+            "meta": false
+        },
+        {
+            "name": "factor",
+            "column": "Factor",
+            "valueType": "NUMBER",
+            "type": "java.lang.Double",
+            "hidden": false,
+            "meta": false
+        },
+        {
+            "name": "multiplier",
+            "column": "Multiplier",
+            "valueType": "NUMBER",
+            "type": "java.lang.Double",
+            "hidden": false,
+            "meta": false
+        },
+        {
+            "name": "divisor",
+            "column": "Divisor",
+            "valueType": "NUMBER",
+            "type": "java.lang.Double",
+            "hidden": false,
+            "meta": false
+        }
+    ],
+    "rows": [
+        [
+            "fbfJHSPpUQD",
+            "201907",
+            "ImspTQPwCqd",
+            "22356.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "fbfJHSPpUQDx",
+            "201907",
+            "ImspTQPwCqd",
+            "22356.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "fbfJHSPpUQD",
+            "201905",
+            "ImspTQPwCqd",
+            "29461.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "fbfJHSPpUQD",
+            "201904",
+            "ImspTQPwCqd",
+            "18576.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "fbfJHSPpUQD",
+            "201908",
+            "ImspTQPwCqd",
+            "22004.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "fbfJHSPpUQD",
+            "201912",
+            "ImspTQPwCqd",
+            "16445.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "fbfJHSPpUQD",
+            "201903",
+            "ImspTQPwCqd",
+            "21877.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "fbfJHSPpUQD",
+            "201909",
+            "ImspTQPwCqd",
+            "22308.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "fbfJHSPpUQD",
+            "201902",
+            "ImspTQPwCqd",
+            "18786.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "fbfJHSPpUQD",
+            "201910",
+            "ImspTQPwCqd",
+            "17926.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "fbfJHSPpUQD",
+            "201911",
+            "ImspTQPwCqd",
+            "19691.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "fbfJHSPpUQD",
+            "202001",
+            "ImspTQPwCqd",
+            "20020.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ],
+        [
+            "fbfJHSPpUQD",
+            "201906",
+            "ImspTQPwCqd",
+            "23813.0",
+            "",
+            "",
+            "",
+            "",
+            ""
+        ]
+    ],
+    "height": 12,
+    "width": 9,
+    "headerWidth": 9
+}


### PR DESCRIPTION
This fixes a crash which would occur if the server responded with data not matching the row or column headers of the current table.  Thanks @janhenrikoverland for finding the bug, which can be reproduced here - https://debug.dhis2.org/2.34dev/dhis-web-data-visualizer/index.html#/AOphCIgmjeN