### PR TITLE
fix: implement digit group separator in SV

### DIFF
--- a/src/visualizations/config/adapters/dhis_dhis/index.js
+++ b/src/visualizations/config/adapters/dhis_dhis/index.js
@@ -1,5 +1,6 @@
 import getTitle from './title'
 import getSubtitle from './subtitle'
+import getValue from './value'
 
 export default function({ store, layout, extraOptions }) {
     const data = store.generateData({
@@ -12,10 +13,8 @@ export default function({ store, layout, extraOptions }) {
             layout.rows && layout.rows.length ? layout.rows[0].dimension : null,
     })
 
-    const value = data[0] === undefined ? extraOptions.noData.text : data[0]
-
     const config = {
-        value: value,
+        value: getValue(data[0], layout, store.data[0].metaData, extraOptions),
         title: getTitle(layout, store.data[0].metaData, extraOptions.dashboard),
         subtitle: getSubtitle(
             layout,

--- a/src/visualizations/config/adapters/dhis_dhis/value/index.js
+++ b/src/visualizations/config/adapters/dhis_dhis/value/index.js
@@ -1,0 +1,12 @@
+import { renderValue } from '../../../../../modules/pivotTable/renderValue'
+import { VALUE_TYPE_TEXT } from '../../../../../modules/pivotTable/pivotTableConstants'
+
+export default function(value, layout, metaData, extraOptions) {
+    const valueType = metaData.items[metaData.dimensions.dx[0]].valueType
+    return (
+        renderValue(value, valueType || VALUE_TYPE_TEXT, {
+            digitGroupSeparator: layout.digitGroupSeparator,
+            skipRounding: layout.skipRounding,
+        }) || extraOptions.noData.text
+    )
+}

--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -1,15 +1,15 @@
 import { getColorByValueFromLegendSet } from '../../../../modules/legends'
-import { 
-    FONT_STYLE_VISUALIZATION_TITLE, 
+import {
+    FONT_STYLE_VISUALIZATION_TITLE,
     FONT_STYLE_VISUALIZATION_SUBTITLE,
-    FONT_STYLE_OPTION_FONT_SIZE, 
-    FONT_STYLE_OPTION_TEXT_COLOR, 
-    FONT_STYLE_OPTION_TEXT_ALIGN, 
-    FONT_STYLE_OPTION_ITALIC, 
-    FONT_STYLE_OPTION_BOLD, 
-    TEXT_ALIGN_LEFT, 
-    TEXT_ALIGN_RIGHT, 
-    TEXT_ALIGN_CENTER 
+    FONT_STYLE_OPTION_FONT_SIZE,
+    FONT_STYLE_OPTION_TEXT_COLOR,
+    FONT_STYLE_OPTION_TEXT_ALIGN,
+    FONT_STYLE_OPTION_ITALIC,
+    FONT_STYLE_OPTION_BOLD,
+    TEXT_ALIGN_LEFT,
+    TEXT_ALIGN_RIGHT,
+    TEXT_ALIGN_CENTER,
 } from '../../../../modules/fontStyle'
 
 const svgNS = 'http://www.w3.org/2000/svg'
@@ -30,7 +30,9 @@ const generateValueSVG = (value, legendSet, y) => {
         svgValue.setAttribute('y', y)
     }
 
-    const fillColor = legendSet ? getColorByValueFromLegendSet(legendSet, value) : defaultFillColor
+    const fillColor = legendSet
+        ? getColorByValueFromLegendSet(legendSet, value)
+        : defaultFillColor
 
     const text = document.createElementNS(svgNS, 'text')
     text.setAttribute('text-anchor', 'middle')
@@ -116,12 +118,31 @@ const generateDVItem = (config, legendSet, parentEl, fontStyle) => {
 
     const title = document.createElementNS(svgNS, 'text')
     const titleFontStyle = fontStyle[FONT_STYLE_VISUALIZATION_TITLE]
-    title.setAttribute('x', getXFromTextAlign(titleFontStyle[FONT_STYLE_OPTION_TEXT_ALIGN]))
+    title.setAttribute(
+        'x',
+        getXFromTextAlign(titleFontStyle[FONT_STYLE_OPTION_TEXT_ALIGN])
+    )
     title.setAttribute('y', 28)
-    title.setAttribute('text-anchor', getTextAnchorFromTextAlign(titleFontStyle[FONT_STYLE_OPTION_TEXT_ALIGN]))
-    title.setAttribute('font-size', `${titleFontStyle[FONT_STYLE_OPTION_FONT_SIZE]}px`)
-    title.setAttribute('font-weight', titleFontStyle[FONT_STYLE_OPTION_BOLD] ? FONT_STYLE_OPTION_BOLD : 'normal')
-    title.setAttribute('font-style', titleFontStyle[FONT_STYLE_OPTION_ITALIC] ? FONT_STYLE_OPTION_ITALIC : 'normal')
+    title.setAttribute(
+        'text-anchor',
+        getTextAnchorFromTextAlign(titleFontStyle[FONT_STYLE_OPTION_TEXT_ALIGN])
+    )
+    title.setAttribute(
+        'font-size',
+        `${titleFontStyle[FONT_STYLE_OPTION_FONT_SIZE]}px`
+    )
+    title.setAttribute(
+        'font-weight',
+        titleFontStyle[FONT_STYLE_OPTION_BOLD]
+            ? FONT_STYLE_OPTION_BOLD
+            : 'normal'
+    )
+    title.setAttribute(
+        'font-style',
+        titleFontStyle[FONT_STYLE_OPTION_ITALIC]
+            ? FONT_STYLE_OPTION_ITALIC
+            : 'normal'
+    )
     title.setAttribute('fill', titleFontStyle[FONT_STYLE_OPTION_TEXT_COLOR])
 
     if (config.title) {
@@ -132,14 +153,38 @@ const generateDVItem = (config, legendSet, parentEl, fontStyle) => {
 
     const subtitleFontStyle = fontStyle[FONT_STYLE_VISUALIZATION_SUBTITLE]
     const subtitle = document.createElementNS(svgNS, 'text')
-    subtitle.setAttribute('x', getXFromTextAlign(subtitleFontStyle[FONT_STYLE_OPTION_TEXT_ALIGN]))
+    subtitle.setAttribute(
+        'x',
+        getXFromTextAlign(subtitleFontStyle[FONT_STYLE_OPTION_TEXT_ALIGN])
+    )
     subtitle.setAttribute('y', 28)
     subtitle.setAttribute('dy', 22)
-    subtitle.setAttribute('text-anchor', getTextAnchorFromTextAlign(subtitleFontStyle[FONT_STYLE_OPTION_TEXT_ALIGN]))
-    subtitle.setAttribute('font-size', `${subtitleFontStyle[FONT_STYLE_OPTION_FONT_SIZE]}px`)
-    subtitle.setAttribute('font-weight', subtitleFontStyle[FONT_STYLE_OPTION_BOLD] ? FONT_STYLE_OPTION_BOLD : 'normal')
-    subtitle.setAttribute('font-style', subtitleFontStyle[FONT_STYLE_OPTION_ITALIC] ? FONT_STYLE_OPTION_ITALIC : 'normal')
-    subtitle.setAttribute('fill', subtitleFontStyle[FONT_STYLE_OPTION_TEXT_COLOR])
+    subtitle.setAttribute(
+        'text-anchor',
+        getTextAnchorFromTextAlign(
+            subtitleFontStyle[FONT_STYLE_OPTION_TEXT_ALIGN]
+        )
+    )
+    subtitle.setAttribute(
+        'font-size',
+        `${subtitleFontStyle[FONT_STYLE_OPTION_FONT_SIZE]}px`
+    )
+    subtitle.setAttribute(
+        'font-weight',
+        subtitleFontStyle[FONT_STYLE_OPTION_BOLD]
+            ? FONT_STYLE_OPTION_BOLD
+            : 'normal'
+    )
+    subtitle.setAttribute(
+        'font-style',
+        subtitleFontStyle[FONT_STYLE_OPTION_ITALIC]
+            ? FONT_STYLE_OPTION_ITALIC
+            : 'normal'
+    )
+    subtitle.setAttribute(
+        'fill',
+        subtitleFontStyle[FONT_STYLE_OPTION_TEXT_COLOR]
+    )
     if (config.subtitle) {
         subtitle.appendChild(document.createTextNode(config.subtitle))
 
@@ -151,7 +196,11 @@ const generateDVItem = (config, legendSet, parentEl, fontStyle) => {
     return svg
 }
 
-export default function(config, parentEl, { dashboard, legendSets, fontStyle }) {
+export default function(
+    config,
+    parentEl,
+    { dashboard, legendSets, fontStyle }
+) {
     const legendSet = legendSets[0]
     parentEl.style.overflow = 'hidden'
     parentEl.style.display = 'flex'


### PR DESCRIPTION
Fixes [DHIS2-9340](https://jira.dhis2.org/browse/DHIS2-9340).

It uses the same functions for formatting the numeric value used in PT.
For this to work, both `skipRounding` and `digitGroupSeparator` DV options are used.

For screenshots and an example see https://github.com/dhis2/data-visualizer-app/pull/1228.