### PR TITLE
fix: Multi-axis colors incorrect (DHIS2-9220)

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/series/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/index.js
@@ -66,12 +66,11 @@ function getIdColorMap(series, layout, extraOptions) {
 
         const colorsByAxis = Object.keys(axisIdsMap).reduce((map, axis) => {
             const numberOfIds = axisIdsMap[axis].length
-            map[axis] = generateColors(
+            map[axis] = numberOfIds > 1 ? generateColors(
                 theme[axis].startColor,
                 theme[axis].endColor,
-                numberOfIds,
-                true
-            )
+                numberOfIds
+            ) : [theme[axis].mainColor]
             return map
         }, {})
 

--- a/src/visualizations/util/colors/gradientColorGenerator.js
+++ b/src/visualizations/util/colors/gradientColorGenerator.js
@@ -1,59 +1,44 @@
-function hex(c) {
-    var s = '0123456789abcdef'
-    var i = parseInt(c)
+const hex = (c) => {
+    const s = "0123456789abcdef";
+    let i = parseInt(c, 10);
     if (i === 0 || isNaN(c)) {
-        return '00'
+      return "00";
     }
-    i = Math.round(Math.min(Math.max(0, i), 255))
-    return s.charAt((i - (i % 16)) / 16) + s.charAt(i % 16)
-}
-
-/* Convert an RGB triplet to a hex string */
-function convertToHex(rgb) {
-    return hex(rgb[0]) + hex(rgb[1]) + hex(rgb[2])
-}
-
-/* Remove '#' in color hex string */
-function trim(s) {
-    return s.charAt(0) === '#' ? s.substring(1, 7) : s
-}
-
-/* Convert a hex string to an RGB triplet */
-function convertToRGB(hex) {
-    var color = []
-    color[0] = parseInt(trim(hex).substring(0, 2), 16)
-    color[1] = parseInt(trim(hex).substring(2, 4), 16)
-    color[2] = parseInt(trim(hex).substring(4, 6), 16)
-    return color
-}
-
-export function generateColors(colorStart, colorEnd, colorCount, addHash) {
-    // The beginning of your gradient
-    var start = convertToRGB(colorStart)
-
-    // The end of your gradient
-    var end = convertToRGB(colorEnd)
-
-    // The number of colors to compute
-    var len = colorCount
-
-    //Alpha blending amount
-    var alpha = 0.0
-
-    var saida = []
-
-    var i
-
-    for (i = 0; i < len; i++) {
-        var c = []
-        alpha += 1.0 / len
-
-        c[0] = start[0] * alpha + (1 - alpha) * end[0]
-        c[1] = start[1] * alpha + (1 - alpha) * end[1]
-        c[2] = start[2] * alpha + (1 - alpha) * end[2]
-
-        saida.push((addHash ? '#' : '') + convertToHex(c))
+    i = Math.round(Math.min(Math.max(0, i), 255));
+    return s.charAt((i - (i % 16)) / 16) + s.charAt(i % 16);
+  };
+  
+  /* Convert an RGB triplet to a hex string */
+  const convertToHex = (rgb) => hex(rgb[0]) + hex(rgb[1]) + hex(rgb[2]);
+  
+  /* Remove '#' in color hex string */
+  const trim = (s) => (s.charAt(0) === "#" ? s.substring(1, 7) : s);
+  
+  /* Convert a hex string to an RGB triplet */
+  const convertToRGB = (hex) => {
+    const color = [];
+    color[0] = parseInt(trim(hex).substring(0, 2), 16);
+    color[1] = parseInt(trim(hex).substring(2, 4), 16);
+    color[2] = parseInt(trim(hex).substring(4, 6), 16);
+    return color;
+  };
+  
+  export const generateColors = (colorStart, colorEnd, colorCount, addHash) => {
+    const start = convertToRGB(colorStart), // The beginning of gradient
+        end = convertToRGB(colorEnd), // The end of gradient
+        result = [];
+    let alpha = 0.0; //Alpha blending amount
+  
+    for (let i = 0; i < colorCount; i++) {
+      const colors = [];
+      alpha += 1.0 / colorCount;
+  
+      colors[0] = start[0] * alpha + (1 - alpha) * end[0];
+      colors[1] = start[1] * alpha + (1 - alpha) * end[1];
+      colors[2] = start[2] * alpha + (1 - alpha) * end[2];
+  
+      result.push((addHash ? "#" : "") + convertToHex(colors));
     }
-
-    return saida
-}
+  
+    return result;
+  };

--- a/src/visualizations/util/colors/gradientColorGenerator.js
+++ b/src/visualizations/util/colors/gradientColorGenerator.js
@@ -1,44 +1,35 @@
-const hex = (c) => {
-    const s = "0123456789abcdef";
-    let i = parseInt(c, 10);
-    if (i === 0 || isNaN(c)) {
-      return "00";
+export const generateColors = (start, end, steps) => {
+    if (!end || !steps || steps < 2) {
+      return [start];
     }
-    i = Math.round(Math.min(Math.max(0, i), 255));
-    return s.charAt((i - (i % 16)) / 16) + s.charAt(i % 16);
-  };
+    const stepFactor = 1 / (steps - 1),
+      result = [];
   
-  /* Convert an RGB triplet to a hex string */
-  const convertToHex = (rgb) => hex(rgb[0]) + hex(rgb[1]) + hex(rgb[2]);
+    for (let step = 0; step < steps; step++) {
+      const color1 = convertHexToRGB(start),
+        color2 = convertHexToRGB(end),
+        factor = stepFactor * step;
   
-  /* Remove '#' in color hex string */
-  const trim = (s) => (s.charAt(0) === "#" ? s.substring(1, 7) : s);
-  
-  /* Convert a hex string to an RGB triplet */
-  const convertToRGB = (hex) => {
-    const color = [];
-    color[0] = parseInt(trim(hex).substring(0, 2), 16);
-    color[1] = parseInt(trim(hex).substring(2, 4), 16);
-    color[2] = parseInt(trim(hex).substring(4, 6), 16);
-    return color;
-  };
-  
-  export const generateColors = (colorStart, colorEnd, colorCount, addHash) => {
-    const start = convertToRGB(colorStart), // The beginning of gradient
-        end = convertToRGB(colorEnd), // The end of gradient
-        result = [];
-    let alpha = 0.0; //Alpha blending amount
-  
-    for (let i = 0; i < colorCount; i++) {
-      const colors = [];
-      alpha += 1.0 / colorCount;
-  
-      colors[0] = start[0] * alpha + (1 - alpha) * end[0];
-      colors[1] = start[1] * alpha + (1 - alpha) * end[1];
-      colors[2] = start[2] * alpha + (1 - alpha) * end[2];
-  
-      result.push((addHash ? "#" : "") + convertToHex(colors));
+      const rgbArray = color1.slice();
+      rgbArray.forEach(
+        (part, index, array) =>
+          (array[index] = Math.round(
+            part + factor * (color2[index] - color1[index])
+          ))
+      );
+      result.push(convertRGBToHex(rgbArray));
     }
   
     return result;
   };
+  
+  const convertRGBToHex = (rgb) =>
+    "#" +
+    ((1 << 24) + (rgb[0] << 16) + (rgb[1] << 8) + rgb[2]).toString(16).slice(1);
+  
+  const convertHexToRGB = (hex) =>
+    hex
+      .replace(/^#/, "")
+      .match(/.{1,2}/g)
+      .map((val) => parseInt(val, 16));
+  


### PR DESCRIPTION
Fixes [DHIS2-9220](https://jira.dhis2.org/browse/DHIS2-9220)
Based on [PoC](https://codesandbox.io/s/gradient-generator-4qz5j?file=/src/App.js), [snippet](https://runkit.com/martinkrulltott/5f3ba0115eda78001abfc9a7)

The colors for multi-axis were generated incorrectly, resulting in incorrectly colored visualizations.
The spec for selecting colors is:

> 1 item = mainColor
> 2 items = startColor, endColor
> n items = startColor ... n-2 ... endColor

The generator has been rewritten from scratch, using modern JS syntax, to honor the logic in the spec above.

-------------
The screenshot below showcases the following:

- 6 items: Start color + 4 + end color
- 1 item: Main color
- 2 items: Start color + end color
- 3 items: Start color + 1 + end color

![image](https://user-images.githubusercontent.com/12590483/90513264-a2576280-e15f-11ea-8c69-4c2b9dc1b2c9.png)

-------------

**Old vs New**

Old 1
![image](https://user-images.githubusercontent.com/12590483/90514123-09294b80-e161-11ea-9ee8-dfb54ab02394.png)

New 1
![image](https://user-images.githubusercontent.com/12590483/90512812-02013e00-e15f-11ea-8531-03b0259523be.png)

-------------

Old 2
![image](https://user-images.githubusercontent.com/12590483/90514178-1d6d4880-e161-11ea-87ab-c03d287a075f.png)


New 2
![image](https://user-images.githubusercontent.com/12590483/90513933-bea7cf00-e160-11ea-9935-f8acbedb5dc5.png)

-------------

Old 3
![image](https://user-images.githubusercontent.com/12590483/90514354-5d343000-e161-11ea-9635-367411877733.png)

New 3
![image](https://user-images.githubusercontent.com/12590483/90514387-68875b80-e161-11ea-8dd9-527612300763.png)
