### PR TITLE
feat: move and export hasCustomAxes (DHIS2-9010)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/analytics",
-    "version": "8.3.0-alpha.1",
+    "version": "8.3.0-alpha.2",
     "main": "./build/cjs/lib.js",
     "module": "./build/es/lib.js",
     "sideEffects": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/analytics",
-    "version": "8.0.1",
+    "version": "8.3.0-alpha.1",
     "main": "./build/cjs/lib.js",
     "module": "./build/es/lib.js",
     "sideEffects": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/analytics",
-    "version": "8.3.0-alpha.2",
+    "version": "8.3.0-alpha.3",
     "main": "./build/cjs/lib.js",
     "module": "./build/es/lib.js",
     "sideEffects": [

--- a/src/index.js
+++ b/src/index.js
@@ -25,7 +25,11 @@ export { apiFetchDimensions, apiFetchRecommendedIds } from './api/dimensions'
 
 // Modules: axis
 
-export { getAxisName, getAxisNameByLayoutType } from './modules/axis'
+export {
+    getAxisName,
+    getAxisNameByLayoutType,
+    hasCustomAxes,
+} from './modules/axis'
 
 // Modules: predefined dimensions
 

--- a/src/modules/axis.js
+++ b/src/modules/axis.js
@@ -38,3 +38,7 @@ export const getAxisNameByLayoutType = (axisId, layoutType) => {
 
 export const getAxisName = axisId =>
     getAxisNameByLayoutType(axisId, LAYOUT_TYPE_DEFAULT)
+
+export function hasCustomAxes(series) {
+    return series?.length && series.some(item => item.axis > 0)
+}

--- a/src/modules/axis.js
+++ b/src/modules/axis.js
@@ -39,6 +39,5 @@ export const getAxisNameByLayoutType = (axisId, layoutType) => {
 export const getAxisName = axisId =>
     getAxisNameByLayoutType(axisId, LAYOUT_TYPE_DEFAULT)
 
-export function hasCustomAxes(series) {
-    return series?.length && series.some(item => item.axis > 0)
-}
+export const hasCustomAxes = series =>
+    Boolean(series?.length && series.some(item => item.axis > 0))

--- a/src/visualizations/config/adapters/dhis_highcharts/customAxes.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/customAxes.js
@@ -26,22 +26,6 @@ export function getFullIdAxisMap(customAxes = [], series = []) {
     return idAxisMap
 }
 
-// returns: true or false
-export function hasCustomAxes(series) {
-    return series?.length && series.some(item => item.axis > 0)
-}
-
-// returns: true or false
-export function hasCustomAxesItems(series, columns) {
-    const axisIds = Object.keys(getIdAxisMap(series))
-    const seriesIds = columns.reduce((all, dim) => {
-        all.push(...dim.items.map(item => item.id))
-        return all
-    }, [])
-
-    return axisIds.find(id => seriesIds.includes(id))
-}
-
 // returns:
 // {
 //     0: ['a', 'b'],

--- a/src/visualizations/config/adapters/dhis_highcharts/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/index.js
@@ -9,11 +9,12 @@ import getSubtitle from './subtitle'
 import getLegend from './legend'
 import getPane from './pane'
 import getNoData from './noData'
-import { isStacked } from '../../../../modules/visTypes'
+import { isStacked, isDualAxisType } from '../../../../modules/visTypes'
 import getSortedConfig from './getSortedConfig'
 import getTrimmedConfig from './getTrimmedConfig'
 import addTrendLines, { isRegressionIneligible } from './addTrendLines'
 import { defaultMultiAxisTheme1 } from '../../../util/colors/themes'
+import { hasCustomAxes } from '../../../../modules/axis'
 
 const getTransformedLayout = layout => ({
     ...layout,
@@ -115,12 +116,16 @@ export default function({ store, layout, el, extraConfig, extraOptions }) {
         config = getSortedConfig(config, _layout, stacked)
     }
 
+    // DHIS2-9010 prevent trend lines from render when using multiple axes
+    const filteredSeries = layout.series.filter(layoutSeriesItem => series.some(seriesItem => seriesItem.id === layoutSeriesItem.dimensionItem))
+
     // DHIS2-1243 add trend lines after sorting
     // trend line on pie and gauge does not make sense
     if (
         isString(_layout.regressionType) &&
         _layout.regressionType !== 'NONE' &&
-        !isRegressionIneligible(_layout.type)
+        !isRegressionIneligible(_layout.type) &&
+        !(isDualAxisType(layout.type) && hasCustomAxes(filteredSeries))
     ) {
         config.series = addTrendLines(
             _layout.regressionType,

--- a/src/visualizations/config/adapters/dhis_highcharts/series/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/index.js
@@ -5,7 +5,6 @@ import getType from '../type'
 import {
     getFullIdAxisMap,
     getAxisIdsMap,
-    hasCustomAxes,
 } from '../customAxes'
 import { generateColors } from '../../../../util/colors/gradientColorGenerator'
 import {
@@ -15,6 +14,7 @@ import {
     isYearOverYear,
     VIS_TYPE_LINE,
 } from '../../../../../modules/visTypes'
+import { hasCustomAxes } from '../../../../../modules/axis'
 import { getAxisStringFromId } from '../../../../util/axisId'
 
 const DEFAULT_ANIMATION_DURATION = 200

--- a/src/visualizations/config/adapters/dhis_highcharts/yAxis/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/yAxis/index.js
@@ -7,7 +7,8 @@ import isString from 'd2-utilizr/lib/isString'
 import getAxisTitle from '../getAxisTitle'
 import getGauge from './gauge'
 import { isStacked, VIS_TYPE_GAUGE, isDualAxisType } from '../../../../../modules/visTypes'
-import { hasCustomAxes, getAxisIdsMap } from '../customAxes'
+import { hasCustomAxes } from '../../../../../modules/axis'
+import { getAxisIdsMap } from '../customAxes'
 import { getAxisStringFromId } from '../../../../util/axisId'
 
 const DEFAULT_MIN_VALUE = 0


### PR DESCRIPTION
**WIP: @dhis2/analytics@8.3.0-alpha**

Relates to https://github.com/dhis2/data-visualizer-app/pull/1171

Exports `hasCustomAxes` to be used in DV for [DHIS2-9010](https://jira.dhis2.org/browse/DHIS2-9010).
As `hasCustomAxes` used to be part of the highcharts config which made it hard to be exported, it's been moved to the `axis` module. Also fixes a bug with trend lines and custom axes.

- Moves `hasCustomAxes`
- Exports `hasCustomAxes`
- Removes `hasCustomAxesItems` (unused, legacy?)
- Prevents trend lines from rendering based on `hasCustomAxes`