### PR TITLE
feat: negative values in highcharts (DHIS2-1982)

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/yAxis/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/yAxis/index.js
@@ -60,17 +60,19 @@ function getPlotLineLabelStyle(fontStyle) {
     }
 }
 
-function getMinValue(layout) {
-    return isNumeric(layout.rangeAxisMinValue)
-        ? layout.rangeAxisMinValue
-        : DEFAULT_MIN_VALUE
-}
+const getMinValue = (rangeAxisMinValue, dataValues) => 
+    isNumeric(rangeAxisMinValue) ? 
+        rangeAxisMinValue : 
+        dataValues?.some(value => value < DEFAULT_MIN_VALUE) ? 
+            undefined : 
+            DEFAULT_MIN_VALUE
 
-function getMaxValue(layout) {
-    return isNumeric(layout.rangeAxisMaxValue)
-        ? layout.rangeAxisMaxValue
-        : undefined
-}
+const getMaxValue = (rangeAxisMaxValue, dataValues) =>
+    isNumeric(rangeAxisMaxValue) ? 
+        rangeAxisMaxValue :
+        dataValues?.every(value => value < DEFAULT_MIN_VALUE) ?
+            DEFAULT_MIN_VALUE :
+            undefined
 
 function getSteps(layout) {
     return isNumeric(layout.rangeAxisSteps) ? layout.rangeAxisSteps : undefined
@@ -203,6 +205,7 @@ function getDefault(layout, series, extraOptions) {
             seriesItem => seriesItem.id === layoutSeriesItem.dimensionItem
         )
     )
+    const dataValues = series?.map(item => item.data).flat()
     if (isDualAxisType(layout.type) && hasCustomAxes(filteredSeries) && !axisHasRelativeItems(layout.columns)) {
         const axisIdsMap = getAxisIdsMap(layout.series, series)
         axes.push(
@@ -214,8 +217,8 @@ function getDefault(layout, series, extraOptions) {
     } else {
         axes.push(
             objectClean({
-                min: getMinValue(layout),
-                max: getMaxValue(layout),
+                min: getMinValue(layout.rangeAxisMinValue, dataValues),
+                max: getMaxValue(layout.rangeAxisMaxValue, dataValues),
                 tickAmount: getSteps(layout),
                 title: getAxisTitle(layout.rangeAxisLabel, layout.fontStyle[FONT_STYLE_VERTICAL_AXIS_TITLE], FONT_STYLE_VERTICAL_AXIS_TITLE, layout.type
                 ),


### PR DESCRIPTION
Implements [DHIS2-1982](https://jira.dhis2.org/browse/DHIS2-1982)
Based on [this document](https://docs.google.com/document/d/1ggOAAgSXYcZ7ao1bNcEpMiJklpBhRtZsYjnUA5IuWDE/edit#)

Enables negative values to be displayed properly by default for all vis types but Gauge and SV.

By not providing a min or max Highcharts figures out a suitable range automatically. However, 0 needs to be provided as min or max in some cases, to prevent e.g. `[5000, 5100, 5200]` to start at  ~5000 rather than 0 and a similar situation for negative values. Thus:
- If all values are positive, `min: 0` will be used
- If all values are negative, `max: 0` will be used
- In other cases, no value will be used

-----------

When testing this `BCG stock PHU` can be used with either `Aggregation type` set to default, `Count` or `Average` to get some useable negative test values.

-----------

**Some examples**
LINE all negative
![image](https://user-images.githubusercontent.com/12590483/95190808-21682f00-07d0-11eb-9c7b-56f765380a10.png)

LINE mixed
![image](https://user-images.githubusercontent.com/12590483/95190872-39d84980-07d0-11eb-8d76-19212fe8ee47.png)

COLUMN all negative
![image](https://user-images.githubusercontent.com/12590483/95190950-54aabe00-07d0-11eb-9e11-fe6525bcf55f.png)

COLUMN mixed
![image](https://user-images.githubusercontent.com/12590483/95190902-43fa4800-07d0-11eb-802c-84d81019c2c2.png)

RADAR mixed
![image](https://user-images.githubusercontent.com/12590483/95190989-65f3ca80-07d0-11eb-8069-cc415c5ae08d.png)

STACKED AREA mixed
![image](https://user-images.githubusercontent.com/12590483/95191202-b1a67400-07d0-11eb-960f-e4d0f6b68c75.png)

STACKED BAR mixed
![image](https://user-images.githubusercontent.com/12590483/95191237-bec36300-07d0-11eb-9231-dd352ee23442.png)

