### PR TITLE
feat: drill down/up support on table cells

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "@dhis2/d2-i18n": "^1.0.4",
         "@dhis2/d2-ui-org-unit-dialog": "^7.0.3",
         "@dhis2/d2-ui-period-selector-dialog": "^7.0.3",
-        "@dhis2/ui-core": "^4.19.1",
+        "@dhis2/ui-core": "^4.20.0",
         "@material-ui/core": "^3.9.3",
         "@material-ui/icons": "^3.0.2",
         "classnames": "^2.2.6",

--- a/src/components/PivotTable/PivotTable.js
+++ b/src/components/PivotTable/PivotTable.js
@@ -10,7 +10,13 @@ import { PivotTableHead } from './PivotTableHead'
 import { PivotTableBody } from './PivotTableBody'
 import { useSortableColumns } from '../../modules/pivotTable/useSortableColumns'
 
-const PivotTable = ({ visualization, data, legendSets, renderCounter }) => {
+const PivotTable = ({
+    visualization,
+    data,
+    legendSets,
+    renderCounter,
+    onToggleContextualMenu,
+}) => {
     const containerRef = useRef(undefined)
     const { width, height } = useParentSize(containerRef, renderCounter)
 
@@ -42,7 +48,10 @@ const PivotTable = ({ visualization, data, legendSets, renderCounter }) => {
                     sortBy={sortBy}
                     onSortByColumn={onSortByColumn}
                 />
-                <PivotTableBody clippingResult={clippingResult} />
+                <PivotTableBody
+                    clippingResult={clippingResult}
+                    onToggleContextualMenu={onToggleContextualMenu}
+                />
             </PivotTableContainer>
         </Provider>
     )
@@ -53,6 +62,7 @@ PivotTable.propTypes = {
     visualization: PropTypes.object.isRequired,
     legendSets: PropTypes.arrayOf(PropTypes.object),
     renderCounter: PropTypes.number,
+    onToggleContextualMenu: PropTypes.func,
 }
 
 export default PivotTable

--- a/src/components/PivotTable/PivotTableBody.js
+++ b/src/components/PivotTable/PivotTableBody.js
@@ -4,7 +4,7 @@ import { PivotTableClippedAxis } from './PivotTableClippedAxis'
 import { PivotTableEmptyRow } from './PivotTableEmptyRow'
 import { PivotTableRow } from './PivotTableRow'
 
-export const PivotTableBody = ({ clippingResult }) => (
+export const PivotTableBody = ({ clippingResult, onToggleContextualMenu }) => (
     <tbody>
         <PivotTableClippedAxis
             axisClippingResult={clippingResult.rows}
@@ -19,6 +19,7 @@ export const PivotTableBody = ({ clippingResult }) => (
                     key={index}
                     clippingResult={clippingResult}
                     rowIndex={index}
+                    onToggleContextualMenu={onToggleContextualMenu}
                 />
             )}
         />
@@ -27,4 +28,5 @@ export const PivotTableBody = ({ clippingResult }) => (
 
 PivotTableBody.propTypes = {
     clippingResult: PropTypes.object.isRequired,
+    onToggleContextualMenu: PropTypes.func,
 }

--- a/src/components/PivotTable/PivotTableRow.js
+++ b/src/components/PivotTable/PivotTableRow.js
@@ -7,7 +7,11 @@ import { PivotTableEmptyCell } from './PivotTableEmptyCell'
 import { usePivotTableEngine } from './PivotTableEngineContext'
 import times from 'lodash/times'
 
-export const PivotTableRow = ({ clippingResult, rowIndex }) => {
+export const PivotTableRow = ({
+    clippingResult,
+    rowIndex,
+    onToggleContextualMenu,
+}) => {
     const engine = usePivotTableEngine()
     return (
         <tr>
@@ -23,7 +27,11 @@ export const PivotTableRow = ({ clippingResult, rowIndex }) => {
                 axisClippingResult={clippingResult.columns}
                 EmptyComponent={() => <PivotTableEmptyCell type="value" />}
                 ItemComponent={({ index: columnIndex }) => (
-                    <PivotTableValueCell row={rowIndex} column={columnIndex} />
+                    <PivotTableValueCell
+                        row={rowIndex}
+                        column={columnIndex}
+                        onToggleContextualMenu={onToggleContextualMenu}
+                    />
                 )}
             />
         </tr>
@@ -36,4 +44,5 @@ PivotTableRow.propTypes = {
         rows: PropTypes.object.isRequired,
     }).isRequired,
     rowIndex: PropTypes.number.isRequired,
+    onToggleContextualMenu: PropTypes.func,
 }

--- a/src/components/PivotTable/PivotTableValueCell.js
+++ b/src/components/PivotTable/PivotTableValueCell.js
@@ -1,5 +1,6 @@
-import React from 'react'
+import React, { useRef } from 'react'
 import PropTypes from 'prop-types'
+
 import { applyLegendSet } from '../../modules/pivotTable/applyLegendSet'
 import { PivotTableCell } from './PivotTableCell'
 import { usePivotTableEngine } from './PivotTableEngineContext'
@@ -9,7 +10,11 @@ import {
 } from '../../modules/pivotTable/pivotTableConstants'
 import { PivotTableEmptyCell } from './PivotTableEmptyCell'
 
-export const PivotTableValueCell = ({ row, column }) => {
+export const PivotTableValueCell = ({
+    row,
+    column,
+    onToggleContextualMenu,
+}) => {
     const engine = usePivotTableEngine()
 
     const cellContent = engine.get({
@@ -40,14 +45,26 @@ export const PivotTableValueCell = ({ row, column }) => {
         maxWidth: width,
     }
 
+    const cellRef = useRef(undefined)
+
+    const onClick = () => {
+        if (
+            cellContent.cellType === CELL_TYPE_VALUE &&
+            cellContent.renderedValue
+        ) {
+            onToggleContextualMenu(cellRef, cellContent)
+        }
+    }
+
     return (
         <PivotTableCell
             key={column}
             classes={[cellContent.cellType, cellContent.valueType]}
             title={cellContent.renderedValue}
             style={style}
+            onClick={onClick}
         >
-            {cellContent.renderedValue ?? null}
+            <span ref={cellRef}>{cellContent.renderedValue ?? null}</span>
         </PivotTableCell>
     )
 }
@@ -55,4 +72,5 @@ export const PivotTableValueCell = ({ row, column }) => {
 PivotTableValueCell.propTypes = {
     column: PropTypes.number.isRequired,
     row: PropTypes.number.isRequired,
+    onToggleContextualMenu: PropTypes.func,
 }

--- a/src/components/PivotTable/PivotTableValueCell.js
+++ b/src/components/PivotTable/PivotTableValueCell.js
@@ -16,6 +16,7 @@ export const PivotTableValueCell = ({
     onToggleContextualMenu,
 }) => {
     const engine = usePivotTableEngine()
+    const cellRef = useRef(undefined)
 
     const cellContent = engine.get({
         row,
@@ -44,8 +45,6 @@ export const PivotTableValueCell = ({
         minWidth: width,
         maxWidth: width,
     }
-
-    const cellRef = useRef(undefined)
 
     const onClick = () => {
         if (

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -4,7 +4,10 @@ import { parseValue } from './parseValue'
 import { renderValue } from './renderValue'
 import { measureText } from './measureText'
 
-import { DIMENSION_ID_ORGUNIT } from '../predefinedDimensions'
+import {
+    DIMENSION_ID_ORGUNIT,
+    DIMENSION_ID_PERIOD,
+} from '../predefinedDimensions'
 
 import {
     AGGREGATE_TYPE_NA,
@@ -320,6 +323,19 @@ export class PivotTableEngine {
 
         const dataRow = this.data[row][column]
 
+        const ouId =
+            dataRow[
+                this.dimensionLookup.headerDimensions.findIndex(
+                    header => header.dimension === DIMENSION_ID_ORGUNIT
+                )
+            ]
+        const peId =
+            dataRow[
+                this.dimensionLookup.headerDimensions.findIndex(
+                    header => header.dimension === DIMENSION_ID_PERIOD
+                )
+            ]
+
         let rawValue =
             cellType === CELL_TYPE_VALUE
                 ? dataRow[this.dimensionLookup.dataHeaders.value]
@@ -355,6 +371,8 @@ export class PivotTableEngine {
             rawValue,
             renderedValue,
             dxDimension,
+            ouId,
+            peId,
         }
     }
 

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -323,18 +323,17 @@ export class PivotTableEngine {
 
         const dataRow = this.data[row][column]
 
-        const ouId =
-            dataRow[
-                this.dimensionLookup.headerDimensions.findIndex(
-                    header => header.dimension === DIMENSION_ID_ORGUNIT
-                )
-            ]
-        const peId =
-            dataRow[
-                this.dimensionLookup.headerDimensions.findIndex(
-                    header => header.dimension === DIMENSION_ID_PERIOD
-                )
-            ]
+        const ouIndex = this.dimensionLookup.headerDimensions.findIndex(
+            header => header.dimension === DIMENSION_ID_ORGUNIT
+        )
+
+        const ouId = ouIndex !== -1 ? dataRow[ouIndex] : null
+
+        const peIndex = this.dimensionLookup.headerDimensions.findIndex(
+            header => header.dimension === DIMENSION_ID_PERIOD
+        )
+
+        const peId = peIndex !== -1 ? dataRow[peIndex] : null
 
         let rawValue =
             cellType === CELL_TYPE_VALUE

--- a/yarn.lock
+++ b/yarn.lock
@@ -1358,14 +1358,16 @@
   dependencies:
     prop-types "^15"
 
-"@dhis2/ui-core@^4.19.1", "@dhis2/ui-core@^4.6.1", "@dhis2/ui-core@^4.9.1":
-  version "4.19.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-4.19.1.tgz#3cf32b2a24f2435d527ebef1daa99b84396da4f8"
-  integrity sha512-jvX6h+lRhKaw18B46AQuwltDKIb06e1HxGaPpplFJS1vRrTs8Yvn1pP1BFUBhTgVD3/3zLlO+lD3IsUavJUqOg==
+"@dhis2/ui-core@^4.20.0", "@dhis2/ui-core@^4.6.1", "@dhis2/ui-core@^4.9.1":
+  version "4.20.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/ui-core/-/ui-core-4.20.0.tgz#1a92487fbaef674818397c9d0a388f40cd42ed85"
+  integrity sha512-iYTgcnJxUabBWbWcmeixtQIkWTniS/DMptSCq6leVeFToX4E0jVI/3MEe8fqcJ/JfyNPu57Gys2dxQ/YrNg9FA==
   dependencies:
     "@dhis2/prop-types" "^1.6.4"
-    "@popperjs/core" "^2.1.0"
+    "@popperjs/core" "^2.4.0"
     classnames "^2.2.6"
+    react-popper "^2.2.3"
+    resize-observer-polyfill "^1.5.1"
 
 "@dhis2/ui-widgets@^2.0.4":
   version "2.1.0"
@@ -1764,6 +1766,11 @@
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.1.1.tgz#12c572ab88ef7345b43f21883fca26631c223085"
   integrity sha512-sLqWxCzC5/QHLhziXSCAksBxHfOnQlhPRVgPK0egEw+ktWvG75T2k+aYWVjVh9+WKeT3tlG3ZNbZQvZLmfuOIw==
+
+"@popperjs/core@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.4.0.tgz#0e1bdf8d021e7ea58affade33d9d607e11365915"
+  integrity sha512-NMrDy6EWh9TPdSRiHmHH2ye1v5U0gBD7pRYwSwJvomx7Bm4GG04vu63dYiVzebLOx2obPpJugew06xVP0Nk7hA==
 
 "@reach/router@^1.2.1":
   version "1.3.3"
@@ -12683,6 +12690,11 @@ react-fast-compare@^2.0.4:
   resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-2.0.4.tgz#e84b4d455b0fec113e0402c329352715196f81f9"
   integrity sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw==
 
+react-fast-compare@^3.0.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/react-fast-compare/-/react-fast-compare-3.1.1.tgz#0becf31e3812fa70dc231e259f40d892d4767900"
+  integrity sha512-SCsAORWK59BvauR2L1BTdjQbJcSGJJz03U0awektk2hshLKrITDDFTlgGCqIZpTDlPC/NFlZee6xTMzXPVLiHw==
+
 react-focus-lock@^2.1.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.2.1.tgz#1d12887416925dc53481914b7cedd39494a3b24a"
@@ -12742,6 +12754,14 @@ react-popper@^1.3.6:
     popper.js "^1.14.4"
     prop-types "^15.6.1"
     typed-styles "^0.0.7"
+    warning "^4.0.2"
+
+react-popper@^2.2.3:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/react-popper/-/react-popper-2.2.3.tgz#33d425fa6975d4bd54d9acd64897a89d904b9d97"
+  integrity sha512-mOEiMNT1249js0jJvkrOjyHsGvqcJd3aGW/agkiMoZk3bZ1fXN1wQszIQSjHIai48fE67+zwF8Cs+C4fWqlfjw==
+  dependencies:
+    react-fast-compare "^3.0.1"
     warning "^4.0.2"
 
 react-redux@^5.0.7:


### PR DESCRIPTION
Part of the work for adding drilling feature to PT: https://jira.dhis2.org/browse/DHIS2-8769

Each value cell has now an onClick handler which is used to trigger a callback passed from the plugin and which receives a reference for positioning the context menu, and an object with the cell info.

This object is extended to contain also the ids of the org unit and the period which define the cell value.
(This would probably change with the refactor of the PT engine)

These parameters are then used by the `ContextualMenu` component in DV's plugin (for now, it can be moved out from the plugin and in `analytics`) for configuring the menu items.