### PR TITLE
fix: selected periods have the name function

### DIFF
--- a/src/components/PeriodSelector/PeriodSelector.js
+++ b/src/components/PeriodSelector/PeriodSelector.js
@@ -33,9 +33,10 @@ class PeriodSelector extends Component {
         const offeredPeriods = this.state.offeredPeriods.filter(
             period => !periodIds.includes(period.id)
         )
-        const newPeriods = this.state.offeredPeriods.filter(period =>
-            periodIds.includes(period.id)
-        )
+        const newPeriods = this.state.offeredPeriods
+            .filter(period => periodIds.includes(period.id))
+            .map(({ id, idx, name }) => ({ id, idx, name: name() }))
+
         const selectedPeriods = this.state.selectedPeriods.concat(newPeriods)
 
         this.setState({ selectedPeriods, offeredPeriods })


### PR DESCRIPTION
Part of fix for : https://jira.dhis2.org/browse/DHIS2-8638

Functions are now needed to get the translated period names. This fix was missed in the previous PR. This one gets the translated period for the selected periods list.