### PR TITLE
fix: Remove deep cloning from fontStyle (DHIS2-8426)

### DIFF
--- a/src/modules/fontStyle.js
+++ b/src/modules/fontStyle.js
@@ -1,6 +1,5 @@
 /*eslint no-unused-vars: ["error", { "ignoreRestSiblings": true }]*/
 import i18n from '@dhis2/d2-i18n'
-import cloneDeep from 'lodash/cloneDeep'
 
 // Font styles
 export const FONT_STYLE_VISUALIZATION_TITLE = 'visualizationTitle'
@@ -193,7 +192,7 @@ export const mergeFontStyleWithDefault = fontStyle => {
 }
 
 export const deleteFontStyleOption = (inputFontStyle, fontStyleKey, option) => {
-    let fontStyle = cloneDeep(inputFontStyle)
+    let fontStyle = { ...inputFontStyle }
     if (fontStyle[fontStyleKey]) {
         const { [option]: remove, ...rest } = fontStyle[fontStyleKey]
         fontStyle[fontStyleKey] = { ...rest }

--- a/src/modules/fontStyle.js
+++ b/src/modules/fontStyle.js
@@ -182,12 +182,11 @@ export const defaultFontStyle = {
 }
 
 export const mergeFontStyleWithDefault = fontStyle => {
-    const result = cloneDeep(defaultFontStyle)
+    const result = { ...defaultFontStyle }
     for (const style in fontStyle) {
-        for (const option in fontStyle[style]) {
-            if (result[style]) {
-                result[style][option] = fontStyle[style][option]
-            }
+        result[style] = {
+            ...result[style],
+            ...fontStyle[style],
         }
     }
     return result

--- a/src/modules/fontStyle.js
+++ b/src/modules/fontStyle.js
@@ -192,19 +192,13 @@ export const mergeFontStyleWithDefault = fontStyle => {
 }
 
 export const deleteFontStyleOption = (inputFontStyle, fontStyleKey, option) => {
-    let fontStyle = { ...inputFontStyle }
-    if (fontStyle[fontStyleKey]) {
-        const { [option]: remove, ...rest } = fontStyle[fontStyleKey]
-        fontStyle[fontStyleKey] = { ...rest }
-
-        if (!Object.keys(fontStyle[fontStyleKey]).length) {
-            const { [fontStyleKey]: remove, ...rest } = fontStyle
-            fontStyle = { ...rest }
-        }
+    const style = {
+        ...inputFontStyle,
+        [fontStyleKey]: {
+            ...inputFontStyle[fontStyleKey],
+        },
     }
-    if (!Object.keys(fontStyle).length) {
-        fontStyle = null
-    }
-
-    return fontStyle
+    style[fontStyleKey] && delete style[fontStyleKey][option]
+    !Object.keys(style[fontStyleKey]).length && delete style[fontStyleKey]
+    return Object.keys(style).length ? style : null
 }


### PR DESCRIPTION
`fontStyle` (introduced in [DHIS2-8426](https://jira.dhis2.org/browse/DHIS2-8426)) is a nested object which means that it can't be shallow copied without risking changing the children of the original object. This was previously solved by using `cloneDeep`.

This change removes the deep clone from the `fontStyle` handling, since it's an expensive operation that can quite easily be avoided for this particular object (since it's only 2 levels deep). As suggested by @janhenrikoverland 