### PR TITLE
fix: pass selected as part of options to Transfer (TECH-380, DHIS2-8807)

### DIFF
--- a/src/components/PeriodDimension/PeriodSelector.js
+++ b/src/components/PeriodDimension/PeriodSelector.js
@@ -153,7 +153,10 @@ class PeriodSelector extends Component {
             selectedWidth={TRANSFER_SELECTED_WIDTH}
             selectedEmptyComponent={this.renderEmptySelection()}
             rightFooter={this.props.rightFooter}
-            options={this.state.allPeriods.map(({ id, name }) => ({
+            options={[
+                ...this.state.allPeriods,
+                ...this.state.selectedPeriods,
+            ].map(({ id, name }) => ({
                 label: name,
                 value: id,
             }))}


### PR DESCRIPTION
The period selector cannot display selected items that aren't part of the current filter (i.e. period type).

As per https://github.com/dhis2/ui/issues/143, the suggestion to fix the [TECH-380](https://jira.dhis2.org/browse/TECH-380) is to add all `selected` items as part of the `options`, to make sure that `options` always contain all `selected` items. 

With this fix, selected items from multiple filters (i.e. period types) are shown simultaneously on the right, see screenshot below for example.

![image](https://user-images.githubusercontent.com/12590483/86446402-325a5d80-bd14-11ea-9453-960e4d749a64.png)
