### PR TITLE
fix: data dimension spacing and crash (NO JIRA)

### DIFF
--- a/src/components/DataDimension/DataTypesSelector.js
+++ b/src/components/DataDimension/DataTypesSelector.js
@@ -11,7 +11,7 @@ export const DataTypes = ({ currentDataType, onChange }) => (
         <SingleSelectField
             label={i18n.t('Data Type')}
             selected={dataTypes[currentDataType]?.id}
-            onChange={ref => onChange(ref.selected.value)}
+            onChange={ref => onChange(ref.selected)}
             dense
         >
             {Object.values(dataTypes).map(type => (

--- a/src/components/DataDimension/Detail.js
+++ b/src/components/DataDimension/Detail.js
@@ -18,7 +18,7 @@ export const Detail = ({ currentValue, onChange }) => {
             <SingleSelectField
                 label={i18n.t('Detail')}
                 selected={currentValue}
-                onChange={ref => onChange(ref.selected.value)}
+                onChange={ref => onChange(ref.selected)}
                 dense
             >
                 {Object.entries(options).map(option => (

--- a/src/components/DataDimension/Groups.js
+++ b/src/components/DataDimension/Groups.js
@@ -35,7 +35,7 @@ export const Groups = ({
                             ? dataTypes[dataType].getPlaceholder()
                             : null
                     }
-                    onChange={ref => onGroupChange(ref.selected.value)}
+                    onChange={ref => onGroupChange(ref.selected)}
                     dense
                 >
                     {optionItems.map(item => (

--- a/src/components/DataDimension/styles/DataTypesSelector.style.js
+++ b/src/components/DataDimension/styles/DataTypesSelector.style.js
@@ -4,10 +4,7 @@ export default css`
     .container {
         display: flex;
         flex-flow: column;
-        height: 70px;
         border-bottom: 0;
-        padding-left: 10px;
-        padding-right: 5px;
-        padding-top: 5px;
+        padding: 5px 5px 10px 10px;
     }
 `

--- a/src/components/DataDimension/styles/Detail.style.js
+++ b/src/components/DataDimension/styles/Detail.style.js
@@ -4,8 +4,6 @@ export default css`
     .detail-container {
         display: flex;
         flex-flow: column;
-        width: 40%;
-        padding-right: 5px;
-        padding-left: 5px;
+        padding-left: 6px;
     }
 `

--- a/src/components/DataDimension/styles/Groups.style.js
+++ b/src/components/DataDimension/styles/Groups.style.js
@@ -8,15 +8,13 @@ export default css`
         min-height: 53px;
         border-right: 0;
         border-left: 0;
-        padding-top: 5px;
-        padding-left: 10px;
+        padding: 5px 5px 10px 10px;
     }
     .group-container {
         display: flex;
         flex-direction: column;
         width: inherit;
-        min-width: 294px;
+        min-width: 290px;
         flex-grow: 1;
-        padding-right: 5px;
     }
 `


### PR DESCRIPTION
`NO JIRA` as these issues should've been part of https://github.com/dhis2/analytics/pull/476

The Data dimension was still using the legacy way of handling selected items in `SingleSelect` from `ui`, causing selection to crash. This has been addressed by removing the `.value` from the selected option.

This fix also addresses a minor ui glitch with spacing in the select field area.
Correct spacing:

![image](https://user-images.githubusercontent.com/12590483/85002562-53884f00-b155-11ea-86ba-b0e4cbd75c08.png)

-----------------

![image](https://user-images.githubusercontent.com/12590483/85002537-4a977d80-b155-11ea-8b0d-a1ed045152fc.png)

-----------------

![image](https://user-images.githubusercontent.com/12590483/85002599-60a53e00-b155-11ea-841b-8eb3115facd4.png)
