### PR TITLE
fix: resolve previously introduced build error (DHIS2-9413)

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/chart.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/chart.js
@@ -18,10 +18,12 @@ const getEvents = () => ({
     events: {
         load: function() { // Align legend icon with legend text
             this.legend.allItems.forEach((item) => {
-                // eslint-disable-next-line no-unused-expressions
-                item.legendSymbol?.attr({
-                    translateY: -((item.legendItem.getBBox().height) * 0.75 / 4 ) + ( item.legendSymbol.r / 2 )
-                });
+                if (item.legendSymbol) {
+                    item.legendSymbol.attr({
+                        translateY: -((item.legendItem.getBBox().height) * 0.75 / 4 ) + ( item.legendSymbol.r / 2 )
+                    });
+                }
+                
             });
         }
     }

--- a/src/visualizations/config/adapters/dhis_highcharts/chart.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/chart.js
@@ -18,6 +18,7 @@ const getEvents = () => ({
     events: {
         load: function() { // Align legend icon with legend text
             this.legend.allItems.forEach((item) => {
+                // eslint-disable-next-line no-unused-expressions
                 item.legendSymbol?.attr({
                     translateY: -((item.legendItem.getBBox().height) * 0.75 / 4 ) + ( item.legendSymbol.r / 2 )
                 });

--- a/src/visualizations/config/adapters/dhis_highcharts/yAxis/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/yAxis/index.js
@@ -172,7 +172,7 @@ function getLabels(layout) {
 
 function getMultipleAxes(theme, axes) {
     const axisObjects = []
-    axes.map(axisId => {
+    axes.forEach(axisId => {
         const id = Number(axisId)
         axisObjects.push({
             title: {


### PR DESCRIPTION
https://github.com/dhis2/analytics/pull/587 introduced a build error which didn't get caught by our build process. 
`eslint` doesn't support optional chaining within array functions, so the rule was disabled for this specific case.

EDIT: There's a mismatch between the eslint validation in the lint process and the build process. Instead of disabling the rule, the optional chaining was replaced by an if statement.