### PR TITLE
fix: radar clashing axis titles

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/xAxis/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/xAxis/index.js
@@ -34,7 +34,7 @@ export const getLabelsStyle = fontStyle => fontStyle ? {
     },
 } : {}
 
-const getDefault = (store, layout) =>
+export const getDefault = (store, layout) =>
     objectClean({
         categories: getCategories(store.data[0].metaData, layout.rows[0].dimension),
         title: getAxisTitle(layout.domainAxisLabel, layout.fontStyle[FONT_STYLE_HORIZONTAL_AXIS_TITLE], FONT_STYLE_HORIZONTAL_AXIS_TITLE, layout.type),

--- a/src/visualizations/config/adapters/dhis_highcharts/xAxis/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/xAxis/index.js
@@ -3,12 +3,14 @@ import getAxisTitle from '../getAxisTitle'
 import getCategories from '../getCategories'
 import getYearOnYear from './yearOnYear'
 import getTwoCategory from './twoCategory'
+import getRadar from './radar'
 import {
     VIS_TYPE_GAUGE,
     VIS_TYPE_YEAR_OVER_YEAR_LINE,
     VIS_TYPE_YEAR_OVER_YEAR_COLUMN,
     VIS_TYPE_PIE,
-    isTwoCategoryChartType,
+    VIS_TYPE_RADAR,
+    isTwoCategoryChartType, 
 } from '../../../../../modules/visTypes'
 import { 
     FONT_STYLE_HORIZONTAL_AXIS_TITLE, 
@@ -53,6 +55,9 @@ export default function(store, layout, extraOptions) {
             case VIS_TYPE_YEAR_OVER_YEAR_LINE:
             case VIS_TYPE_YEAR_OVER_YEAR_COLUMN:
                 xAxis = [getYearOnYear(store, layout, extraOptions)]
+                break
+            case VIS_TYPE_RADAR:
+                xAxis = [getRadar(store, layout)]
                 break
             default:
                 xAxis = [getDefault(store, layout)]

--- a/src/visualizations/config/adapters/dhis_highcharts/xAxis/radar.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/xAxis/radar.js
@@ -1,16 +1,9 @@
 import isString from 'd2-utilizr/lib/isString'
-import objectClean from 'd2-utilizr/lib/objectClean'
-import { FONT_STYLE_CATEGORY_AXIS_LABELS, FONT_STYLE_HORIZONTAL_AXIS_TITLE, FONT_STYLE_OPTION_TEXT_ALIGN, TEXT_ALIGN_CENTER } from '../../../../../modules/fontStyle'
-import getAxisTitle from '../getAxisTitle'
-import getCategories from '../getCategories'
-import { getLabelsStyle } from './'
+import { FONT_STYLE_HORIZONTAL_AXIS_TITLE, FONT_STYLE_OPTION_TEXT_ALIGN, TEXT_ALIGN_CENTER } from '../../../../../modules/fontStyle'
+import { getDefault } from './'
 
 export default (store, layout) => {
-    const config = objectClean({
-        categories: getCategories(store.data[0].metaData, layout.rows[0].dimension),
-        title: getAxisTitle(layout.domainAxisLabel, layout.fontStyle[FONT_STYLE_HORIZONTAL_AXIS_TITLE], FONT_STYLE_HORIZONTAL_AXIS_TITLE, layout.type),
-        labels: getLabelsStyle(layout.fontStyle[FONT_STYLE_CATEGORY_AXIS_LABELS]), 
-    })
+    const config = getDefault(store, layout)
 
     if (isString(layout.domainAxisLabel) && config.title && layout.fontStyle[FONT_STYLE_HORIZONTAL_AXIS_TITLE][FONT_STYLE_OPTION_TEXT_ALIGN] === TEXT_ALIGN_CENTER) {
         config.title.textAlign = 'right'

--- a/src/visualizations/config/adapters/dhis_highcharts/xAxis/radar.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/xAxis/radar.js
@@ -1,0 +1,20 @@
+import isString from 'd2-utilizr/lib/isString'
+import objectClean from 'd2-utilizr/lib/objectClean'
+import { FONT_STYLE_CATEGORY_AXIS_LABELS, FONT_STYLE_HORIZONTAL_AXIS_TITLE, FONT_STYLE_OPTION_TEXT_ALIGN, TEXT_ALIGN_CENTER } from '../../../../../modules/fontStyle'
+import getAxisTitle from '../getAxisTitle'
+import getCategories from '../getCategories'
+import { getLabelsStyle } from './'
+
+export default (store, layout) => {
+    const config = objectClean({
+        categories: getCategories(store.data[0].metaData, layout.rows[0].dimension),
+        title: getAxisTitle(layout.domainAxisLabel, layout.fontStyle[FONT_STYLE_HORIZONTAL_AXIS_TITLE], FONT_STYLE_HORIZONTAL_AXIS_TITLE, layout.type),
+        labels: getLabelsStyle(layout.fontStyle[FONT_STYLE_CATEGORY_AXIS_LABELS]), 
+    })
+
+    if (isString(layout.domainAxisLabel) && config.title && layout.fontStyle[FONT_STYLE_HORIZONTAL_AXIS_TITLE][FONT_STYLE_OPTION_TEXT_ALIGN] === TEXT_ALIGN_CENTER) {
+        config.title.textAlign = 'right'
+    }
+    
+    return config
+}


### PR DESCRIPTION
Issue: The default position of the axis titles for Radar caused axis titles to clash

Solution: Set `textAlign` to _right_ for Radar x axis title when positioned in the middle (default).

----------------

Issue - clashing titles
![image](https://user-images.githubusercontent.com/12590483/93886151-5ca13300-fce5-11ea-8c17-3cb373551e45.png)


Default: Both set to `middle`, fixed 
![image](https://user-images.githubusercontent.com/12590483/93885728-cc62ee00-fce4-11ea-9df2-67af0bf5464a.png)

With custom colors and the _Extra Large_ font size
![image](https://user-images.githubusercontent.com/12590483/93885743-d1c03880-fce4-11ea-8742-e31997c9b53b.png)

Both set to `start`, unchanged
![image](https://user-images.githubusercontent.com/12590483/93885781-df75be00-fce4-11ea-867c-8dec32e3c437.png)

Both set to `end`, unchanged
![image](https://user-images.githubusercontent.com/12590483/93885804-ebfa1680-fce4-11ea-99a8-960924940326.png)
