### PR TITLE
fix: optional chaining for legend items (DHIS2-9413)

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/chart.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/chart.js
@@ -18,7 +18,7 @@ const getEvents = () => ({
     events: {
         load: function() { // Align legend icon with legend text
             this.legend.allItems.forEach((item) => {
-                item.legendSymbol.attr({
+                item.legendSymbol?.attr({
                     translateY: -((item.legendItem.getBBox().height) * 0.75 / 4 ) + ( item.legendSymbol.r / 2 )
                 });
             });


### PR DESCRIPTION
Fixes [DHIS2-9413](https://jira.dhis2.org/browse/DHIS2-9413)

**Background**
https://github.com/dhis2/analytics/pull/534 introduced font styling for various text based options. As the font size of the legend could be changed, the corresponding icon (aka `legendSymbol`) had to be repositioned to be vertically aligned with the (now larger or smaller) text. However not all legend items has that object (namely trend lines), which caused legend items without the `legendSymbol` to crash the app.

**Fix**
By using optional chaining, items without the `legendSymbol` prop can be ignored.


**Proof** 
Locally opening the AO that caused this crash in the smoke test (`O52HFRvCjIi`) using the smoke test backend (`https://smoke.dhis2.org/dev_smoke/`).
![image](https://user-images.githubusercontent.com/12590483/92226448-0ccd0a00-eea5-11ea-94b7-d95d7685e6b7.png)
