### PR TITLE
fix: debounce Data Dimension's filterText change

### DIFF
--- a/src/components/DataDimension/DataDimension.js
+++ b/src/components/DataDimension/DataDimension.js
@@ -150,6 +150,8 @@ export class DataDimension extends Component {
         })
     }
 
+    debouncedUpdateAlternatives = debounce(this.updateAlternatives, 300)
+
     onGroupChange = async groupId => {
         if (groupId !== this.state.groupId) {
             this.setState({ groupId }, this.updateAlternatives)
@@ -163,17 +165,11 @@ export class DataDimension extends Component {
     }
 
     onClearFilter = () => {
-        this.setState(
-            { filterText: '' },
-            debounce(async () => this.updateAlternatives(), 300)
-        )
+        this.setState({ filterText: '' }, this.debouncedUpdateAlternatives)
     }
 
     onFilterTextChange = filterText => {
-        this.setState(
-            { filterText },
-            debounce(async () => this.updateAlternatives(), 300)
-        )
+        this.setState({ filterText }, this.debouncedUpdateAlternatives)
     }
 
     selectItems = selectedIds => {


### PR DESCRIPTION
Calling `updateAlternatives` in the filterText onChange handler wasn't getting debounced properly, i.e. typing 10 characters in a row caused 10 network requests instead of 1.

It seems this happened because a _new_ anonymous debounced function was getting called on each event, instead of a single, persistent function that can track its debouncing status, so I made a named debounced function to call on each event.

Thanks for taking a look!