### PR TITLE
fix: enable multi axis for Area (DHIS2-9011)

### DIFF
--- a/src/modules/visTypes.js
+++ b/src/modules/visTypes.js
@@ -130,7 +130,12 @@ const yearOverYearTypes = [
     VIS_TYPE_YEAR_OVER_YEAR_COLUMN,
 ]
 
-const dualAxisTypes = [VIS_TYPE_COLUMN, VIS_TYPE_BAR, VIS_TYPE_LINE]
+const dualAxisTypes = [
+    VIS_TYPE_COLUMN,
+    VIS_TYPE_BAR,
+    VIS_TYPE_LINE,
+    VIS_TYPE_AREA,
+]
 
 const twoCategoryChartTypes = [
     VIS_TYPE_COLUMN,


### PR DESCRIPTION
Fixes [DHIS2-9011](https://jira.dhis2.org/browse/DHIS2-9011).

Required by [@dhis2/data-visualizer-app PR 1192](https://github.com/dhis2/data-visualizer-app/pull/1192).

Since we now differentiate between `Area` and `Stacked area`, multi axis can be enabled for `Area` (no stacking).