### PR TITLE
fix: setting org unit as series cause crash

### DIFF
--- a/src/modules/layout/__tests__/dimensionHasRelativeItems.spec.js
+++ b/src/modules/layout/__tests__/dimensionHasRelativeItems.spec.js
@@ -1,0 +1,12 @@
+import { TEST_DIMENSION_1, TEST_DIMENSION_5 } from '../testResources'
+import { dimensionHasRelativeItems } from '../dimensionHasRelativeItems'
+
+describe('dimensionHasRelativeItems', () => {
+    it('has relative items and should return true', () => {
+        expect(dimensionHasRelativeItems(TEST_DIMENSION_5)).toBe(true)
+    })
+
+    it('has no relative items and should be false', () => {
+        expect(dimensionHasRelativeItems(TEST_DIMENSION_1)).toBe(false)
+    })
+})

--- a/src/modules/layout/__tests__/dimensionHasRelativeItems.spec.js
+++ b/src/modules/layout/__tests__/dimensionHasRelativeItems.spec.js
@@ -6,7 +6,7 @@ describe('dimensionHasRelativeItems', () => {
         expect(dimensionHasRelativeItems(TEST_DIMENSION_5)).toBe(true)
     })
 
-    it('has no relative items and should be false', () => {
+    it('has no relative items and should return false', () => {
         expect(dimensionHasRelativeItems(TEST_DIMENSION_1)).toBe(false)
     })
 })

--- a/src/modules/layout/dimensionHasRelativeItems.js
+++ b/src/modules/layout/dimensionHasRelativeItems.js
@@ -1,4 +1,7 @@
 import { hasRelativeItems } from '../relativeItems'
 
 export const dimensionHasRelativeItems = dimension =>
-    hasRelativeItems(dimension.dimension, dimension.items)
+    hasRelativeItems(
+        dimension.dimension,
+        dimension.items.map(item => item.id)
+    )

--- a/src/modules/layout/dimensionHasRelativeItems.js
+++ b/src/modules/layout/dimensionHasRelativeItems.js
@@ -1,7 +1,6 @@
 import { hasRelativeItems } from '../relativeItems'
+import { dimensionGetId } from './dimensionGetId'
+import { dimensionGetItemIds } from './dimensionGetItemIds'
 
 export const dimensionHasRelativeItems = dimension =>
-    hasRelativeItems(
-        dimension.dimension,
-        dimension.items.map(item => item.id)
-    )
+    hasRelativeItems(dimensionGetId(dimension), dimensionGetItemIds(dimension))

--- a/src/modules/layout/testResources.js
+++ b/src/modules/layout/testResources.js
@@ -11,6 +11,7 @@ import {
     DIMENSION_ID_PERIOD,
     DIMENSION_ID_ORGUNIT,
 } from '../predefinedDimensions'
+import { getRelativePeriodIds } from '../../components/PeriodDimension/utils/relativePeriods'
 
 // Items
 
@@ -19,6 +20,7 @@ export const TEST_ITEM_ID_2 = 'dxItem2Id'
 export const TEST_ITEM_ID_3 = 'peItem1Id'
 export const TEST_ITEM_ID_4 = 'ouItem1Id'
 export const TEST_ITEM_ID_5 = 'dynamicItem1Id'
+export const TEST_ITEM_ID_6 = getRelativePeriodIds()[0]
 
 export const TEST_ITEM_1 = {
     [ITEM_PROP_ID.name]: TEST_ITEM_ID_1,
@@ -38,6 +40,10 @@ export const TEST_ITEM_4 = {
 
 export const TEST_ITEM_5 = {
     [ITEM_PROP_ID.name]: TEST_ITEM_ID_5,
+}
+
+export const TEST_ITEM_6 = {
+    [ITEM_PROP_ID.name]: TEST_ITEM_ID_6,
 }
 
 export const TEST_ITEM_INVALID_1 = {
@@ -82,6 +88,11 @@ export const TEST_DIMENSION_3 = {
 export const TEST_DIMENSION_4 = {
     [DIMENSION_PROP_ID.name]: DIMENSION_ID_DYNAMIC,
     [DIMENSION_PROP_ITEMS.name]: [TEST_ITEM_5],
+}
+
+export const TEST_DIMENSION_5 = {
+    [DIMENSION_PROP_ID.name]: DIMENSION_ID_PERIOD,
+    [DIMENSION_PROP_ITEMS.name]: [TEST_ITEM_6],
 }
 
 export const TEST_DIMENSION_EMPTY_1 = {


### PR DESCRIPTION
Issue: Setting org unit as series caused a crash. 
_Error message:_
![image](https://user-images.githubusercontent.com/12590483/93784145-e80abd80-fc2c-11ea-89f7-4768fbf69282.png)

Cause: `itemIds` passed as an array of objects `[{id: '12345'}]`  instead of an array of ids `['12345']`

Solution: Map the `id` prop to `dimension.items` in `dimensionHasRelativeItems`

_Proof: Org unit can be used as Series_
![image](https://user-images.githubusercontent.com/12590483/93784501-62d3d880-fc2d-11ea-862f-0524fd32974c.png)
