### PR TITLE
fix: render trendlines in front of columns (DHIS2-9829)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-09-15T07:30:45.529Z\n"
-"PO-Revision-Date: 2020-09-15T07:30:45.529Z\n"
+"POT-Creation-Date: 2020-10-21T13:43:05.146Z\n"
+"PO-Revision-Date: 2020-10-21T13:43:05.146Z\n"
 
 msgid "Data Type"
 msgstr ""
@@ -557,6 +557,9 @@ msgid "Compare changes over time between multiple time periods."
 msgstr ""
 
 msgid "Display a single value. Recommend relative period to show latest data."
+msgstr ""
+
+msgid "No legend for this series"
 msgstr ""
 
 msgid "Target"

--- a/src/visualizations/config/adapters/dhis_highcharts/addTrendLines.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/addTrendLines.js
@@ -20,6 +20,7 @@ const DEFAULT_TRENDLINE = {
         symbol: 'circle',
         radius: 2,
     },
+    zIndex: 1
 }
 
 export const isRegressionIneligible = type =>


### PR DESCRIPTION
Implements [DHIS2-9829](https://jira.dhis2.org/browse/DHIS2-9829)

---

### Key features

1. Bump z-index of trendlines

---

### Description

Trendlines are added to Highcharts as regular series items, meaning they adhere to the same order and z-index rules as other items. When using 2 items or more, this means the series order will be Item1, Trendline1, Item2, Trendline2 etc. 
If Trendline1 intersects with Item2 (higher order), Trendline1 will go behind the columns.

This is simply fixed by bumping the z-index of trendline items.

---

### Screenshots

_trendlines behind columns (old)_
![image](https://user-images.githubusercontent.com/12590483/96731268-5a4ef900-13b7-11eb-8791-847a1e12c27f.png)


_trendlines in front of columns_
![image](https://user-images.githubusercontent.com/12590483/96731309-66d35180-13b7-11eb-89af-82666266e02b.png)


