### PR TITLE
fix: bump to v4.5.8 for publishing (4.x)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/analytics",
-    "version": "4.5.6",
+    "version": "4.5.8",
     "main": "./build/index.js",
     "sideEffects": [
         "./src/locales/index.js"


### PR DESCRIPTION
The publish action failed probably because 4.5.7 tags are already present and 4.5.6 didn't work.
Bump to 4.5.8 to see if the publish action works this time.