### PR TITLE
fix: remove manage axis divider (DHIS2-6385)

### DIFF
--- a/src/components/DimensionMenu.js
+++ b/src/components/DimensionMenu.js
@@ -84,11 +84,6 @@ export class DimensionMenu extends Component {
             closeSubMenu()
         }
 
-        // divider
-        if (applicableAxisIds.length) {
-            menuItems.push(getDividerItem('dual-axis-item-divider'))
-        }
-
         // Assigned categories
         if (
             dimensionId === DIMENSION_ID_DATA &&


### PR DESCRIPTION
Related to [DHIS2-6385](https://jira.dhis2.org/browse/DHIS2-6385).

After moving the "Manage axis" from the contextual menu, a divider was still shown at the top of the menu.

Before:
![image (1)](https://user-images.githubusercontent.com/150978/90518026-80ada980-e166-11ea-8271-a398c1e0050f.png)

After:
![Screenshot 2020-08-18 at 15 19 55](https://user-images.githubusercontent.com/150978/90518051-8905e480-e166-11ea-8efd-f5396400515b.png)
