### PR TITLE
fix: text styling not applied when switching to 2 category

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/xAxis/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/xAxis/index.js
@@ -23,7 +23,7 @@ function noAxis() {
     return null
 }
 
-const getLabelsStyle = fontStyle => fontStyle ? {
+export const getLabelsStyle = fontStyle => fontStyle ? {
     style: {
         color: fontStyle[FONT_STYLE_OPTION_TEXT_COLOR],
         textShadow: '0 0 #ccc',

--- a/src/visualizations/config/adapters/dhis_highcharts/xAxis/twoCategory.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/xAxis/twoCategory.js
@@ -1,5 +1,11 @@
 import getAxisTitle from '../getAxisTitle'
 import getCategories from '../getCategories'
+import { getLabelsStyle } from './'
+import {
+    FONT_STYLE_HORIZONTAL_AXIS_TITLE,
+    FONT_STYLE_CATEGORY_AXIS_LABELS,
+} from '../../../../../modules/fontStyle'
+
 
 export default function(store, layout) {
     const axis1Categories = getCategories(
@@ -15,17 +21,12 @@ export default function(store, layout) {
     // bottom x axis
     const xAxis = [
         {
-            title: getAxisTitle(layout.domainAxisLabel),
+            title: getAxisTitle(layout.domainAxisLabel, layout.fontStyle[FONT_STYLE_HORIZONTAL_AXIS_TITLE]),
             categories: Array.from(
                 { length: axis2Categories.length || 1 },
                 () => axis1Categories
             ),
-            labels: {
-                style: {
-                    color: '#666',
-                    textShadow: '0 0 #ccc',
-                },
-            },
+            labels: getLabelsStyle(layout.fontStyle[FONT_STYLE_CATEGORY_AXIS_LABELS]),
         },
     ]
 


### PR DESCRIPTION
The font styling was not applied when switching to 2 category.
See screencast below:
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/150978/92707452-96715180-f355-11ea-930c-7d8f8b4e0676.gif)

The fix makes sure the styling is applied also in 2 category charts:
![Screenshot 2020-09-10 at 11 09 24](https://user-images.githubusercontent.com/150978/92708061-1dbec500-f356-11ea-9691-9c6bb16e114f.png)

