### PR TITLE
fix: dimension menu updates requested by DV (DHIS2-9365)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/analytics",
-    "version": "9.0.1-alpha.1",
+    "version": "9.0.1-alpha.2",
     "main": "./build/cjs/lib.js",
     "module": "./build/es/lib.js",
     "sideEffects": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/analytics",
-    "version": "9.0.0",
+    "version": "9.0.1-alpha.1",
     "main": "./build/cjs/lib.js",
     "module": "./build/es/lib.js",
     "sideEffects": [

--- a/src/components/DimensionMenu.js
+++ b/src/components/DimensionMenu.js
@@ -1,12 +1,7 @@
-import React, { Component } from 'react'
-import Divider from '@material-ui/core/Divider'
-import Menu from '@material-ui/core/Menu'
-import MenuItem from '@material-ui/core/MenuItem'
-import ArrowRightIcon from '@material-ui/icons/ArrowRight'
-import Zoom from '@material-ui/core/Zoom'
+import React from 'react'
+import { MenuDivider, FlyoutMenu, MenuItem, Tooltip } from '@dhis2/ui'
 import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
-import Tooltip from '@material-ui/core/Tooltip'
 
 import { getAvailableAxes } from '../modules/layoutUiRules'
 import { AXIS_ID_FILTERS } from '../modules/layout/axis'
@@ -25,215 +20,159 @@ const getAxisItemLabel = (axisName, isDimensionInLayout) =>
         : i18n.t('Add to {{axisName}}', { axisName })
 
 const getRemoveMenuItem = onClick => (
-    <MenuItem key="remove-menu-item" onClick={onClick}>
-        {i18n.t('Remove')}
-    </MenuItem>
+    <MenuItem
+        key="remove-menu-item"
+        onClick={onClick}
+        label={i18n.t('Remove')}
+    />
 )
 
-const getDividerItem = key => <Divider light key={key} />
+const getDividerItem = key => <MenuDivider dense key={key} />
 
 const getUnavailableLabel = visType =>
     i18n.t('Not available for {{visualizationType}}', {
         visualizationType: getDisplayNameByVisType(visType),
     })
 
-export class DimensionMenu extends Component {
-    state = { submenuAnchorEl: null }
-    render() {
-        const {
-            dimensionId,
-            currentAxisId,
-            visType,
-            numberOfDimensionItems,
-            assignedCategoriesItemHandler,
-            isAssignedCategoriesInLayout,
-            axisItemHandler,
-            removeItemHandler,
-            anchorEl,
-            onClose,
-            classes,
-        } = this.props
+const DimensionMenu = ({
+    dimensionId,
+    currentAxisId,
+    visType,
+    numberOfDimensionItems,
+    assignedCategoriesItemHandler,
+    isAssignedCategoriesInLayout,
+    axisItemHandler,
+    removeItemHandler,
+    classes,
+    onClose,
+}) => {
+    const menuItems = []
 
-        const menuItems = []
+    const isDimensionInLayout = !!currentAxisId
 
-        const isDimensionInLayout = !!currentAxisId
+    // add/move to axis item
+    const availableAxisIds = getAvailableAxes(visType)
 
-        // add/move to axis item
-        const availableAxisIds = getAvailableAxes(visType)
+    const applicableAxisIds = availableAxisIds.filter(
+        axisId => axisId !== currentAxisId
+    )
 
-        const applicableAxisIds = availableAxisIds.filter(
-            axisId => axisId !== currentAxisId
-        )
+    const assignedCategoriesAvailableDestinations = getAvailableAxes(
+        visType
+    ).filter(axis => axis !== AXIS_ID_FILTERS)
 
-        const assignedCategoriesAvailableDestinations = getAvailableAxes(
-            visType
-        ).filter(axis => axis !== AXIS_ID_FILTERS)
+    const assignedCategoriesItemLabel = isAssignedCategoriesInLayout
+        ? i18n.t('Remove Assigned Categories')
+        : i18n.t('Add Assigned Categories')
 
-        const assignedCategoriesItemLabel = isAssignedCategoriesInLayout
-            ? i18n.t('Remove Assigned Categories')
-            : i18n.t('Add Assigned Categories')
-
-        const closeSubMenu = () => {
-            this.setState({
-                submenuAnchorEl: null,
-            })
-        }
-
-        const closeWholeMenu = () => {
-            onClose()
-            closeSubMenu()
-        }
-
-        // Assigned categories
-        if (
-            dimensionId === DIMENSION_ID_DATA &&
-            assignedCategoriesItemHandler
-        ) {
-            if (assignedCategoriesAvailableDestinations.length) {
-                if (!isAssignedCategoriesInLayout) {
-                    menuItems.push(
-                        <MenuItem
-                            key={`assigned-categories-item-${dimensionId}`}
-                            onClick={event =>
-                                this.setState({
-                                    submenuAnchorEl: event.currentTarget,
-                                })
-                            }
-                        >
-                            <div>{assignedCategoriesItemLabel}</div>
-                            <ArrowRightIcon />
-                        </MenuItem>
-                    )
-
-                    menuItems.push(
-                        <Menu
-                            key={`assigned-categories-sub-menu-${dimensionId}`}
-                            open={Boolean(this.state.submenuAnchorEl)}
-                            anchorEl={this.state.submenuAnchorEl}
-                            anchorOrigin={{
-                                vertical: 'top',
-                                horizontal: 'right',
-                            }}
-                            onClose={closeSubMenu}
-                            onExited={closeSubMenu}
-                        >
-                            {assignedCategoriesAvailableDestinations.map(
-                                destination => (
-                                    <MenuItem
-                                        key={destination}
-                                        onClick={() => {
-                                            assignedCategoriesItemHandler(
-                                                destination
-                                            )
-                                            closeWholeMenu()
-                                        }}
-                                    >
-                                        {getAxisItemLabel(
-                                            getAxisNameByLayoutType(
-                                                destination,
-                                                getLayoutTypeByVisType(visType)
-                                            )
-                                        )}
-                                    </MenuItem>
-                                )
-                            )}
-                        </Menu>
-                    )
-                } else {
-                    menuItems.push(
-                        <MenuItem
-                            key={`assigned-categories-item-${dimensionId}`}
-                            onClick={() => {
-                                assignedCategoriesItemHandler()
-                                closeWholeMenu()
-                            }}
-                        >
-                            <div>{assignedCategoriesItemLabel}</div>
-                        </MenuItem>
-                    )
-                }
+    // Assigned categories
+    if (dimensionId === DIMENSION_ID_DATA && assignedCategoriesItemHandler) {
+        if (assignedCategoriesAvailableDestinations.length) {
+            if (!isAssignedCategoriesInLayout) {
+                menuItems.push(
+                    <MenuItem
+                        label={assignedCategoriesItemLabel}
+                        key={`assigned-categories-item-${dimensionId}`}
+                    >
+                        {assignedCategoriesAvailableDestinations.map(
+                            destination => (
+                                <MenuItem
+                                    key={destination}
+                                    onClick={() => {
+                                        assignedCategoriesItemHandler(
+                                            destination
+                                        )
+                                        onClose()
+                                    }}
+                                    label={getAxisItemLabel(
+                                        getAxisNameByLayoutType(
+                                            destination,
+                                            getLayoutTypeByVisType(visType)
+                                        )
+                                    )}
+                                />
+                            )
+                        )}
+                    </MenuItem>
+                )
             } else {
                 menuItems.push(
-                    <Tooltip
+                    <MenuItem
                         key={`assigned-categories-item-${dimensionId}`}
-                        title={getUnavailableLabel(visType)}
-                        aria-label="disabled"
-                        placement="right-start"
-                        classes={classes}
-                    >
-                        <div>
-                            <MenuItem disabled>
-                                <div>{assignedCategoriesItemLabel}</div>
-                                <ArrowRightIcon />
-                            </MenuItem>
-                        </div>
-                    </Tooltip>
+                        onClick={() => {
+                            assignedCategoriesItemHandler()
+                            onClose()
+                        }}
+                        label={assignedCategoriesItemLabel}
+                    />
                 )
             }
-        }
-
-        // divider
-        menuItems.length &&
-            menuItems.push(getDividerItem('assigned-categories-divider'))
-
-        menuItems.push(
-            ...applicableAxisIds.map(axisId => (
-                <MenuItem
-                    key={`${dimensionId}-to-${axisId}`}
-                    onClick={() => {
-                        axisItemHandler({
-                            dimensionId,
-                            axisId,
-                            numberOfDimensionItems,
-                            requireItems: !getPredefinedDimensionProp(
-                                dimensionId,
-                                DIMENSION_PROP_NO_ITEMS
-                            ),
-                            isDimensionInLayout,
-                        })
-                        closeWholeMenu()
-                    }}
-                >
-                    {getAxisItemLabel(
-                        getAxisNameByLayoutType(
-                            axisId,
-                            getLayoutTypeByVisType(visType)
-                        ),
-                        isDimensionInLayout
-                    )}
-                </MenuItem>
-            ))
-        )
-
-        // remove item
-        if (isDimensionInLayout) {
-            // divider
-            if (applicableAxisIds.length) {
-                menuItems.push(getDividerItem('remove-item-divider'))
-            }
-
+        } else {
             menuItems.push(
-                getRemoveMenuItem(() => {
-                    removeItemHandler(dimensionId)
-                    closeWholeMenu()
-                })
+                <Tooltip
+                    key={`assigned-categories-item-${dimensionId}`}
+                    content={getUnavailableLabel(visType)}
+                    aria-label="disabled"
+                    classes={classes}
+                >
+                    <MenuItem
+                        disabled
+                        dense
+                        label={assignedCategoriesItemLabel}
+                    />
+                </Tooltip>
             )
         }
+    }
 
-        return (
-            <Menu
-                id={dimensionId}
-                anchorEl={anchorEl}
-                open={Boolean(anchorEl)}
-                onClose={closeWholeMenu}
-                onExited={closeWholeMenu}
-                transitionDuration={{ enter: 50, exit: 0 }}
-                TransitionComponent={Zoom}
-            >
-                {menuItems}
-            </Menu>
+    // divider
+    menuItems.length &&
+        menuItems.push(getDividerItem('assigned-categories-divider'))
+
+    menuItems.push(
+        ...applicableAxisIds.map(axisId => (
+            <MenuItem
+                key={`${dimensionId}-to-${axisId}`}
+                onClick={() => {
+                    axisItemHandler({
+                        dimensionId,
+                        axisId,
+                        numberOfDimensionItems,
+                        requireItems: !getPredefinedDimensionProp(
+                            dimensionId,
+                            DIMENSION_PROP_NO_ITEMS
+                        ),
+                        isDimensionInLayout,
+                    })
+                    onClose()
+                }}
+                label={getAxisItemLabel(
+                    getAxisNameByLayoutType(
+                        axisId,
+                        getLayoutTypeByVisType(visType)
+                    ),
+                    isDimensionInLayout
+                )}
+            />
+        ))
+    )
+
+    // remove item
+    if (isDimensionInLayout) {
+        // divider
+        if (applicableAxisIds.length) {
+            menuItems.push(getDividerItem('remove-item-divider'))
+        }
+
+        menuItems.push(
+            getRemoveMenuItem(() => {
+                removeItemHandler(dimensionId)
+                onClose()
+            })
         )
     }
+
+    return <FlyoutMenu dense>{menuItems}</FlyoutMenu>
 }
 
 DimensionMenu.propTypes = {
@@ -241,7 +180,6 @@ DimensionMenu.propTypes = {
     numberOfDimensionItems: PropTypes.number.isRequired,
     removeItemHandler: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
-    anchorEl: PropTypes.object,
     assignedCategoriesItemHandler: PropTypes.func,
     classes: PropTypes.object,
     currentAxisId: PropTypes.string,

--- a/src/components/DimensionsPanel/List/DimensionItem.js
+++ b/src/components/DimensionsPanel/List/DimensionItem.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, createRef } from 'react'
 import PropTypes from 'prop-types'
 import LockIcon from '@material-ui/icons/Lock'
 
@@ -12,7 +12,8 @@ import { styles } from './styles/DimensionItem.style'
 export class DimensionItem extends Component {
     state = { mouseOver: false }
 
-    onOptionsClick = id => event => this.props.onOptionsClick(event, id)
+    onOptionsClick = (id, ref) => event =>
+        this.props.onOptionsClick(event, id, ref)
 
     onMouseOver = () => {
         this.setState({ mouseOver: true })
@@ -68,6 +69,8 @@ export class DimensionItem extends Component {
                 ? { ...styles.item, ...styles.selected }
                 : styles.item
 
+        const optionsRef = createRef()
+
         return (
             <li
                 onMouseOver={this.onMouseOver}
@@ -93,11 +96,11 @@ export class DimensionItem extends Component {
                     )}
                 </DimensionLabel>
                 {onOptionsClick ? (
-                    <div style={styles.optionsWrapper}>
+                    <div style={styles.optionsWrapper} ref={optionsRef}>
                         {this.state.mouseOver && !isDeactivated && !isLocked ? (
                             <OptionsButton
                                 style={styles.optionsButton}
-                                onClick={this.onOptionsClick(id)}
+                                onClick={this.onOptionsClick(id, optionsRef)}
                             />
                         ) : null}
                     </div>


### PR DESCRIPTION
**WIP v9.0.1-alpha**

Fixes [DHIS2-9365](https://jira.dhis2.org/browse/DHIS2-9365)
Relates to https://github.com/dhis2/data-visualizer-app/pull/1237

- `DimensionMenu` no longer uses `anchorEl`, as the anchoring should now be handled by the parent component (requires a change in DV to function properly) 
- Refactors `DimensionMenu` to a functional component that uses `@dhis2/ui` instead of `MUI`
- `DimensionItem` now passed the ref of the option button in the `onOptionsClick` (to be used in DV to display the dimension menu in the right location)

-----------

**TODO**
- [x] Is this a breaking change?
