### PR TITLE
fix: extract color from pattern for trendlines

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/addTrendLines.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/addTrendLines.js
@@ -155,6 +155,9 @@ function getTwoCategoryTrendLines(layout, series, isStacked) {
 }
 
 function getDarkerColor(color) {
+    // For patterns, color is an object containing patternIndex.
+    // patternIndex can be 0, thus the need to check for the presence of the key in the object.
+    // The actual color code needs to be extracted for the the Highcharts pattern definition.
     if (Object.prototype.hasOwnProperty.call(color, 'patternIndex')) {
         const colorSetPatterns = colorSets[COLOR_SET_PATTERNS].patterns
         color =

--- a/src/visualizations/config/adapters/dhis_highcharts/addTrendLines.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/addTrendLines.js
@@ -1,6 +1,7 @@
 import arrayContains from 'd2-utilizr/lib/arrayContains'
 import { rgb } from 'd3-color'
 
+import { colorSets, COLOR_SET_PATTERNS } from '../../../util/colors/colorSets'
 import getStackedData from './getStackedData'
 import {
     VIS_TYPE_GAUGE,
@@ -154,6 +155,13 @@ function getTwoCategoryTrendLines(layout, series, isStacked) {
 }
 
 function getDarkerColor(color) {
+    if (Object.prototype.hasOwnProperty.call(color, 'patternIndex')) {
+        const colorSetPatterns = colorSets[COLOR_SET_PATTERNS].patterns
+        color =
+            colorSetPatterns[color.patternIndex].color ||
+            DEFAULT_TRENDLINE.color
+    }
+
     return rgb(color)
         .darker(0.5)
         .toString()


### PR DESCRIPTION
When the colorSet option is set to patterns, there isn't a color passed
to highcharts, but the index of the pattern.
The trendline tho needs a color to distinguish between the different
trendlines when using multiple data items.
Luckily the Highcharts patterns have a color in their definition, the
same one used in the pattern.

Before, all trendlines were black:
![Screenshot 2020-09-23 at 12 15 05](https://user-images.githubusercontent.com/150978/93999781-88c8bc80-fd96-11ea-8589-ce240f02901d.png)

Now, the trendlines have the correct color based on the series:
![Screenshot 2020-09-23 at 12 15 37](https://user-images.githubusercontent.com/150978/93999793-8c5c4380-fd96-11ea-88c2-ba43e0318b29.png)
