### PR TITLE
fix: move d2-i18n to peer dependency [WIP]

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,12 +37,12 @@
         "typeface-roboto": "^0.0.54"
     },
     "peerDependencies": {
+        "@dhis2/d2-i18n": "^1.0.6",
         "prop-types": "^15",
         "react": "^16.3",
         "react-dom": "^16.3"
     },
     "dependencies": {
-        "@dhis2/d2-i18n": "^1.0.4",
         "@dhis2/d2-ui-org-unit-dialog": "^6.5.9",
         "@dhis2/d2-ui-period-selector-dialog": "^6.5.7",
         "@dhis2/ui-core": "^4.16.0",


### PR DESCRIPTION
BREAKING CHANGE: apps that use components having i18n must have d2-i18n as a dependency

Part of fix for https://jira.dhis2.org/browse/DHIS2-8638

WIP:
* discuss: if an app is using the analytics library but not using any components that require d2-i18n, then the app does not actually need d2-i18n
* waiting on d2-ui components to be published