### PR TITLE
fix: dimension panel search field is missing the 'x' to clear (DHIS2-8790)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "@dhis2/d2-i18n": "^1.0.4",
         "@dhis2/d2-ui-org-unit-dialog": "^6.5.9",
         "@dhis2/d2-ui-period-selector-dialog": "^6.5.7",
-        "@dhis2/ui-core": "^4.16.0",
+        "@dhis2/ui-core": "^4.19.1",
         "@material-ui/core": "^3.9.3",
         "@material-ui/icons": "^3.0.2",
         "classnames": "^2.2.6",

--- a/src/components/DimensionsPanel/DimensionsPanel.js
+++ b/src/components/DimensionsPanel/DimensionsPanel.js
@@ -34,7 +34,7 @@ export class DimensionsPanel extends Component {
             <div style={{ ...styles.divContainer, ...style }}>
                 <Filter
                     style={styles.textField}
-                    placeholder={i18n.t('Filter dimensions 123')}
+                    placeholder={i18n.t('Filter dimensions')}
                     text={this.state.filterText}
                     onChange={this.onFilterTextChange}
                     onClear={this.onClearFilter}

--- a/src/components/DimensionsPanel/DimensionsPanel.js
+++ b/src/components/DimensionsPanel/DimensionsPanel.js
@@ -34,10 +34,11 @@ export class DimensionsPanel extends Component {
             <div style={{ ...styles.divContainer, ...style }}>
                 <Filter
                     style={styles.textField}
-                    placeholder={i18n.t('Filter dimensions')}
+                    placeholder={i18n.t('Filter dimensions 123')}
                     text={this.state.filterText}
                     onChange={this.onFilterTextChange}
                     onClear={this.onClearFilter}
+                    type="search"
                 />
                 <DimensionList
                     dimensions={dimensions}

--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -14,10 +14,14 @@ export const Filter = ({ text, onChange, onClear, placeholder, type }) => (
 
 Filter.propTypes = {
     placeholder: PropTypes.string.isRequired,
-    text: PropTypes.string.isRequired,
+    text: PropTypes.string,
     type: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
     onClear: PropTypes.func.isRequired,
+}
+
+Filter.defaultProps = {
+    type: 'text',
 }
 
 export default Filter

--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -2,18 +2,20 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { InputField } from '@dhis2/ui-core'
 
-export const Filter = ({ text, onChange, onClear, placeholder }) => (
+export const Filter = ({ text, onChange, onClear, placeholder, type }) => (
     <InputField
         placeholder={placeholder}
         onChange={ref => (ref.value.length ? onChange(ref.value) : onClear())}
         value={text}
         dense
+        type={type}
     />
 )
 
 Filter.propTypes = {
     placeholder: PropTypes.string.isRequired,
     text: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
     onClear: PropTypes.func.isRequired,
 }

--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -14,10 +14,10 @@ export const Filter = ({ text, onChange, onClear, placeholder, type }) => (
 
 Filter.propTypes = {
     placeholder: PropTypes.string.isRequired,
-    text: PropTypes.string,
     type: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
     onClear: PropTypes.func.isRequired,
+    text: PropTypes.string,
 }
 
 Filter.defaultProps = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1309,19 +1309,26 @@
     babel-runtime "^6.26.0"
     prop-types "^15.6.0"
 
-"@dhis2/prop-types@^1.5", "@dhis2/prop-types@^1.5.0":
+"@dhis2/prop-types@^1.5":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@dhis2/prop-types/-/prop-types-1.5.0.tgz#7e69919f66698be373dd21940a8a770234ded6a1"
   integrity sha512-dueFkkAMOIMbXiU7Mhr3Y+DBRyOd/rHA+5/IDiYWN1xttlUTSuGZLQ5AnJ7osBicEhx+qElaGbTdRYQj3SMBtA==
   dependencies:
     prop-types "^15"
 
-"@dhis2/ui-core@^4.16.0", "@dhis2/ui-core@^4.6.1", "@dhis2/ui-core@^4.9.1":
-  version "4.16.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-4.16.0.tgz#868555c2d8758af3f26e168d2a469bde39c91b1d"
-  integrity sha512-pa47/ZZrQa9SUXlOW4r8HKyuzfO/i4vENR1u2+2zrPfBtbFK4FPwXANmdVAw+V6epbWJU8k2Fi31j1ZMwauq/w==
+"@dhis2/prop-types@^1.6.4":
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/@dhis2/prop-types/-/prop-types-1.6.4.tgz#ec4d256c9440d4d00071524422a727c61ddaa6f6"
+  integrity sha512-qkVj8OuyjDmSxzYDlCWZllvC9hIbrIImMp79/U5CVsIRbjUF0zA/tfbv4rWnsWALmwEHOQFbzl5GnO5D8RNneA==
   dependencies:
-    "@dhis2/prop-types" "^1.5.0"
+    prop-types "^15"
+
+"@dhis2/ui-core@^4.19.1", "@dhis2/ui-core@^4.6.1", "@dhis2/ui-core@^4.9.1":
+  version "4.19.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-4.19.1.tgz#3cf32b2a24f2435d527ebef1daa99b84396da4f8"
+  integrity sha512-jvX6h+lRhKaw18B46AQuwltDKIb06e1HxGaPpplFJS1vRrTs8Yvn1pP1BFUBhTgVD3/3zLlO+lD3IsUavJUqOg==
+  dependencies:
+    "@dhis2/prop-types" "^1.6.4"
     "@popperjs/core" "^2.1.0"
     classnames "^2.2.6"
 


### PR DESCRIPTION
Fixes [DHIS2-8790](https://jira.dhis2.org/browse/DHIS2-8790).
Adds the browser default 'x' by passing through the `type` prop (which can be set to `search` to get the 'x'.

Also updates the `@dhis2/ui-core` dep to latest, v4.19.1

![image](https://user-images.githubusercontent.com/12590483/80979914-3d823180-8e28-11ea-8671-4880937e575b.png)

Relates to: https://github.com/dhis2/data-visualizer-app/pull/948
