### PR TITLE
feat: add vis type descriptions (DHIS2-7855)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-07-27T07:46:11.678Z\n"
-"PO-Revision-Date: 2020-07-27T07:46:11.678Z\n"
+"POT-Creation-Date: 2020-07-30T10:01:08.963Z\n"
+"PO-Revision-Date: 2020-07-30T10:01:08.963Z\n"
 
 msgid "Data Type"
 msgstr ""
@@ -416,6 +416,9 @@ msgstr ""
 msgid "Assigned Categories"
 msgstr ""
 
+msgid "Pivot table"
+msgstr ""
+
 msgid "Column"
 msgstr ""
 
@@ -452,7 +455,49 @@ msgstr ""
 msgid "Single value"
 msgstr ""
 
-msgid "Pivot table"
+msgid "View data and indicators in a manipulatable table."
+msgstr ""
+
+msgid ""
+"Compare sizes of related element, displayed vertically. Recommend period in "
+"filter."
+msgstr ""
+
+msgid ""
+"Compare parts of a whole against related elements, vertically. Recommend "
+"data or org. unit as series."
+msgstr ""
+
+msgid ""
+"Compare sizes of related elements, displayed horizontally. Recommend period "
+"in filter."
+msgstr ""
+
+msgid ""
+"Compare parts of a whole against related elements, horizontally. Recommend "
+"data or org. unit as series."
+msgstr ""
+
+msgid "Track or compare changes over time. Recommend period as the category."
+msgstr ""
+
+msgid ""
+"Compare parts of a whole at a single point in time. Recommend period in the "
+"filter."
+msgstr ""
+
+msgid "Compare several items against multiple variables."
+msgstr ""
+
+msgid ""
+"Compare a percentage indicator against a 100% scale. Recommend period in "
+"filter."
+msgstr ""
+
+msgid "Compare changes over time between multiple time periods."
+msgstr ""
+
+msgid "Display a single value. Recommend relative period to show latest data."
 msgstr ""
 
 msgid "Target"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/analytics",
-    "version": "8.0.0",
+    "version": "8.1.0-alpha.1",
     "main": "./build/cjs/lib.js",
     "module": "./build/es/lib.js",
     "sideEffects": [

--- a/src/index.js
+++ b/src/index.js
@@ -121,6 +121,7 @@ export {
     VIS_TYPE_SINGLE_VALUE,
     VIS_TYPE_PIVOT_TABLE,
     visTypeDisplayNames,
+    visTypeDescriptions,
     visTypeIcons,
     getDisplayNameByVisType,
     defaultVisType,

--- a/src/modules/visTypes.js
+++ b/src/modules/visTypes.js
@@ -29,6 +29,7 @@ export const VIS_TYPE_SINGLE_VALUE = 'SINGLE_VALUE'
 export const VIS_TYPE_PIVOT_TABLE = 'PIVOT_TABLE'
 
 export const visTypeDisplayNames = {
+    [VIS_TYPE_PIVOT_TABLE]: i18n.t('Pivot table'),
     [VIS_TYPE_COLUMN]: i18n.t('Column'),
     [VIS_TYPE_STACKED_COLUMN]: i18n.t('Stacked column'),
     [VIS_TYPE_BAR]: i18n.t('Bar'),
@@ -41,10 +42,52 @@ export const visTypeDisplayNames = {
     [VIS_TYPE_YEAR_OVER_YEAR_LINE]: i18n.t('Year over year (line)'),
     [VIS_TYPE_YEAR_OVER_YEAR_COLUMN]: i18n.t('Year over year (column)'),
     [VIS_TYPE_SINGLE_VALUE]: i18n.t('Single value'),
-    [VIS_TYPE_PIVOT_TABLE]: i18n.t('Pivot table'),
+}
+
+export const visTypeDescriptions = {
+    [VIS_TYPE_PIVOT_TABLE]: i18n.t(
+        'View data and indicators in a manipulatable table.'
+    ),
+    [VIS_TYPE_COLUMN]: i18n.t(
+        'Compare sizes of related element, displayed vertically. Recommend period in filter.'
+    ),
+    [VIS_TYPE_STACKED_COLUMN]: i18n.t(
+        'Compare parts of a whole against related elements, vertically. Recommend data or org. unit as series.'
+    ),
+    [VIS_TYPE_BAR]: i18n.t(
+        'Compare sizes of related elements, displayed horizontally. Recommend period in filter.'
+    ),
+    [VIS_TYPE_STACKED_BAR]: i18n.t(
+        'Compare parts of a whole against related elements, horizontally. Recommend data or org. unit as series.'
+    ),
+    [VIS_TYPE_LINE]: i18n.t(
+        'Track or compare changes over time. Recommend period as the category.'
+    ),
+    [VIS_TYPE_AREA]: i18n.t(
+        'Track or compare changes over time. Recommend period as the category.'
+    ),
+    [VIS_TYPE_PIE]: i18n.t(
+        'Compare parts of a whole at a single point in time. Recommend period in the filter.'
+    ),
+    [VIS_TYPE_RADAR]: i18n.t(
+        'Compare several items against multiple variables.'
+    ),
+    [VIS_TYPE_GAUGE]: i18n.t(
+        'Compare a percentage indicator against a 100% scale. Recommend period in filter.'
+    ),
+    [VIS_TYPE_YEAR_OVER_YEAR_LINE]: i18n.t(
+        'Compare changes over time between multiple time periods.'
+    ),
+    [VIS_TYPE_YEAR_OVER_YEAR_COLUMN]: i18n.t(
+        'Compare changes over time between multiple time periods.'
+    ),
+    [VIS_TYPE_SINGLE_VALUE]: i18n.t(
+        'Display a single value. Recommend relative period to show latest data.'
+    ),
 }
 
 export const visTypeIcons = {
+    [VIS_TYPE_PIVOT_TABLE]: PivotTableIcon,
     [VIS_TYPE_BAR]: BarIcon,
     [VIS_TYPE_STACKED_BAR]: StackedBarIcon,
     [VIS_TYPE_COLUMN]: ColumnIcon,
@@ -57,7 +100,6 @@ export const visTypeIcons = {
     [VIS_TYPE_YEAR_OVER_YEAR_LINE]: YearOverYearLineIcon,
     [VIS_TYPE_YEAR_OVER_YEAR_COLUMN]: YearOverYearColumnIcon,
     [VIS_TYPE_SINGLE_VALUE]: SingleValueIcon,
-    [VIS_TYPE_PIVOT_TABLE]: PivotTableIcon,
 }
 
 export const getDisplayNameByVisType = visType => {


### PR DESCRIPTION
**WIP: @dhis2/analytics@8.1.0-alpha**

Implements [DHIS2-7855](https://jira.dhis2.org/browse/DHIS2-7855)
Based on [spec](https://sleepy-yalow-3c0c76.netlify.app/type-selector), [code](https://github.com/dhis2/design-specs/blob/master/src/components/type-selector.js)


- Adds descriptions to vis types
- Moves `Pivot Table` to the start of the list