### PR TITLE
fix: use pointer cursor style on clickable value cells

### DIFF
--- a/src/components/PivotTable/PivotTableValueCell.js
+++ b/src/components/PivotTable/PivotTableValueCell.js
@@ -47,10 +47,7 @@ export const PivotTableValueCell = ({
     }
 
     const onClick = () => {
-        if (
-            cellContent.cellType === CELL_TYPE_VALUE &&
-            cellContent.renderedValue
-        ) {
+        if (cellContent.cellType === CELL_TYPE_VALUE) {
             onToggleContextualMenu(cellRef, cellContent)
         }
     }

--- a/src/components/PivotTable/PivotTableValueCell.js
+++ b/src/components/PivotTable/PivotTableValueCell.js
@@ -38,17 +38,12 @@ export const PivotTableValueCell = ({
               )
             : undefined
 
-    const cursorStyle =
-        cellContent.cellType === CELL_TYPE_VALUE && cellContent.renderedValue
-            ? 'pointer'
-            : 'auto'
     const width = engine.columnWidths[engine.columnMap[column]].width
     const style = {
         ...legendStyle,
         width,
         minWidth: width,
         maxWidth: width,
-        cursor: cursorStyle,
     }
 
     const onClick = () => {

--- a/src/components/PivotTable/PivotTableValueCell.js
+++ b/src/components/PivotTable/PivotTableValueCell.js
@@ -38,12 +38,17 @@ export const PivotTableValueCell = ({
               )
             : undefined
 
+    const cursorStyle =
+        cellContent.cellType === CELL_TYPE_VALUE && cellContent.renderedValue
+            ? 'pointer'
+            : 'auto'
     const width = engine.columnWidths[engine.columnMap[column]].width
     const style = {
         ...legendStyle,
         width,
         minWidth: width,
         maxWidth: width,
+        cursor: cursorStyle,
     }
 
     const onClick = () => {

--- a/src/components/PivotTable/styles/PivotTable.style.js
+++ b/src/components/PivotTable/styles/PivotTable.style.js
@@ -86,6 +86,7 @@ export const cell = css`
     }
     .value {
         background-color: #ffffff;
+        cursor: pointer;
     }
     .TEXT {
         text-align: left;


### PR DESCRIPTION
Part of the work for adding drilling feature to PT: https://jira.dhis2.org/browse/DHIS2-8769

Use pointer style for the cursor when the value cell is clickable for drilling.

Always enable drilling also on empty value cells.