### PR TITLE
fix: fix bug when 1 item is selected for each of the 2 categories (DHIS2-9350)

### DIFF
--- a/src/visualizations/store/adapters/dhis_highcharts/twoCategory.js
+++ b/src/visualizations/store/adapters/dhis_highcharts/twoCategory.js
@@ -22,7 +22,7 @@ export default function(acc, series, categories, idValueMap, metaData) {
         const serieData = getTwoCategorySplitSerieData(groupedData)
 
         // avoid a list of null values
-        if (serieData.every(e => e === serieData[0])) {
+        if (serieData.every(e => e === null)) {
             serieData.length = 0
             groupedData.length = 0
         }


### PR DESCRIPTION
Fixes [DHIS2-9350](https://jira.dhis2.org/browse/DHIS2-9350).

The check for all values null was faulty and caused to empty the series
data when only 1 item is selected in both categories of a 2 category
visualization.

This is what it should look like, instead of an empty chart:
![Screenshot 2020-08-27 at 15 06 52](https://user-images.githubusercontent.com/150978/91445865-f9071f80-e876-11ea-820c-2d340f353229.png)
