### PR TITLE
fix: disable onClick on value cells if no ouId

### DIFF
--- a/src/components/PivotTable/PivotTableValueCell.js
+++ b/src/components/PivotTable/PivotTableValueCell.js
@@ -33,7 +33,7 @@ export const PivotTableValueCell = ({
         return (
             <PivotTableEmptyCell
                 type={cellContent?.cellType}
-                onClick={onClick}
+                onClick={onToggleContextualMenu ? onClick : undefined}
                 ref={cellRef}
             />
         )
@@ -60,7 +60,7 @@ export const PivotTableValueCell = ({
 
     const classes = [cellContent.cellType, cellContent.valueType]
 
-    if (cellContent.ouId) {
+    if (onToggleContextualMenu && cellContent.ouId) {
         classes.push('clickable')
     }
     return (
@@ -69,7 +69,7 @@ export const PivotTableValueCell = ({
             classes={classes}
             title={cellContent.renderedValue}
             style={style}
-            onClick={onClick}
+            onClick={onToggleContextualMenu ? onClick : undefined}
             ref={cellRef}
         >
             {cellContent.renderedValue ?? null}

--- a/src/components/PivotTable/PivotTableValueCell.js
+++ b/src/components/PivotTable/PivotTableValueCell.js
@@ -66,7 +66,7 @@ export const PivotTableValueCell = ({
     return (
         <PivotTableCell
             key={column}
-            classes={classes} //[cellContent.cellType, cellContent.valueType, isClickable]}
+            classes={classes}
             title={cellContent.renderedValue}
             style={style}
             onClick={onClick}

--- a/src/components/PivotTable/PivotTableValueCell.js
+++ b/src/components/PivotTable/PivotTableValueCell.js
@@ -18,12 +18,6 @@ export const PivotTableValueCell = ({
     const engine = usePivotTableEngine()
     const cellRef = useRef(undefined)
 
-    const onClick = () => {
-        if (cellContent.cellType === CELL_TYPE_VALUE && cellContent.ouId) {
-            onToggleContextualMenu(cellRef, cellContent)
-        }
-    }
-
     const cellContent = engine.get({
         row,
         column,
@@ -58,18 +52,26 @@ export const PivotTableValueCell = ({
         maxWidth: width,
     }
 
-    const classes = [cellContent.cellType, cellContent.valueType]
-
-    if (onToggleContextualMenu && cellContent.ouId) {
-        classes.push('clickable')
+    const isClickable =
+        onToggleContextualMenu &&
+        cellContent.cellType === CELL_TYPE_VALUE &&
+        cellContent.ouId
+    const classes = [
+        cellContent.cellType,
+        cellContent.valueType,
+        isClickable && 'clickable',
+    ]
+    const onClick = () => {
+        onToggleContextualMenu(cellRef, cellContent)
     }
+
     return (
         <PivotTableCell
             key={column}
             classes={classes}
             title={cellContent.renderedValue}
             style={style}
-            onClick={onToggleContextualMenu ? onClick : undefined}
+            onClick={isClickable ? onClick : undefined}
             ref={cellRef}
         >
             {cellContent.renderedValue ?? null}

--- a/src/components/PivotTable/PivotTableValueCell.js
+++ b/src/components/PivotTable/PivotTableValueCell.js
@@ -19,7 +19,7 @@ export const PivotTableValueCell = ({
     const cellRef = useRef(undefined)
 
     const onClick = () => {
-        if (cellContent.cellType === CELL_TYPE_VALUE) {
+        if (cellContent.cellType === CELL_TYPE_VALUE && cellContent.ouId) {
             onToggleContextualMenu(cellRef, cellContent)
         }
     }
@@ -58,10 +58,15 @@ export const PivotTableValueCell = ({
         maxWidth: width,
     }
 
+    const classes = [cellContent.cellType, cellContent.valueType]
+
+    if (cellContent.ouId) {
+        classes.push('clickable')
+    }
     return (
         <PivotTableCell
             key={column}
-            classes={[cellContent.cellType, cellContent.valueType]}
+            classes={classes} //[cellContent.cellType, cellContent.valueType, isClickable]}
             title={cellContent.renderedValue}
             style={style}
             onClick={onClick}

--- a/src/components/PivotTable/styles/PivotTable.style.js
+++ b/src/components/PivotTable/styles/PivotTable.style.js
@@ -86,13 +86,15 @@ export const cell = css`
     }
     .value {
         background-color: #ffffff;
-        cursor: pointer;
     }
     .TEXT {
         text-align: left;
     }
     .NUMBER {
         text-align: right;
+    }
+    .clickable {
+        cursor: pointer;
     }
 
     .value:hover {


### PR DESCRIPTION
Right now we don't have support for period drill up/down, so in case ou
dimension is in filters, the contextual menu opens empty (peId is passed
if pe dimension is in rows/columns).