### PR TITLE
chore: move PeriodSelector component to analytics [v2.4.10] [DHIS2-8638]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 # production
 /build
 /dist
+/src/locales
 
 # misc
 .DS_Store

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "dependencies": {
         "@dhis2/d2-i18n": "^1.0.4",
         "@dhis2/d2-ui-org-unit-dialog": "^6.3.0",
-        "@dhis2/d2-ui-period-selector-dialog": "^6.3.0",
         "@dhis2/ui-core": "^3.4.0",
         "@material-ui/core": "^3.9.3",
         "@material-ui/icons": "^3.0.2",

--- a/src/components/PeriodDimension/PeriodDimension.js
+++ b/src/components/PeriodDimension/PeriodDimension.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import uniqBy from 'lodash/uniqBy'
 import DialogTitle from '@material-ui/core/DialogTitle'
 import DialogContent from '@material-ui/core/DialogContent'
-import { PeriodSelector } from '@dhis2/d2-ui-period-selector-dialog'
+import PeriodSelector from '../PeriodSelector/PeriodSelector'
 import i18n from '@dhis2/d2-i18n'
 
 import { DIMENSION_ID_PERIOD } from '../../modules/fixedDimensions'

--- a/src/components/PeriodDimension/__tests__/PeriodDimension.spec.js
+++ b/src/components/PeriodDimension/__tests__/PeriodDimension.spec.js
@@ -2,8 +2,10 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 import { PeriodDimension } from '../PeriodDimension'
 
-jest.mock('@dhis2/d2-ui-period-selector-dialog', () => ({
-    PeriodSelector: 'mockPeriodSelector',
+jest.mock('../../PeriodSelector/PeriodSelector', () => ({
+    __esModule: true,
+    default: 'mockPeriodSelector',
+    namedExport: jest.fn(),
 }))
 
 describe('The Period Dimension component', () => {

--- a/src/components/PeriodSelector/FixedPeriodFilter.js
+++ b/src/components/PeriodSelector/FixedPeriodFilter.js
@@ -1,0 +1,193 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+
+import InputLabel from './InputLabel'
+import Select from '@material-ui/core/Select'
+import MenuItem from '@material-ui/core/MenuItem'
+import Menu from '@material-ui/core/Menu'
+import FormControl from '@material-ui/core/FormControl'
+import ArrowDownIcon from '@material-ui/icons/KeyboardArrowDown'
+import ArrowUpIcon from '@material-ui/icons/KeyboardArrowUp'
+
+import i18n from '@dhis2/d2-i18n'
+import PeriodTypeFilter from './PeriodTypeFilter'
+import FixedPeriodsGenerator from './modules/FixedPeriodsGenerator'
+
+export const defaultState = {
+    periodType: 'Monthly',
+    year: new Date().getFullYear(),
+    yearsOffset: 0,
+    yearSelectElement: null,
+}
+
+export const YEARS_RANGE = 8
+
+class FixedPeriodFilter extends Component {
+    constructor(props) {
+        super(props)
+
+        this.periodsGenerator = new FixedPeriodsGenerator()
+        this.state = defaultState
+    }
+
+    componentDidMount = () => {
+        const periods = this.generatePeriods(
+            this.state.periodType,
+            this.state.year
+        )
+
+        this.props.setOfferedPeriods(periods, true)
+    }
+
+    onPeriodTypeChange = event => {
+        this.setState({
+            periodType: event.target.value,
+        })
+
+        if (this.state.year) {
+            this.props.setOfferedPeriods(
+                this.generatePeriods(event.target.value, this.state.year)
+            )
+        }
+    }
+
+    onYearChange = event => {
+        this.setState({
+            year: event.target.value,
+            yearSelectElement: null,
+        })
+
+        if (this.state.periodType) {
+            this.props.setOfferedPeriods(
+                this.generatePeriods(this.state.periodType, event.target.value)
+            )
+        }
+    }
+
+    onYearSelectClick = event => {
+        this.setState({ yearSelectElement: event.currentTarget })
+    }
+
+    getYears = () => {
+        let years = []
+
+        years = years.concat(
+            [
+                ...Array(
+                    Math.floor(YEARS_RANGE / 2) +
+                        (YEARS_RANGE % 2 === 0 ? 1 : 2)
+                ).keys(),
+            ]
+                .slice(1)
+                .reverse()
+                .map(
+                    offset =>
+                        new Date().getFullYear() -
+                        offset +
+                        this.state.yearsOffset
+                )
+        )
+
+        years = years.concat(
+            [...Array(Math.floor(YEARS_RANGE / 2)).keys()].map(
+                offset =>
+                    new Date().getFullYear() + offset + this.state.yearsOffset
+            )
+        )
+
+        return years
+    }
+
+    generatePeriods = (periodType, year) => {
+        const generator = this.periodsGenerator.get(periodType)
+
+        return generator
+            .generatePeriods({
+                offset: year - new Date().getFullYear(),
+                filterFuturePeriods: false,
+                reversePeriods: false,
+            })
+            .map((period, idx) => ({ ...period, idx }))
+    }
+
+    closeYearSelect = () => {
+        this.setState({ yearSelectElement: null })
+    }
+
+    shiftYearsBack = () => {
+        this.setState({ yearsOffset: this.state.yearsOffset - YEARS_RANGE })
+    }
+
+    shiftYearsForth = () => {
+        this.setState({ yearsOffset: this.state.yearsOffset + YEARS_RANGE })
+    }
+
+    renderYearSelectValue = () => this.state.year
+
+    render() {
+        const years = this.getYears()
+
+        return (
+            <>
+                <PeriodTypeFilter
+                    options={this.periodsGenerator.getOptions()}
+                    value={this.state.periodType}
+                    onChange={this.onPeriodTypeChange}
+                />
+                <FormControl>
+                    <InputLabel label={i18n.t('Year')} />
+                    <Select
+                        SelectDisplayProps={{
+                            style: { cursor: 'pointer', color: '#000000' },
+                            onClick: this.onYearSelectClick,
+                        }}
+                        value={this.state.year}
+                        inputProps={{ name: 'year', id: 'year' }}
+                        renderValue={this.renderYearSelectValue}
+                        disableUnderline
+                        disabled
+                    />
+                    <Menu
+                        MenuListProps={{
+                            style: { width: '130px' },
+                        }}
+                        anchorEl={this.state.yearSelectElement}
+                        open={Boolean(this.state.yearSelectElement)}
+                        onClose={this.closeYearSelect}
+                    >
+                        <MenuItem
+                            value=""
+                            key="shiftYearsBack"
+                            onClick={this.shiftYearsBack}
+                        >
+                            <ArrowUpIcon />
+                        </MenuItem>
+                        {years.map(year => (
+                            <MenuItem
+                                onClick={this.onYearChange}
+                                key={year}
+                                value={year}
+                                selected={this.state.year === year}
+                            >
+                                {year}
+                            </MenuItem>
+                        ))}
+                        <MenuItem
+                            value=""
+                            key="shiftYearsForth"
+                            onClick={this.shiftYearsForth}
+                        >
+                            <ArrowDownIcon />
+                        </MenuItem>
+                    </Menu>
+                </FormControl>
+            </>
+        )
+    }
+}
+
+FixedPeriodFilter.propTypes = {
+    setOfferedPeriods: PropTypes.func.isRequired,
+}
+
+export default FixedPeriodFilter

--- a/src/components/PeriodSelector/InputLabel.js
+++ b/src/components/PeriodSelector/InputLabel.js
@@ -1,0 +1,28 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import MuiLabel from '@material-ui/core/InputLabel'
+import { withStyles } from '@material-ui/core/styles'
+
+const styles = {
+    inputLabel: {
+        color: '#595959',
+        whiteSpace: 'nowrap',
+    },
+}
+
+const InputLabel = ({ classes, label }) => {
+    return (
+        <>
+            <MuiLabel className={classes.inputLabel} htmlFor="period-type">
+                {label}
+            </MuiLabel>
+        </>
+    )
+}
+
+InputLabel.propTypes = {
+    label: PropTypes.string.isRequired,
+    classes: PropTypes.object,
+}
+
+export default withStyles(styles)(InputLabel)

--- a/src/components/PeriodSelector/PeriodSelector.js
+++ b/src/components/PeriodSelector/PeriodSelector.js
@@ -1,0 +1,152 @@
+import React, { Component, Fragment } from 'react'
+import PropTypes from 'prop-types'
+
+import ItemSelector from '../ItemSelector/ItemSelector'
+import PeriodTypeButton from './PeriodTypeButton'
+import FixedPeriodFilter from './FixedPeriodFilter'
+import RelativePeriodFilter from './RelativePeriodFilter'
+import { FIXED, RELATIVE } from './modules/periodTypes'
+
+import styles from './styles/PeriodSelector.style'
+
+class PeriodSelector extends Component {
+    state = {
+        offeredPeriods: [],
+        offeredPeriodsInOrder: [],
+        selectedPeriods: [],
+        periodType: RELATIVE,
+    }
+
+    constructor(props) {
+        super(props)
+
+        this.state.selectedPeriods = this.props.selectedItems
+    }
+
+    onPeriodTypeClick = periodType => {
+        if (this.state.periodType !== periodType) {
+            this.setState({ periodType })
+        }
+    }
+
+    onSelectPeriods = periodIds => {
+        const offeredPeriods = this.state.offeredPeriods.filter(
+            period => !periodIds.includes(period.id)
+        )
+        const newPeriods = this.state.offeredPeriods.filter(period =>
+            periodIds.includes(period.id)
+        )
+        const selectedPeriods = this.state.selectedPeriods.concat(newPeriods)
+
+        this.setState({ selectedPeriods, offeredPeriods })
+        this.props.onSelect(selectedPeriods)
+    }
+
+    setSelectedPeriodOrder = periodIds => {
+        const selectedPeriods = periodIds.map(id =>
+            this.state.selectedPeriods.find(period => period.id === id)
+        )
+
+        this.setState({ selectedPeriods })
+        this.props.onReorder(selectedPeriods)
+    }
+
+    onDeselectPeriods = periodIds => {
+        const selectedPeriods = this.state.selectedPeriods.filter(
+            period => !periodIds.includes(period.id)
+        )
+        const removedPeriods = this.state.selectedPeriods.filter(period =>
+            periodIds.includes(period.id)
+        )
+        const offeredPeriods = this.state.offeredPeriodsInOrder.filter(
+            period => !selectedPeriods.map(p => p.id).includes(period.id)
+        )
+
+        this.setState({ selectedPeriods, offeredPeriods })
+        this.props.onDeselect(removedPeriods)
+    }
+
+    initializeOfferedPeriods = (periods, initial = false) => {
+        const selectedPeriods = initial
+            ? this.props.selectedItems
+            : this.state.selectedPeriods
+        const offeredPeriods = periods.filter(
+            period => !selectedPeriods.map(p => p.id).includes(period.id)
+        )
+
+        this.setState({ offeredPeriodsInOrder: periods, offeredPeriods })
+    }
+
+    renderPeriodTypeButtons = () => (
+        <div>
+            <PeriodTypeButton
+                periodType={RELATIVE}
+                activePeriodType={this.state.periodType}
+                text={'Relative periods'}
+                onClick={this.onPeriodTypeClick}
+            />
+            <PeriodTypeButton
+                periodType={FIXED}
+                activePeriodType={this.state.periodType}
+                text={'Fixed periods'}
+                onClick={this.onPeriodTypeClick}
+            />
+        </div>
+    )
+
+    render = () => {
+        const filterZone = () => {
+            const Filter =
+                this.state.periodType === FIXED
+                    ? FixedPeriodFilter
+                    : RelativePeriodFilter
+
+            return (
+                <div className="options-area">
+                    <Filter setOfferedPeriods={this.initializeOfferedPeriods} />
+                    <style jsx>{styles}</style>
+                </div>
+            )
+        }
+
+        const unselected = {
+            items: this.state.offeredPeriods,
+            onSelect: this.onSelectPeriods,
+            filterText: '',
+        }
+
+        const selected = {
+            items: this.state.selectedPeriods,
+            onDeselect: this.onDeselectPeriods,
+            onReorder: this.setSelectedPeriodOrder,
+        }
+
+        return (
+            <Fragment>
+                {this.renderPeriodTypeButtons()}
+                <div style={{ display: 'flex', marginTop: '18px' }}>
+                    <ItemSelector
+                        itemClassName="period-selector"
+                        unselected={unselected}
+                        selected={selected}
+                    >
+                        {filterZone()}
+                    </ItemSelector>
+                </div>
+            </Fragment>
+        )
+    }
+}
+
+PeriodSelector.propTypes = {
+    onDeselect: PropTypes.func.isRequired,
+    onReorder: PropTypes.func.isRequired,
+    onSelect: PropTypes.func.isRequired,
+    selectedItems: PropTypes.arrayOf(PropTypes.object),
+}
+
+PeriodSelector.defaultProps = {
+    selectedItems: [],
+}
+
+export default PeriodSelector

--- a/src/components/PeriodSelector/PeriodTypeButton.js
+++ b/src/components/PeriodSelector/PeriodTypeButton.js
@@ -1,0 +1,36 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+import i18n from '@dhis2/d2-i18n'
+
+import styles from './styles/PeriodTypeButton.style'
+
+class PeriodTypeButton extends Component {
+    handleClick = () => {
+        this.props.onClick(this.props.periodType)
+    }
+
+    render = () => (
+        <>
+            <button
+                className={`nav-button ${
+                    this.props.periodType === this.props.activePeriodType
+                        ? 'active'
+                        : ''
+                }`}
+                onClick={this.handleClick}
+            >
+                {i18n.t(this.props.text)}
+            </button>
+            <style jsx>{styles}</style>
+        </>
+    )
+}
+
+PeriodTypeButton.propTypes = {
+    activePeriodType: PropTypes.string.isRequired,
+    periodType: PropTypes.string.isRequired,
+    text: PropTypes.string.isRequired,
+    onClick: PropTypes.func.isRequired,
+}
+
+export default PeriodTypeButton

--- a/src/components/PeriodSelector/PeriodTypeFilter.js
+++ b/src/components/PeriodSelector/PeriodTypeFilter.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import FormControl from '@material-ui/core/FormControl'
+import Select from '@material-ui/core/Select'
+import MenuItem from '@material-ui/core/MenuItem'
+import i18n from '@dhis2/d2-i18n'
+import InputLabel from './InputLabel'
+
+const PeriodTypeFilter = ({ options, onChange, value }) => {
+    return (
+        <FormControl>
+            <InputLabel label={i18n.t('Period type')} />
+            <Select
+                onChange={onChange}
+                value={value}
+                inputProps={{ name: 'periodType', id: 'period-type' }}
+                disableUnderline
+            >
+                {options.map(option => (
+                    <MenuItem value={option} key={option}>
+                        {option}
+                    </MenuItem>
+                ))}
+            </Select>
+        </FormControl>
+    )
+}
+
+PeriodTypeFilter.propTypes = {
+    options: PropTypes.array.isRequired,
+    value: PropTypes.string,
+    onChange: PropTypes.func,
+}
+
+export default PeriodTypeFilter

--- a/src/components/PeriodSelector/RelativePeriodFilter.js
+++ b/src/components/PeriodSelector/RelativePeriodFilter.js
@@ -1,0 +1,55 @@
+import React, { Component } from 'react'
+import PropTypes from 'prop-types'
+
+import PeriodTypeFilter from './PeriodTypeFilter'
+import RelativePeriodsGenerator from './modules/RelativePeriodsGenerator'
+
+export const defaultState = {
+    periodType: 'Months',
+}
+
+class RelativePeriods extends Component {
+    constructor(props) {
+        super(props)
+
+        this.state = defaultState
+        this.periodsGenerator = new RelativePeriodsGenerator()
+    }
+
+    componentDidMount = () => {
+        const periods = this.generatePeriods(this.state.periodType)
+        this.props.setOfferedPeriods(periods, true)
+    }
+
+    onPeriodTypeChange = event => {
+        this.setState({
+            periodType: event.target.value,
+        })
+
+        this.props.setOfferedPeriods(this.generatePeriods(event.target.value))
+    }
+
+    generatePeriods = periodType => {
+        const generator = this.periodsGenerator.get(periodType)
+
+        return generator
+            .generatePeriods()
+            .map((period, idx) => ({ ...period, idx }))
+    }
+
+    render = () => {
+        return (
+            <PeriodTypeFilter
+                options={this.periodsGenerator.getOptions()}
+                value={this.state.periodType}
+                onChange={this.onPeriodTypeChange}
+            />
+        )
+    }
+}
+
+RelativePeriods.propTypes = {
+    setOfferedPeriods: PropTypes.func.isRequired,
+}
+
+export default RelativePeriods

--- a/src/components/PeriodSelector/modules/FixedPeriodsGenerator.js
+++ b/src/components/PeriodSelector/modules/FixedPeriodsGenerator.js
@@ -1,0 +1,586 @@
+// generatePeriods config object: { boolean offset, boolean filterFuturePeriods, boolean reversePeriods }
+
+function DailyPeriodType(formatYyyyMmDd, fnFilter) {
+    this.generatePeriods = config => {
+        let periods = []
+        const offset = parseInt(config.offset, 10)
+        const isFilter = config.filterFuturePeriods
+        const isReverse = config.reversePeriods
+        const year = new Date(Date.now()).getFullYear() + offset
+        const date = new Date(`01 Jan ${year}`)
+
+        while (date.getFullYear() === year) {
+            const period = {}
+            period.startDate = formatYyyyMmDd(date)
+            period.endDate = period.startDate
+            period.name = period.startDate
+            // period['id'] = 'Daily_' + period['startDate'];
+            period.iso = period.startDate.replace(/-/g, '')
+            period.id = period.iso
+            periods.push(period)
+            date.setDate(date.getDate() + 1)
+        }
+
+        periods = isFilter ? fnFilter(periods) : periods
+        periods = isReverse ? periods.reverse() : periods
+
+        return periods
+    }
+}
+
+function WeeklyPeriodType(formatYyyyMmDd, weekObj, fnFilter) {
+    // Calculate the first date of an EPI year base on ISO standard  ( first week always contains 4th Jan )
+    const getEpiWeekStartDay = (year, startDayOfWeek) => {
+        const jan4 = new Date(year, 0, 4)
+        const jan4DayOfWeek = jan4.getDay()
+        const startDate = jan4
+        const dayDiff = jan4DayOfWeek - startDayOfWeek
+
+        if (dayDiff > 0) {
+            startDate.setDate(jan4.getDate() - dayDiff)
+        } else if (dayDiff < 0) {
+            startDate.setDate(jan4.getDate() - dayDiff)
+            startDate.setDate(startDate.getDate() - 7)
+        }
+
+        return startDate
+    }
+
+    this.generatePeriods = config => {
+        let periods = []
+        const offset = parseInt(config.offset, 10)
+        const isFilter = config.filterFuturePeriods
+        const isReverse = config.reversePeriods
+        const year = new Date(Date.now()).getFullYear() + offset
+        const date = getEpiWeekStartDay(year, weekObj.startDay)
+        let week = 1
+
+        while (date.getFullYear() <= year) {
+            const period = {}
+            period.startDate = formatYyyyMmDd(date)
+            period.iso = `${year}${weekObj.shortName}W${week}`
+            period.id = period.iso
+            date.setDate(date.getDate() + 6)
+            period.endDate = formatYyyyMmDd(date)
+            period.name = `Week ${week} - ${period.startDate} - ${period.endDate}`
+
+            // if end date is Jan 4th or later, week belongs to next year
+            if (date.getFullYear() > year && date.getDate() >= 4) {
+                break
+            }
+
+            periods.push(period)
+            date.setDate(date.getDate() + 1)
+
+            week += 1
+        }
+
+        periods = isFilter ? fnFilter(periods) : periods
+        periods = isReverse ? periods.reverse() : periods
+
+        return periods
+    }
+}
+
+function BiWeeklyPeriodType(formatYyyyMmDd, fnFilter) {
+    this.generatePeriods = config => {
+        let periods = []
+        const offset = parseInt(config.offset, 10)
+        const isFilter = config.filterFuturePeriods
+        const isReverse = config.reversePeriods
+        const year = new Date(Date.now()).getFullYear() + offset
+        const date = new Date(`01 Jan ${year}`)
+        const day = date.getDay()
+        let biWeek = 1
+
+        if (day <= 4) {
+            date.setDate(date.getDate() - (day - 1))
+        } else {
+            date.setDate(date.getDate() + (8 - day))
+        }
+
+        while (date.getFullYear() <= year) {
+            const period = {}
+
+            period.iso = `${year}BiW${biWeek}`
+            period.id = period.iso
+            period.startDate = formatYyyyMmDd(date)
+            date.setDate(date.getDate() + 13)
+
+            period.endDate = formatYyyyMmDd(date)
+            period.name = `Bi-Week ${biWeek} - ${period.startDate} - ${period.endDate}`
+
+            // if end date is Jan 4th or later, biweek belongs to next year
+            if (date.getFullYear() > year && date.getDate() >= 4) {
+                break
+            }
+
+            periods.push(period)
+
+            date.setDate(date.getDate() + 1)
+
+            biWeek += 1
+        }
+
+        periods = isFilter ? fnFilter(periods) : periods
+        periods = isReverse ? periods.reverse() : periods
+
+        return periods
+    }
+}
+
+function MonthlyPeriodType(formatYyyyMmDd, monthNames, fnFilter) {
+    const formatIso = date => {
+        const y = date.getFullYear()
+        let m = String(date.getMonth() + 1)
+
+        m = m.length < 2 ? `0${m}` : m
+
+        return y + m
+    }
+
+    this.generatePeriods = config => {
+        let periods = []
+
+        const offset = parseInt(config.offset, 10)
+        const isFilter = config.filterFuturePeriods
+        const isReverse = config.reversePeriods
+        const year = new Date(Date.now()).getFullYear() + offset
+        const date = new Date(`31 Dec ${year}`)
+
+        while (date.getFullYear() === year) {
+            const period = {}
+
+            period.endDate = formatYyyyMmDd(date)
+            date.setDate(1)
+            period.startDate = formatYyyyMmDd(date)
+            period.name = `${monthNames[date.getMonth()]} ${date.getFullYear()}`
+            period.iso = formatIso(date)
+            period.id = period.iso
+            periods.push(period)
+            date.setDate(0)
+        }
+
+        periods = isFilter ? fnFilter(periods) : periods
+        periods = isReverse ? periods : periods.reverse()
+        // Months are collected backwards. If isReverse is true, then do nothing. Else reverse to correct order and return.
+
+        return periods
+    }
+}
+
+function BiMonthlyPeriodType(formatYyyyMmDd, monthNames, fnFilter) {
+    this.generatePeriods = config => {
+        let periods = []
+        const offset = parseInt(config.offset, 10)
+        const isFilter = config.filterFuturePeriods
+        const isReverse = config.reversePeriods
+        const year = new Date(Date.now()).getFullYear() + offset
+        const date = new Date(`31 Dec ${year}`)
+        let index = 6
+
+        while (date.getFullYear() === year) {
+            const period = {}
+
+            period.endDate = formatYyyyMmDd(date)
+            date.setDate(0)
+            date.setDate(1)
+            period.startDate = formatYyyyMmDd(date)
+            period.name = `${monthNames[date.getMonth()]} - ${
+                monthNames[date.getMonth() + 1]
+            } ${date.getFullYear()}`
+            period.iso = `${year}0${index}B`
+            period.id = period.iso
+            periods.push(period)
+            date.setDate(0)
+
+            index--
+        }
+
+        periods = isFilter ? fnFilter(periods) : periods
+        periods = isReverse ? periods : periods.reverse()
+        // Bi-months are collected backwards. If isReverse is true, then do nothing. Else reverse to correct order and return.
+
+        return periods
+    }
+}
+
+function QuarterlyPeriodType(formatYyyyMmDd, monthNames, fnFilter) {
+    this.generatePeriods = config => {
+        let periods = []
+        const offset = parseInt(config.offset, 10)
+        const isFilter = config.filterFuturePeriods
+        const isReverse = config.reversePeriods
+        const year = new Date(Date.now()).getFullYear() + offset
+        const date = new Date(`31 Dec ${year}`)
+        let quarter = 4
+
+        while (date.getFullYear() === year) {
+            const period = {}
+            period.endDate = formatYyyyMmDd(date)
+            date.setDate(0)
+            date.setDate(0)
+            date.setDate(1)
+            period.startDate = formatYyyyMmDd(date)
+            period.name = `${monthNames[date.getMonth()]} - ${
+                monthNames[date.getMonth() + 2]
+            } ${date.getFullYear()}`
+            period.iso = `${year}Q${quarter}`
+            period.id = period.iso
+            periods.push(period)
+            date.setDate(0)
+            quarter -= 1
+        }
+
+        periods = isFilter ? fnFilter(periods) : periods
+        periods = isReverse ? periods : periods.reverse()
+        // Quarters are collected backwards. If isReverse is true, then do nothing. Else reverse to correct order and return.
+
+        return periods
+    }
+}
+
+function SixMonthlyPeriodType(monthNames, fnFilter) {
+    this.generatePeriods = config => {
+        let periods = []
+        const offset = parseInt(config.offset, 10)
+        const isFilter = config.filterFuturePeriods
+        const isReverse = config.reversePeriods
+        const year = new Date(Date.now()).getFullYear() + offset
+
+        let period = {}
+        period.startDate = `${year}-01-01`
+        period.endDate = `${year}-06-30`
+        period.name = `${monthNames[0]} - ${monthNames[5]} ${year}`
+        period.iso = `${year}S1`
+        period.id = period.iso
+        periods.push(period)
+
+        period = {}
+        period.startDate = `${year}-07-01`
+        period.endDate = `${year}-12-31`
+        period.name = `${monthNames[6]} - ${monthNames[11]} ${year}`
+        period.iso = `${year}S2`
+        period.id = period.iso
+        periods.push(period)
+
+        periods = isFilter ? fnFilter(periods) : periods
+        periods = isReverse ? periods.reverse() : periods
+
+        return periods
+    }
+}
+
+function SixMonthlyAprilPeriodType(monthNames, fnFilter) {
+    this.generatePeriods = config => {
+        let periods = []
+        const offset = parseInt(config.offset, 10)
+        const isFilter = config.filterFuturePeriods
+        const isReverse = config.reversePeriods
+        const year = new Date(Date.now()).getFullYear() + offset
+
+        let period = {}
+        period.startDate = `${year}-04-01`
+        period.endDate = `${year}-09-30`
+        period.name = `${monthNames[3]} - ${monthNames[8]} ${year}`
+        period.iso = `${year}AprilS1`
+        period.id = period.iso
+        periods.push(period)
+
+        period = {}
+        period.startDate = `${year}-10-01`
+        period.endDate = `${year + 1}-03-31`
+        period.name = `${monthNames[9]} ${year} - ${monthNames[2]} ${year + 1}`
+        period.iso = `${year}AprilS2`
+        period.id = period.iso
+        periods.push(period)
+
+        periods = isFilter ? fnFilter(periods) : periods
+        periods = isReverse ? periods.reverse() : periods
+
+        return periods
+    }
+}
+
+function YearlyPeriodType(formatYyyyMmDd, fnFilter) {
+    this.generatePeriods = config => {
+        let periods = []
+        const offset = parseInt(config.offset, 10)
+        const isFilter = config.filterFuturePeriods
+        const isReverse = config.reversePeriods
+        const year = new Date(Date.now()).getFullYear() + offset
+        const date = new Date(`31 Dec ${year}`)
+
+        while (year - date.getFullYear() < 10) {
+            const period = {}
+            period.endDate = formatYyyyMmDd(date)
+            date.setMonth(0, 1)
+            period.startDate = formatYyyyMmDd(date)
+            period.name = date.getFullYear().toString()
+            period.iso = date.getFullYear().toString()
+            period.id = period.iso.toString()
+            periods.push(period)
+            date.setDate(0)
+        }
+
+        periods = isFilter ? fnFilter(periods) : periods
+        periods = isReverse ? periods : periods.reverse()
+        // Years are collected backwards. If isReverse is true, then do nothing. Else reverse to correct order and return.
+
+        return periods
+    }
+}
+
+function FinancialOctoberPeriodType(formatYyyyMmDd, monthNames, fnFilter) {
+    this.generatePeriods = config => {
+        let periods = []
+        const offset = parseInt(config.offset, 10)
+        const isFilter = config.filterFuturePeriods
+        const isReverse = config.reversePeriods
+        const year = new Date(Date.now()).getFullYear() + offset
+        const date = new Date(`30 Sep ${year + 1}`)
+
+        for (let i = 0; i < 10; i++) {
+            const period = {}
+            period.endDate = formatYyyyMmDd(date)
+            date.setYear(date.getFullYear() - 1)
+            date.setDate(date.getDate() + 1)
+            period.startDate = formatYyyyMmDd(date)
+            period.name = `${monthNames[9]} ${date.getFullYear()} - ${
+                monthNames[8]
+            } ${date.getFullYear() + 1}`
+            period.id = `${date.getFullYear()}Oct`
+            periods.push(period)
+            date.setDate(date.getDate() - 1)
+        }
+
+        periods = isFilter ? fnFilter(periods) : periods
+        periods = isReverse ? periods : periods.reverse()
+        // FinancialOctober periods are collected backwards. If isReverse is true, then do nothing. Else reverse to correct order and return.
+
+        return periods
+    }
+}
+
+function FinancialNovemberPeriodType(formatYyyyMmDd, monthNames, fnFilter) {
+    this.generatePeriods = config => {
+        let periods = []
+        const offset = parseInt(config.offset, 10)
+        const isFilter = config.filterFuturePeriods
+        const isReverse = config.reversePeriods
+        const year = new Date(Date.now()).getFullYear() + offset
+        const date = new Date(`31 Oct ${year + 1}`)
+
+        for (let i = 0; i < 10; i++) {
+            const period = {}
+            period.endDate = formatYyyyMmDd(date)
+            date.setYear(date.getFullYear() - 1)
+            date.setDate(date.getDate() + 1)
+            period.startDate = formatYyyyMmDd(date)
+            period.name = `${monthNames[10]} ${date.getFullYear()} - ${
+                monthNames[9]
+            } ${date.getFullYear() + 1}`
+            period.id = `${date.getFullYear()}Nov`
+            periods.push(period)
+            date.setDate(date.getDate() - 1)
+        }
+
+        periods = isFilter ? fnFilter(periods) : periods
+        periods = isReverse ? periods : periods.reverse()
+        // FinancialNovember periods are collected backwards. If isReverse is true, then do nothing. Else reverse to correct order and return.
+
+        return periods
+    }
+}
+
+function FinancialJulyPeriodType(formatYyyyMmDd, monthNames, fnFilter) {
+    this.generatePeriods = config => {
+        let periods = []
+        const offset = parseInt(config.offset, 10)
+        const isFilter = config.filterFuturePeriods
+        const isReverse = config.reversePeriods
+        const year = new Date(Date.now()).getFullYear() + offset
+        const date = new Date(`30 Jun ${year + 1}`)
+
+        for (let i = 0; i < 10; i++) {
+            const period = {}
+            period.endDate = formatYyyyMmDd(date)
+            date.setYear(date.getFullYear() - 1)
+            date.setDate(date.getDate() + 1)
+            period.startDate = formatYyyyMmDd(date)
+            period.name = `${monthNames[6]} ${date.getFullYear()} - ${
+                monthNames[5]
+            } ${date.getFullYear() + 1}`
+            period.id = `${date.getFullYear()}July`
+            periods.push(period)
+            date.setDate(date.getDate() - 1)
+        }
+
+        periods = isFilter ? fnFilter(periods) : periods
+        periods = isReverse ? periods : periods.reverse()
+        // FinancialJuly periods are collected backwards. If isReverse is true, then do nothing. Else reverse to correct order and return.
+
+        return periods
+    }
+}
+
+function FinancialAprilPeriodType(formatYyyyMmDd, monthNames, fnFilter) {
+    this.generatePeriods = config => {
+        let periods = []
+        const offset = parseInt(config.offset, 10)
+        const isFilter = config.filterFuturePeriods
+        const isReverse = config.reversePeriods
+        const year = new Date(Date.now()).getFullYear() + offset
+        const date = new Date(`31 Mar ${year + 1}`)
+
+        for (let i = 0; i < 10; i++) {
+            const period = {}
+            period.endDate = formatYyyyMmDd(date)
+            date.setYear(date.getFullYear() - 1)
+            date.setDate(date.getDate() + 1)
+            period.startDate = formatYyyyMmDd(date)
+            period.name = `${monthNames[3]} ${date.getFullYear()} - ${
+                monthNames[2]
+            } ${date.getFullYear() + 1}`
+            period.id = `${date.getFullYear()}April`
+            periods.push(period)
+            date.setDate(date.getDate() - 1)
+        }
+
+        periods = isFilter ? fnFilter(periods) : periods
+        periods = isReverse ? periods : periods.reverse()
+        // FinancialApril periods are collected backwards. If isReverse is true, then do nothing. Else reverse to correct order and return.
+
+        return periods
+    }
+}
+
+function PeriodType() {
+    const monthNames = [
+        'January',
+        'February',
+        'March',
+        'April',
+        'May',
+        'June',
+        'July',
+        'August',
+        'September',
+        'October',
+        'November',
+        'December',
+    ]
+
+    const formatYyyyMmDd = date => {
+        const y = date.getFullYear()
+        let m = String(date.getMonth() + 1)
+        let d = String(date.getDate())
+
+        m = m.length < 2 ? `0${m}` : m
+        d = d.length < 2 ? `0${d}` : d
+
+        return `${y}-${m}-${d}`
+    }
+
+    const filterFuturePeriods = periods => {
+        const array = []
+        const now = new Date(Date.now())
+
+        for (let i = 0; i < periods.length; i++) {
+            if (new Date(periods[i].startDate) <= now) {
+                array.push(periods[i])
+            }
+        }
+
+        return array
+    }
+
+    const periodTypes = []
+
+    periodTypes.Daily = new DailyPeriodType(formatYyyyMmDd, filterFuturePeriods)
+    periodTypes.Weekly = new WeeklyPeriodType(
+        formatYyyyMmDd,
+        { shortName: '', startDay: 1 },
+        filterFuturePeriods
+    )
+    periodTypes['Bi-weekly'] = new BiWeeklyPeriodType(
+        formatYyyyMmDd,
+        filterFuturePeriods
+    )
+    periodTypes['Weekly (Start Wednesday)'] = new WeeklyPeriodType(
+        formatYyyyMmDd,
+        { shortName: 'Wed', startDay: 3 },
+        filterFuturePeriods
+    )
+    periodTypes['Weekly (Start Thursday)'] = new WeeklyPeriodType(
+        formatYyyyMmDd,
+        { shortName: 'Thu', startDay: 4 },
+        filterFuturePeriods
+    )
+    periodTypes['Weekly (Start Saturday)'] = new WeeklyPeriodType(
+        formatYyyyMmDd,
+        { shortName: 'Sat', startDay: 6 },
+        filterFuturePeriods
+    )
+    periodTypes['Weekly (Start Sunday)'] = new WeeklyPeriodType(
+        formatYyyyMmDd,
+        { shortName: 'Sun', startDay: 7 },
+        filterFuturePeriods
+    )
+    periodTypes.Monthly = new MonthlyPeriodType(
+        formatYyyyMmDd,
+        monthNames,
+        filterFuturePeriods
+    )
+    periodTypes['Bi-monthly'] = new BiMonthlyPeriodType(
+        formatYyyyMmDd,
+        monthNames,
+        filterFuturePeriods
+    )
+    periodTypes.Quarterly = new QuarterlyPeriodType(
+        formatYyyyMmDd,
+        monthNames,
+        filterFuturePeriods
+    )
+    periodTypes['Six-monthly'] = new SixMonthlyPeriodType(
+        monthNames,
+        filterFuturePeriods
+    )
+    periodTypes['Six-monthly April'] = new SixMonthlyAprilPeriodType(
+        monthNames,
+        filterFuturePeriods
+    )
+    periodTypes.Yearly = new YearlyPeriodType(
+        formatYyyyMmDd,
+        filterFuturePeriods
+    )
+    periodTypes[
+        'Financial year (Start November)'
+    ] = new FinancialNovemberPeriodType(
+        formatYyyyMmDd,
+        monthNames,
+        filterFuturePeriods
+    )
+    periodTypes[
+        'Financial year (Start October)'
+    ] = new FinancialOctoberPeriodType(
+        formatYyyyMmDd,
+        monthNames,
+        filterFuturePeriods
+    )
+    periodTypes['Financial year (Start July)'] = new FinancialJulyPeriodType(
+        formatYyyyMmDd,
+        monthNames,
+        filterFuturePeriods
+    )
+    periodTypes['Financial year (Start April)'] = new FinancialAprilPeriodType(
+        formatYyyyMmDd,
+        monthNames,
+        filterFuturePeriods
+    )
+
+    this.get = key => periodTypes[key]
+    this.getOptions = () => Object.keys(periodTypes)
+}
+
+export default PeriodType

--- a/src/components/PeriodSelector/modules/RelativePeriodsGenerator.js
+++ b/src/components/PeriodSelector/modules/RelativePeriodsGenerator.js
@@ -1,0 +1,117 @@
+const DaysPeriodType = {
+    generatePeriods() {
+        return [
+            { id: 'TODAY', name: 'Today' },
+            { id: 'YESTERDAY', name: 'Yesterday' },
+            { id: 'LAST_3_DAYS', name: 'Last 3 days' },
+            { id: 'LAST_7_DAYS', name: 'Last 7 days' },
+            { id: 'LAST_14_DAYS', name: 'Last 14 days' },
+        ]
+    },
+}
+
+const WeeksPeriodType = {
+    generatePeriods() {
+        return [
+            { id: 'THIS_WEEK', name: 'This week' },
+            { id: 'LAST_WEEK', name: 'Last week' },
+            { id: 'LAST_4_WEEKS', name: 'Last 4 weeks' },
+            { id: 'LAST_12_WEEKS', name: 'Last 12 weeks' },
+            { id: 'LAST_52_WEEKS', name: 'Last 52 weeks' },
+            { id: 'WEEKS_THIS_YEAR', name: 'Weeks this year' },
+        ]
+    },
+}
+
+const BiWeeksPeriodType = {
+    generatePeriods() {
+        return [
+            { id: 'THIS_BIWEEK', name: 'This bi-week' },
+            { id: 'LAST_BIWEEK', name: 'Last bi-week' },
+            { id: 'LAST_4_BIWEEKS', name: 'Last 4 bi-weeks' },
+        ]
+    },
+}
+
+const MonthsPeriodType = {
+    generatePeriods() {
+        return [
+            { id: 'THIS_MONTH', name: 'This month' },
+            { id: 'LAST_MONTH', name: 'Last month' },
+            { id: 'LAST_3_MONTHS', name: 'Last 3 months' },
+            { id: 'LAST_6_MONTHS', name: 'Last 6 months' },
+            { id: 'LAST_12_MONTHS', name: 'Last 12 months' },
+            { id: 'MONTHS_THIS_YEAR', name: 'Months this year' },
+        ]
+    },
+}
+
+const BiMonthsPeriodType = {
+    generatePeriods() {
+        return [
+            { id: 'THIS_BIMONTH', name: 'This bi-month' },
+            { id: 'LAST_BIMONTH', name: 'Last bi-month' },
+            { id: 'LAST_6_BIMONTHS', name: 'Last 6 bi-months' },
+            { id: 'BIMONTHS_THIS_YEAR', name: 'Bi-months this year' },
+        ]
+    },
+}
+
+const QuartersPeriodType = {
+    generatePeriods() {
+        return [
+            { id: 'THIS_QUARTER', name: 'This quarter' },
+            { id: 'LAST_QUARTER', name: 'Last quarter' },
+            { id: 'LAST_4_QUARTERS', name: 'Last 4 quarters' },
+            { id: 'QUARTERS_THIS_YEAR', name: 'Quarters this year' },
+        ]
+    },
+}
+
+const SixMonthsPeriodType = {
+    generatePeriods() {
+        return [
+            { id: 'THIS_SIX_MONTH', name: 'This six-month' },
+            { id: 'LAST_SIX_MONTH', name: 'Last six-month' },
+            { id: 'LAST_2_SIXMONTHS', name: 'Last 2 six-month' },
+        ]
+    },
+}
+
+const FinancialYearsPeriodType = {
+    generatePeriods() {
+        return [
+            { id: 'THIS_FINANCIAL_YEAR', name: 'This financial year' },
+            { id: 'LAST_FINANCIAL_YEAR', name: 'Last financial year' },
+            { id: 'LAST_5_FINANCIAL_YEARS', name: 'Last 5 financial years' },
+        ]
+    },
+}
+
+const YearsPeriodType = {
+    generatePeriods() {
+        return [
+            { id: 'THIS_YEAR', name: 'This year' },
+            { id: 'LAST_YEAR', name: 'Last year' },
+            { id: 'LAST_5_YEARS', name: 'Last 5 years' },
+        ]
+    },
+}
+
+export default class Generator {
+    options = {
+        Days: DaysPeriodType,
+        Weeks: WeeksPeriodType,
+        'Bi-weeks': BiWeeksPeriodType,
+        Months: MonthsPeriodType,
+        'Bi-months': BiMonthsPeriodType,
+        Quarters: QuartersPeriodType,
+        'Six-months': SixMonthsPeriodType,
+        'Financial Years': FinancialYearsPeriodType,
+        Years: YearsPeriodType,
+    }
+
+    get = key => this.options[key]
+
+    getOptions = () => Object.keys(this.options)
+}

--- a/src/components/PeriodSelector/modules/__tests__/FixedPeriodsGenerator.spec.js
+++ b/src/components/PeriodSelector/modules/__tests__/FixedPeriodsGenerator.spec.js
@@ -1,0 +1,650 @@
+import FixedPeriodsGenerator from '../FixedPeriodsGenerator'
+
+describe('FixedPeriodsGenerator class', () => {
+    const periodsGenerator = new FixedPeriodsGenerator()
+
+    beforeAll(() =>
+        // 2019-06-17
+        jest.spyOn(Date, 'now').mockImplementation(() => 1560765600000)
+    )
+
+    describe('getOptions', () => {
+        it('should return a list of available period ranges', () => {
+            const periods = periodsGenerator.getOptions()
+
+            expect(periods).toEqual([
+                'Daily',
+                'Weekly',
+                'Bi-weekly',
+                'Weekly (Start Wednesday)',
+                'Weekly (Start Thursday)',
+                'Weekly (Start Saturday)',
+                'Weekly (Start Sunday)',
+                'Monthly',
+                'Bi-monthly',
+                'Quarterly',
+                'Six-monthly',
+                'Six-monthly April',
+                'Yearly',
+                'Financial year (Start November)',
+                'Financial year (Start October)',
+                'Financial year (Start July)',
+                'Financial year (Start April)',
+            ])
+        })
+    })
+
+    describe('Daily period generator', () => {
+        let periods
+
+        beforeAll(() => {
+            const generator = periodsGenerator.get('Daily')
+
+            periods = generator.generatePeriods({
+                offset: 2019 - new Date(Date.now()).getFullYear(),
+                filterFuturePeriods: false,
+                reversePeriods: false,
+            })
+        })
+
+        it('should return the correct number of days in 2019', () => {
+            expect(periods.length).toEqual(365)
+        })
+
+        it('should return the correct object for 1 jan 2019 day', () => {
+            expect(periods[0]).toEqual({
+                startDate: '2019-01-01',
+                endDate: '2019-01-01',
+                name: '2019-01-01',
+                iso: '20190101',
+                id: '20190101',
+            })
+        })
+
+        it('should return the correct object for 31 dec 2019 day', () => {
+            expect(periods[364]).toEqual({
+                startDate: '2019-12-31',
+                endDate: '2019-12-31',
+                name: '2019-12-31',
+                iso: '20191231',
+                id: '20191231',
+            })
+        })
+    })
+
+    describe('Weekly period generator', () => {
+        let periods
+
+        beforeAll(() => {
+            const generator = periodsGenerator.get('Weekly')
+
+            periods = generator.generatePeriods({
+                offset: 2009 - new Date(Date.now()).getFullYear(),
+                filterFuturePeriods: false,
+                reversePeriods: false,
+            })
+        })
+
+        it('should return the correct number of weeks in 2009', () => {
+            expect(periods.length).toEqual(53)
+        })
+
+        it('should return the correct object for week 1', () => {
+            expect(periods[0]).toEqual({
+                startDate: '2008-12-29',
+                endDate: '2009-01-04',
+                name: 'Week 1 - 2008-12-29 - 2009-01-04',
+                iso: '2009W1',
+                id: '2009W1',
+            })
+        })
+
+        it('should return the correct object for week 53', () => {
+            expect(periods[52]).toEqual({
+                startDate: '2009-12-28',
+                endDate: '2010-01-03',
+                name: 'Week 53 - 2009-12-28 - 2010-01-03',
+                iso: '2009W53',
+                id: '2009W53',
+            })
+        })
+
+        describe('-> Weekly Wednesday', () => {
+            beforeAll(() => {
+                const generator = periodsGenerator.get(
+                    'Weekly (Start Wednesday)'
+                )
+
+                periods = generator.generatePeriods({
+                    offset: 2019 - new Date(Date.now()).getFullYear(),
+                    filterFuturePeriods: false,
+                    reversePeriods: false,
+                })
+            })
+
+            it('should return the correct number of weekly wednesday in 2019', () => {
+                expect(periods.length).toEqual(52)
+            })
+
+            it('should return the correct object for weekly wednesday 27', () => {
+                expect(periods[26]).toEqual({
+                    startDate: '2019-07-03',
+                    endDate: '2019-07-09',
+                    name: 'Week 27 - 2019-07-03 - 2019-07-09',
+                    iso: '2019WedW27',
+                    id: '2019WedW27',
+                })
+            })
+        })
+
+        describe('-> Weekly Thursday', () => {
+            beforeAll(() => {
+                const generator = periodsGenerator.get(
+                    'Weekly (Start Thursday)'
+                )
+
+                periods = generator.generatePeriods({
+                    offset: 2019 - new Date(Date.now()).getFullYear(),
+                    filterFuturePeriods: false,
+                    reversePeriods: false,
+                })
+            })
+
+            it('should return the correct number of weekly thursday in 2019', () => {
+                expect(periods.length).toEqual(52)
+            })
+
+            it('should return the correct object for weekly thursday 27', () => {
+                expect(periods[26]).toEqual({
+                    startDate: '2019-07-04',
+                    endDate: '2019-07-10',
+                    name: 'Week 27 - 2019-07-04 - 2019-07-10',
+                    iso: '2019ThuW27',
+                    id: '2019ThuW27',
+                })
+            })
+        })
+
+        describe('-> Weekly Saturday', () => {
+            beforeAll(() => {
+                const generator = periodsGenerator.get(
+                    'Weekly (Start Saturday)'
+                )
+
+                periods = generator.generatePeriods({
+                    offset: 2019 - new Date(Date.now()).getFullYear(),
+                    filterFuturePeriods: false,
+                    reversePeriods: false,
+                })
+            })
+
+            it('should return the correct number of weekly saturdays in 2019', () => {
+                expect(periods.length).toEqual(53)
+            })
+
+            it('should return the correct object for weekly saturday 10', () => {
+                expect(periods[9]).toEqual({
+                    startDate: '2019-03-02',
+                    endDate: '2019-03-08',
+                    name: 'Week 10 - 2019-03-02 - 2019-03-08',
+                    iso: '2019SatW10',
+                    id: '2019SatW10',
+                })
+            })
+        })
+
+        describe('-> Weekly Sunday', () => {
+            beforeAll(() => {
+                const generator = periodsGenerator.get('Weekly (Start Sunday)')
+
+                periods = generator.generatePeriods({
+                    offset: 2019 - new Date(Date.now()).getFullYear(),
+                    filterFuturePeriods: false,
+                    reversePeriods: false,
+                })
+            })
+
+            it('should return the correct number of weekly sundays in 2019', () => {
+                expect(periods.length).toEqual(52)
+            })
+
+            it('should return the correct object for weekly sunday 10', () => {
+                expect(periods[10]).toEqual({
+                    startDate: '2019-03-10',
+                    endDate: '2019-03-16',
+                    name: 'Week 11 - 2019-03-10 - 2019-03-16',
+                    iso: '2019SunW11',
+                    id: '2019SunW11',
+                })
+            })
+        })
+    })
+
+    describe('Bi-weekly period generator', () => {
+        let periods
+
+        beforeAll(() => {
+            const generator = periodsGenerator.get('Bi-weekly')
+
+            periods = generator.generatePeriods({
+                offset: 2019 - new Date(Date.now()).getFullYear(),
+                filterFuturePeriods: false,
+                reversePeriods: false,
+            })
+        })
+
+        it('should return the correct number of bi-weeks in 2019', () => {
+            expect(periods.length).toEqual(26)
+        })
+
+        it('should return the correct object for bi-week 1', () => {
+            expect(periods[0]).toEqual({
+                startDate: '2018-12-31',
+                endDate: '2019-01-13',
+                name: 'Bi-Week 1 - 2018-12-31 - 2019-01-13',
+                iso: '2019BiW1',
+                id: '2019BiW1',
+            })
+        })
+
+        it('should return the correct object for bi-week 26', () => {
+            expect(periods[25]).toEqual({
+                startDate: '2019-12-16',
+                endDate: '2019-12-29',
+                name: 'Bi-Week 26 - 2019-12-16 - 2019-12-29',
+                iso: '2019BiW26',
+                id: '2019BiW26',
+            })
+        })
+    })
+
+    describe('Monthly period generator', () => {
+        let periods
+
+        beforeAll(() => {
+            const generator = periodsGenerator.get('Monthly')
+
+            periods = generator.generatePeriods({
+                offset: 2019 - new Date(Date.now()).getFullYear(),
+                filterFuturePeriods: false,
+                reversePeriods: false,
+            })
+        })
+
+        it('should return the correct number of months in 2019', () => {
+            expect(periods.length).toEqual(12)
+        })
+
+        it('should return the correct object for month 1', () => {
+            expect(periods[0]).toEqual({
+                startDate: '2019-01-01',
+                endDate: '2019-01-31',
+                name: 'January 2019',
+                iso: '201901',
+                id: '201901',
+            })
+        })
+
+        it('should return the correct object for month 12', () => {
+            expect(periods[11]).toEqual({
+                startDate: '2019-12-01',
+                endDate: '2019-12-31',
+                name: 'December 2019',
+                iso: '201912',
+                id: '201912',
+            })
+        })
+    })
+
+    describe('Bi-Monthly period generator', () => {
+        let periods
+
+        beforeAll(() => {
+            const generator = periodsGenerator.get('Bi-monthly')
+
+            periods = generator.generatePeriods({
+                offset: 2019 - new Date(Date.now()).getFullYear(),
+                filterFuturePeriods: false,
+                reversePeriods: false,
+            })
+        })
+
+        it('should return the correct number of bi-months in 2019', () => {
+            expect(periods.length).toEqual(6)
+        })
+
+        it('should return the correct object for bi-month 1', () => {
+            expect(periods[0]).toEqual({
+                startDate: '2019-01-01',
+                endDate: '2019-02-28',
+                name: 'January - February 2019',
+                iso: '201901B',
+                id: '201901B',
+            })
+        })
+
+        it('should return the correct object for bi-month 3', () => {
+            expect(periods[2]).toEqual({
+                startDate: '2019-05-01',
+                endDate: '2019-06-30',
+                name: 'May - June 2019',
+                iso: '201903B',
+                id: '201903B',
+            })
+        })
+
+        it('should return the correct object for bi-month 6', () => {
+            expect(periods[5]).toEqual({
+                startDate: '2019-11-01',
+                endDate: '2019-12-31',
+                name: 'November - December 2019',
+                iso: '201906B',
+                id: '201906B',
+            })
+        })
+    })
+
+    describe('Quarterly period generator', () => {
+        let periods
+
+        beforeAll(() => {
+            const generator = periodsGenerator.get('Quarterly')
+
+            periods = generator.generatePeriods({
+                offset: 2019 - new Date(Date.now()).getFullYear(),
+                filterFuturePeriods: false,
+                reversePeriods: false,
+            })
+        })
+
+        it('should return the correct number of quarters in 2019', () => {
+            expect(periods.length).toEqual(4)
+        })
+
+        it('should return the correct object for quarter 1', () => {
+            expect(periods[0]).toEqual({
+                startDate: '2019-01-01',
+                endDate: '2019-03-31',
+                name: 'January - March 2019',
+                iso: '2019Q1',
+                id: '2019Q1',
+            })
+        })
+
+        it('should return the correct object for quarter 4', () => {
+            expect(periods[3]).toEqual({
+                startDate: '2019-10-01',
+                endDate: '2019-12-31',
+                name: 'October - December 2019',
+                iso: '2019Q4',
+                id: '2019Q4',
+            })
+        })
+    })
+
+    describe('Six-monthly period generator', () => {
+        let periods
+
+        beforeAll(() => {
+            const generator = periodsGenerator.get('Six-monthly')
+
+            periods = generator.generatePeriods({
+                offset: 2019 - new Date(Date.now()).getFullYear(),
+                filterFuturePeriods: false,
+                reversePeriods: false,
+            })
+        })
+
+        it('should return the correct number of six-month periods in 2019', () => {
+            expect(periods.length).toEqual(2)
+        })
+
+        it('should return the correct object for six-monthly 1', () => {
+            expect(periods[0]).toEqual({
+                startDate: '2019-01-01',
+                endDate: '2019-06-30',
+                name: 'January - June 2019',
+                iso: '2019S1',
+                id: '2019S1',
+            })
+        })
+
+        it('should return the correct object for six-monthly 2', () => {
+            expect(periods[1]).toEqual({
+                startDate: '2019-07-01',
+                endDate: '2019-12-31',
+                name: 'July - December 2019',
+                iso: '2019S2',
+                id: '2019S2',
+            })
+        })
+    })
+
+    describe('Six-monthly April period generator', () => {
+        let periods
+
+        beforeAll(() => {
+            const generator = periodsGenerator.get('Six-monthly April')
+
+            periods = generator.generatePeriods({
+                offset: 2019 - new Date(Date.now()).getFullYear(),
+                filterFuturePeriods: false,
+                reversePeriods: false,
+            })
+        })
+
+        it('should return the correct number of six-monthly April periods in 2019', () => {
+            expect(periods.length).toEqual(2)
+        })
+
+        it('should return the correct object for six-monthly April 1', () => {
+            expect(periods[0]).toEqual({
+                startDate: '2019-04-01',
+                endDate: '2019-09-30',
+                name: 'April - September 2019',
+                iso: '2019AprilS1',
+                id: '2019AprilS1',
+            })
+        })
+
+        it('should return the correct object for six-monthly April 2', () => {
+            expect(periods[1]).toEqual({
+                startDate: '2019-10-01',
+                endDate: '2020-03-31',
+                name: 'October 2019 - March 2020',
+                iso: '2019AprilS2',
+                id: '2019AprilS2',
+            })
+        })
+    })
+
+    describe('Yearly period generator', () => {
+        let periods
+
+        beforeAll(() => {
+            const generator = periodsGenerator.get('Yearly')
+
+            periods = generator.generatePeriods({
+                offset: 10, // 2020 - 2029
+                filterFuturePeriods: false,
+                reversePeriods: false,
+            })
+        })
+
+        it('should return the correct number of yearly periods', () => {
+            expect(periods.length).toEqual(10)
+        })
+
+        it('should return the correct object for yearly period 1', () => {
+            expect(periods[0]).toEqual({
+                startDate: '2020-01-01',
+                endDate: '2020-12-31',
+                name: '2020',
+                iso: '2020',
+                id: '2020',
+            })
+        })
+
+        it('should return the correct object for yearly period 10', () => {
+            expect(periods[9]).toEqual({
+                startDate: '2029-01-01',
+                endDate: '2029-12-31',
+                name: '2029',
+                iso: '2029',
+                id: '2029',
+            })
+        })
+    })
+
+    describe('Financial November period generator', () => {
+        let periods
+
+        beforeAll(() => {
+            const generator = periodsGenerator.get(
+                'Financial year (Start November)'
+            )
+
+            periods = generator.generatePeriods({
+                offset: 9,
+                filterFuturePeriods: false,
+                reversePeriods: false,
+            })
+        })
+
+        it('should return the correct number of financial November periods', () => {
+            expect(periods.length).toEqual(10)
+        })
+
+        it('should return the correct object for financial November period 1', () => {
+            expect(periods[0]).toEqual({
+                startDate: '2019-11-01',
+                endDate: '2020-10-31',
+                name: 'November 2019 - October 2020',
+                id: '2019Nov',
+            })
+        })
+
+        it('should return the correct object for financial November period 10', () => {
+            expect(periods[9]).toEqual({
+                startDate: '2028-11-01',
+                endDate: '2029-10-31',
+                name: 'November 2028 - October 2029',
+                id: '2028Nov',
+            })
+        })
+    })
+
+    describe('Financial October period generator', () => {
+        let periods
+
+        beforeAll(() => {
+            const generator = periodsGenerator.get(
+                'Financial year (Start October)'
+            )
+
+            periods = generator.generatePeriods({
+                offset: 9,
+                filterFuturePeriods: false,
+                reversePeriods: false,
+            })
+        })
+
+        it('should return the correct number of financial October periods', () => {
+            expect(periods.length).toEqual(10)
+        })
+
+        it('should return the correct object for financial October period 1', () => {
+            expect(periods[0]).toEqual({
+                startDate: '2019-10-01',
+                endDate: '2020-09-30',
+                name: 'October 2019 - September 2020',
+                id: '2019Oct',
+            })
+        })
+
+        it('should return the correct object for financial October period 10', () => {
+            expect(periods[9]).toEqual({
+                startDate: '2028-10-01',
+                endDate: '2029-09-30',
+                name: 'October 2028 - September 2029',
+                id: '2028Oct',
+            })
+        })
+    })
+
+    describe('Financial July period generator', () => {
+        let periods
+
+        beforeAll(() => {
+            const generator = periodsGenerator.get(
+                'Financial year (Start July)'
+            )
+
+            periods = generator.generatePeriods({
+                offset: 9,
+                filterFuturePeriods: false,
+                reversePeriods: false,
+            })
+        })
+
+        it('should return the correct number of financial July periods', () => {
+            expect(periods.length).toEqual(10)
+        })
+
+        it('should return the correct object for financial July 1', () => {
+            expect(periods[0]).toEqual({
+                startDate: '2019-07-01',
+                endDate: '2020-06-30',
+                name: 'July 2019 - June 2020',
+                id: '2019July',
+            })
+        })
+
+        it('should return the correct object for financial July period 10', () => {
+            expect(periods[9]).toEqual({
+                startDate: '2028-07-01',
+                endDate: '2029-06-30',
+                name: 'July 2028 - June 2029',
+                id: '2028July',
+            })
+        })
+    })
+
+    describe('Financial April period generator', () => {
+        let periods
+
+        beforeAll(() => {
+            const generator = periodsGenerator.get(
+                'Financial year (Start April)'
+            )
+
+            periods = generator.generatePeriods({
+                offset: 9,
+                filterFuturePeriods: false,
+                reversePeriods: false,
+            })
+        })
+
+        it('should return the correct number of financial April periods', () => {
+            expect(periods.length).toEqual(10)
+        })
+
+        it('should return the correct object for financial April 1', () => {
+            expect(periods[0]).toEqual({
+                startDate: '2019-04-01',
+                endDate: '2020-03-31',
+                name: 'April 2019 - March 2020',
+                id: '2019April',
+            })
+        })
+
+        it('should return the correct object for financial April period 10', () => {
+            expect(periods[9]).toEqual({
+                startDate: '2028-04-01',
+                endDate: '2029-03-31',
+                name: 'April 2028 - March 2029',
+                id: '2028April',
+            })
+        })
+    })
+})

--- a/src/components/PeriodSelector/modules/periodTypes.js
+++ b/src/components/PeriodSelector/modules/periodTypes.js
@@ -1,0 +1,2 @@
+export const FIXED = 'FIXED'
+export const RELATIVE = 'RELATIVE'

--- a/src/components/PeriodSelector/styles/InputLabel.style.js
+++ b/src/components/PeriodSelector/styles/InputLabel.style.js
@@ -1,0 +1,8 @@
+import css from 'styled-jsx/css'
+
+export default css`
+    .input-label {
+        color: #595959;
+        white-space: nowrap;
+    }
+`

--- a/src/components/PeriodSelector/styles/PeriodSelector.style.js
+++ b/src/components/PeriodSelector/styles/PeriodSelector.style.js
@@ -1,0 +1,8 @@
+import css from 'styled-jsx/css'
+
+export default css`
+    .options-area {
+        padding: 5px 10px 0px 10px;
+        border-bottom: 1px solid #e8e8e8;
+    }
+`

--- a/src/components/PeriodSelector/styles/PeriodTypeButton.style.js
+++ b/src/components/PeriodSelector/styles/PeriodTypeButton.style.js
@@ -1,0 +1,39 @@
+import css from 'styled-jsx/css'
+
+export default css`
+    .nav-button {
+        padding: 5px 13px 3px;
+        border: 1px solid #eceff1;
+        text-transform: none;
+        border-radius: 0;
+        margin-right: -1px;
+        font-size: 0.875rem;
+        font-weight: 500;
+        line-height: 1.75;
+        font-family: Roboto, sans-serif;
+        background-color: transparent;
+    }
+
+    .nav-button:first-child {
+        border-radius: 2px 0 0 2px;
+    }
+
+    .nav-button:last-child {
+        border-radius: 0 2px 2px 0;
+    }
+
+    .nav-button:hover {
+        cursor: pointer;
+        background-color: rgba(0, 0, 0, 0.08);
+    }
+
+    .nav-button:focus {
+        outline: none;
+    }
+
+    .nav-button.active,
+    .nav-button.active:hover {
+        background-color: #00796b;
+        color: #fff;
+    }
+`

--- a/stories/PeriodSelector.stories.js
+++ b/stories/PeriodSelector.stories.js
@@ -1,0 +1,8 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import PeriodSelector from '../src/components/PeriodSelector/PeriodSelector'
+
+storiesOf('PeriodSelector', module).add('default', () => {
+    return <PeriodSelector />
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1159,25 +1159,6 @@
   dependencies:
     find-up "^2.1.0"
 
-"@dhis2/analytics@^2.1.0":
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/analytics/-/analytics-2.2.1.tgz#ed46681c56089db8b5ac8223b5c09cc9a96a1096"
-  integrity sha512-9KWd3hOe6JRhlb3eibxh4Dm/0UjijVer7J4wDLDdvtnoeSo6U0ue6WZ3gw9pVRShqjUU4IsUe7cFgwXpDDlHXQ==
-  dependencies:
-    "@dhis2/d2-i18n" "^1.0.4"
-    "@dhis2/d2-ui-org-unit-dialog" "^6.1.0"
-    "@dhis2/d2-ui-period-selector-dialog" "^6.1.0"
-    "@dhis2/ui-core" "^3.4.0"
-    "@material-ui/core" "^3.9.3"
-    "@material-ui/icons" "^3.0.2"
-    classnames "^2.2.6"
-    d2-utilizr "^0.2.16"
-    d3-color "^1.2.3"
-    highcharts "^7.1.2"
-    lodash "^4.17.11"
-    react-beautiful-dnd "^10.1.1"
-    styled-jsx "^3.2.1"
-
 "@dhis2/cli-helpers-engine@1.3.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@dhis2/cli-helpers-engine/-/cli-helpers-engine-1.3.0.tgz#e12f7a1bfd6223054cf9254e675b2b660b0690a5"
@@ -1217,41 +1198,6 @@
   dependencies:
     i18next "^10.3"
 
-"@dhis2/d2-ui-analytics@^1.0.0":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-analytics/-/d2-ui-analytics-1.0.4.tgz#de33ba8f228a375ddaf664aeb62f1837aaaa4586"
-  integrity sha512-7jhlj9AnJKqvY7tq7DmvNMBJfIlqbe+Ou4/w0giIzFG6uFW/P42EIeM+1ACMj4oA4Z/wFjUZ9kA17lSc0IO0+g==
-  dependencies:
-    "@dhis2/d2-i18n" "^1.0.4"
-    "@dhis2/d2-ui-org-unit-dialog" "^5.3.10"
-    "@dhis2/d2-ui-period-selector-dialog" "^5.3.10"
-    "@material-ui/core" "^3.9.3"
-    "@material-ui/icons" "^3.0.2"
-    classnames "^2.2.6"
-    lodash "^4.17.11"
-    react-beautiful-dnd "^10.1.1"
-    styled-jsx "^3.2.1"
-
-"@dhis2/d2-ui-core@5.3.10":
-  version "5.3.10"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-5.3.10.tgz#c852149814ed6f5123cb74594c87c6e12a059011"
-  integrity sha512-rMsK0Un4nui3hOIP0he5Oz9wgjYIFqrSbhDtONTh9lDYdepoR6DadOC1/AsBEKj4uJisePHShvUljCZ2i+SZsw==
-  dependencies:
-    babel-runtime "^6.26.0"
-    d2 "~31.7"
-    lodash "^4.17.10"
-    material-ui "^0.20.0"
-
-"@dhis2/d2-ui-core@6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-6.1.0.tgz#3efe93fe0094dc968ecd938ed9e1c24fe186d71d"
-  integrity sha512-4hgQu3t94B/XhPPFwuNW9SQ2VC+OEk4j4B/tPQMEyxrhCyUWfEN7D+MDxKkIu/P+cyKPTa0liMJF2tGOglyYsA==
-  dependencies:
-    babel-runtime "^6.26.0"
-    d2 "~31.7"
-    lodash "^4.17.10"
-    material-ui "^0.20.0"
-
 "@dhis2/d2-ui-core@6.3.0":
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-6.3.0.tgz#ec0ef63978a34d5b2330303c426bf7d59e0836fc"
@@ -1261,28 +1207,6 @@
     d2 "~31.7"
     lodash "^4.17.10"
     material-ui "^0.20.0"
-
-"@dhis2/d2-ui-org-unit-dialog@^5.3.10":
-  version "5.3.10"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-dialog/-/d2-ui-org-unit-dialog-5.3.10.tgz#45a12d6aa41741d2ea239ea58658a8d276dbc9f6"
-  integrity sha512-NXxPmFMt+NJkTeVwZGppWN+sa16n6M5C4kHsySaHG7hJ7ZT6vjJnc8WBcqfZbk3oMrTFvRapt25pscwbLTKvBg==
-  dependencies:
-    "@dhis2/d2-i18n" "^1.0.3"
-    "@dhis2/d2-ui-org-unit-tree" "5.3.10"
-    "@material-ui/core" "^3.3.1"
-    "@material-ui/icons" "^3.0.1"
-    prop-types "^15.5.10"
-
-"@dhis2/d2-ui-org-unit-dialog@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-dialog/-/d2-ui-org-unit-dialog-6.1.0.tgz#8f941129450097ba42fec19e2d65108368ccca49"
-  integrity sha512-/Rhxr22NU2l4Dto2dsn1+hfvH5z7/ORjp1bHi0J8haobODbWzW0xCq63xwsmb3qjyuG/cfY7cwVqpH7osD4Awg==
-  dependencies:
-    "@dhis2/d2-i18n" "^1.0.3"
-    "@dhis2/d2-ui-org-unit-tree" "6.1.0"
-    "@material-ui/core" "^3.3.1"
-    "@material-ui/icons" "^3.0.1"
-    prop-types "^15.5.10"
 
 "@dhis2/d2-ui-org-unit-dialog@^6.3.0":
   version "6.3.0"
@@ -1295,28 +1219,6 @@
     "@material-ui/icons" "^3.0.1"
     prop-types "^15.5.10"
 
-"@dhis2/d2-ui-org-unit-tree@5.3.10":
-  version "5.3.10"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-5.3.10.tgz#181f5666081dbe233adf6db6bb2e1ef7be938869"
-  integrity sha512-p/IvFEPt5xRDznnpf7M/rYpDfNLzxmheGuTfNd6qlNWKldr8w4NUsFL9mmdMQGJbkGhazmsLmrDM35gPgYgL/w==
-  dependencies:
-    "@dhis2/d2-ui-core" "5.3.10"
-    "@material-ui/core" "^3.3.1"
-    babel-runtime "^6.26.0"
-    prop-types "^15.5.10"
-    recompose "^0.26.0"
-    rxjs "^5.5.7"
-
-"@dhis2/d2-ui-org-unit-tree@6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-6.1.0.tgz#6604cf93c9d11395e157bdee8ca44133e36673df"
-  integrity sha512-l4OnCkhzF8V/4GhS5gbFdsFyMBjmFyt2ECfbootafUh0jegMRE4vWLFdk88h6X3jwcRSD6d/gjnkB8Li1rGikQ==
-  dependencies:
-    "@dhis2/d2-ui-core" "6.1.0"
-    "@material-ui/core" "^3.3.1"
-    babel-runtime "^6.26.0"
-    prop-types "^15.5.10"
-
 "@dhis2/d2-ui-org-unit-tree@6.3.0":
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-6.3.0.tgz#5c80074a38987f853383aa12f10ecd11127332ef"
@@ -1326,43 +1228,6 @@
     "@material-ui/core" "^3.3.1"
     babel-runtime "^6.26.0"
     prop-types "^15.5.10"
-
-"@dhis2/d2-ui-period-selector-dialog@^5.3.10":
-  version "5.3.11"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-period-selector-dialog/-/d2-ui-period-selector-dialog-5.3.11.tgz#32383d6703c45078ea1a6e242a6cf9db2e0b2e56"
-  integrity sha512-Jy1qhtrwRPqmUa5BrOAJlk/xgwZYlIv8HEroM1v/cOt5QuP4b3Y3PZbpx7w4stBERD0b0UN7rIwjBRbhutrVpw==
-  dependencies:
-    "@dhis2/d2-i18n" "^1.0.4"
-    "@dhis2/d2-ui-analytics" "^1.0.0"
-    "@material-ui/core" "^3.3.1"
-    "@material-ui/icons" "^3.0.1"
-    babel-runtime "^6.26.0"
-    lodash "^4.17.11"
-    prop-types "^15.6.0"
-
-"@dhis2/d2-ui-period-selector-dialog@^6.1.0":
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-period-selector-dialog/-/d2-ui-period-selector-dialog-6.1.0.tgz#c7b5b20b44923d9b6e180bb90e3ccd1889dc419d"
-  integrity sha512-JOKX/UgOgaINSL09tqVOy0l98W7koZh045c6H3iDxf6WE8u3i2/Gj1FEGIrV3/GfZ0hHov9+sdboTL4f85OnUA==
-  dependencies:
-    "@dhis2/d2-i18n" "^1.0.4"
-    "@dhis2/d2-ui-analytics" "^1.0.0"
-    "@material-ui/core" "^3.3.1"
-    "@material-ui/icons" "^3.0.1"
-    babel-runtime "^6.26.0"
-    prop-types "^15.6.0"
-
-"@dhis2/d2-ui-period-selector-dialog@^6.3.0":
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-period-selector-dialog/-/d2-ui-period-selector-dialog-6.3.0.tgz#56bba56d8a7e914364e94e3d025dda8f03a3622f"
-  integrity sha512-JOofPyx+h45PsVi/0Ubf4xQurBwnnq+wTSOtibKfWSvxNgrNUug08F8+LYxoP/+IUogmkzuFD0uQs9pW3pYa0g==
-  dependencies:
-    "@dhis2/analytics" "^2.1.0"
-    "@dhis2/d2-i18n" "^1.0.4"
-    "@material-ui/core" "^3.3.1"
-    "@material-ui/icons" "^3.0.1"
-    babel-runtime "^6.26.0"
-    prop-types "^15.6.0"
 
 "@dhis2/ui-core@^3.4.0":
   version "3.4.0"
@@ -10673,13 +10538,6 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@^5.5.7:
-  version "5.5.12"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.5.12.tgz#6fa61b8a77c3d793dbaf270bee2f43f652d741cc"
-  integrity sha512-xx2itnL5sBbqeeiVgNPVuQQ1nC8Jp2WfNJhXWHmElW9YmrpS9UVnNzhP3EH3HFqexO5Tlp8GhYY+WEcqcVMvGw==
-  dependencies:
-    symbol-observable "1.0.1"
-
 rxjs@^6.1.0, rxjs@^6.4.0:
   version "6.4.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.4.0.tgz#f3bb0fe7bda7fb69deac0c16f17b50b0b8790504"
@@ -11439,11 +11297,6 @@ svgo@^1.1.1:
     stable "^0.1.8"
     unquote "~1.1.1"
     util.promisify "~1.0.0"
-
-symbol-observable@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
-  integrity sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=
 
 symbol-observable@1.2.0, symbol-observable@^1.0.4, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"


### PR DESCRIPTION
Part of fix for [DHIS2-8638](https://jira.dhis2.org/browse/DHIS2-8638)

The PeriodSelector component has been part of a circular dependency between d2-ui and analytics. This has created a lot of headaches with upgrading and other at-times strange errors and behaviour. In the future, PeriodSelector will be part of ui-widgets, but until that can happen, Period Selector is being moved to analytics to resolve the circular dependency issues

* No functional changes
* Component can (and should) be viewed and tested in Storybook (yarn start)


Code is nearly identical to what was in d2-ui. Only changes were related to converting the css file to styled-jsx. So for review, I recommend only checking the style files and trying the component in storybook. 