### PR TITLE
fix: onClick and classes props on PivotTableEmptyCell

### DIFF
--- a/src/components/PivotTable/PivotTableColumnHeaders.js
+++ b/src/components/PivotTable/PivotTableColumnHeaders.js
@@ -30,7 +30,7 @@ export const PivotTableColumnHeaders = ({
                 axisClippingResult={clippingResult.columns}
                 EmptyComponent={({ size }) => (
                     <PivotTableEmptyCell
-                        type="column-header"
+                        classes="column-header"
                         style={{ minWidth: size }}
                     />
                 )}

--- a/src/components/PivotTable/PivotTableEmptyCell.js
+++ b/src/components/PivotTable/PivotTableEmptyCell.js
@@ -1,20 +1,13 @@
 import React from 'react'
-import PropTypes from 'prop-types'
 import { cell as cellStyle } from './styles/PivotTable.style'
 import { PivotTableCell } from './PivotTableCell'
 
-export const PivotTableEmptyCell = React.forwardRef(
-    ({ type, ...props }, ref) => {
-        return (
-            <PivotTableCell ref={ref} className={type} {...props}>
-                <style jsx>{cellStyle}</style>
-            </PivotTableCell>
-        )
-    }
-)
+export const PivotTableEmptyCell = React.forwardRef(({ ...props }, ref) => {
+    return (
+        <PivotTableCell ref={ref} {...props}>
+            <style jsx>{cellStyle}</style>
+        </PivotTableCell>
+    )
+})
 
 PivotTableEmptyCell.displayName = 'PivotTableEmptyCell'
-
-PivotTableEmptyCell.propTypes = {
-    type: PropTypes.string.isRequired,
-}

--- a/src/components/PivotTable/PivotTableRow.js
+++ b/src/components/PivotTable/PivotTableRow.js
@@ -25,7 +25,7 @@ export const PivotTableRow = ({
             ))}
             <PivotTableClippedAxis
                 axisClippingResult={clippingResult.columns}
-                EmptyComponent={() => <PivotTableEmptyCell type="value" />}
+                EmptyComponent={() => <PivotTableEmptyCell classes="value" />}
                 ItemComponent={({ index: columnIndex }) => (
                     <PivotTableValueCell
                         row={rowIndex}

--- a/src/components/PivotTable/PivotTableValueCell.js
+++ b/src/components/PivotTable/PivotTableValueCell.js
@@ -23,12 +23,25 @@ export const PivotTableValueCell = ({
         column,
     })
 
+    const isClickable =
+        onToggleContextualMenu &&
+        cellContent.cellType === CELL_TYPE_VALUE &&
+        cellContent.ouId
+    const classes = [
+        cellContent.cellType,
+        cellContent.valueType,
+        isClickable && 'clickable',
+    ]
+    const onClick = () => {
+        onToggleContextualMenu(cellRef, cellContent)
+    }
+
     if (!cellContent || cellContent.empty) {
         return (
             <PivotTableEmptyCell
-                type={cellContent?.cellType}
-                onClick={onToggleContextualMenu ? onClick : undefined}
+                onClick={isClickable ? onClick : undefined}
                 ref={cellRef}
+                classes={[cellContent.cellType, isClickable && 'clickable']}
             />
         )
     }
@@ -50,19 +63,6 @@ export const PivotTableValueCell = ({
         width,
         minWidth: width,
         maxWidth: width,
-    }
-
-    const isClickable =
-        onToggleContextualMenu &&
-        cellContent.cellType === CELL_TYPE_VALUE &&
-        cellContent.ouId
-    const classes = [
-        cellContent.cellType,
-        cellContent.valueType,
-        isClickable && 'clickable',
-    ]
-    const onClick = () => {
-        onToggleContextualMenu(cellRef, cellContent)
     }
 
     return (


### PR DESCRIPTION
Correctly pass onClick handler to PivotTableEmptyCell.

Also refactored the component to use `classes` instead of `className` to allow for multiple classes.
For empty value cells, `clickable` class should be passed alongside the cell `type` one.