### PR TITLE
test: Support Cypress tests

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2020-10-21T13:43:05.146Z\n"
-"PO-Revision-Date: 2020-10-21T13:43:05.146Z\n"
+"POT-Creation-Date: 2020-11-02T07:31:40.378Z\n"
+"PO-Revision-Date: 2020-11-02T07:31:40.378Z\n"
 
 msgid "Data Type"
 msgstr ""
@@ -26,9 +26,6 @@ msgstr ""
 msgid "Add to {{axisName}}"
 msgstr ""
 
-msgid "Remove"
-msgstr ""
-
 msgid "Not available for {{visualizationType}}"
 msgstr ""
 
@@ -36,6 +33,9 @@ msgid "Remove Assigned Categories"
 msgstr ""
 
 msgid "Add Assigned Categories"
+msgstr ""
+
+msgid "Remove"
 msgstr ""
 
 msgid "Filter dimensions"

--- a/src/components/DataDimension/DataDimension.js
+++ b/src/components/DataDimension/DataDimension.js
@@ -215,6 +215,7 @@ export class DataDimension extends Component {
                     <DataTypes
                         currentDataType={this.state.dataType}
                         onChange={this.onDataTypeChange}
+                        dataTest={'data-dimension-data-types-select-field'}
                     />
                     <Groups
                         dataType={this.state.dataType}
@@ -223,11 +224,13 @@ export class DataDimension extends Component {
                         onGroupChange={this.onGroupChange}
                         onDetailChange={this.onDetailChange}
                         detailValue={this.state.groupDetail}
+                        dataTest={'data-dimension-groups-select-field'}
                     />
                     <FilterField
                         text={this.state.filterText}
                         onFilterTextChange={this.onFilterTextChange}
                         onClearFilter={this.onClearFilter}
+                        dataTest={'data-dimension-filter-input-field'}
                     />
                 </div>
             )
@@ -253,6 +256,7 @@ export class DataDimension extends Component {
                 itemClassName="data-dimension"
                 unselected={unselected}
                 selected={selected}
+                dataTest={'data-dimension-item-selector'}
             >
                 {filterZone()}
             </ItemSelector>

--- a/src/components/DataDimension/DataTypesSelector.js
+++ b/src/components/DataDimension/DataTypesSelector.js
@@ -6,10 +6,11 @@ import { SingleSelectField, SingleSelectOption } from '@dhis2/ui'
 import { dataTypes } from '../../modules/dataTypes'
 import styles from './styles/DataTypesSelector.style'
 
-export const DataTypes = ({ currentDataType, onChange }) => (
+export const DataTypes = ({ currentDataType, onChange, dataTest }) => (
     <div className="container">
         <SingleSelectField
             label={i18n.t('Data Type')}
+            dataTest={dataTest}
             selected={dataTypes[currentDataType]?.id}
             onChange={ref => onChange(ref.selected)}
             dense
@@ -19,6 +20,7 @@ export const DataTypes = ({ currentDataType, onChange }) => (
                     value={type.id}
                     key={type.id}
                     label={type.getName()}
+                    dataTest={`${dataTest}-option-${type.id}`}
                 />
             ))}
         </SingleSelectField>
@@ -29,6 +31,7 @@ export const DataTypes = ({ currentDataType, onChange }) => (
 DataTypes.propTypes = {
     currentDataType: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
+    dataTest: PropTypes.string,
 }
 
 export default DataTypes

--- a/src/components/DataDimension/Groups.js
+++ b/src/components/DataDimension/Groups.js
@@ -13,6 +13,7 @@ export const Groups = ({
     groups,
     onDetailChange,
     onGroupChange,
+    dataTest,
 }) => {
     let optionItems = groups
 
@@ -29,6 +30,7 @@ export const Groups = ({
             <div className="group-container">
                 <SingleSelectField
                     label={dataTypes[dataType].getGroupLabel()}
+                    dataTest={dataTest}
                     selected={groupId}
                     placeholder={
                         !groupId && dataTypes[dataType].getPlaceholder
@@ -43,6 +45,7 @@ export const Groups = ({
                             value={item.id}
                             key={item.id}
                             label={item.name}
+                            dataTest={`${dataTest}-option-${item.id}`}
                         />
                     ))}
                 </SingleSelectField>
@@ -61,6 +64,7 @@ Groups.propTypes = {
     groups: PropTypes.array.isRequired,
     onDetailChange: PropTypes.func.isRequired,
     onGroupChange: PropTypes.func.isRequired,
+    dataTest: PropTypes.string,
 }
 
 export default Groups

--- a/src/components/DimensionMenu.js
+++ b/src/components/DimensionMenu.js
@@ -75,7 +75,7 @@ const DimensionMenu = ({
                     <MenuItem
                         label={assignedCategoriesItemLabel}
                         key={`assigned-categories-item-${dimensionId}`}
-                        dataTest={`${dataTest}-item-assigned-categories-menu`}
+                        dataTest={`${dataTest}-item-co-menu`}
                     >
                         {assignedCategoriesAvailableDestinations.map(
                             destination => (
@@ -93,7 +93,7 @@ const DimensionMenu = ({
                                             getLayoutTypeByVisType(visType)
                                         )
                                     )}
-                                    dataTest={`${dataTest}-item-action-assigned-categories-to-${destination}`}
+                                    dataTest={`${dataTest}-item-action-co-to-${destination}`}
                                 />
                             )
                         )}
@@ -108,7 +108,7 @@ const DimensionMenu = ({
                             onClose()
                         }}
                         label={assignedCategoriesItemLabel}
-                        dataTest={`${dataTest}-item-remove-assigned-categories`}
+                        dataTest={`${dataTest}-item-remove-co`}
                     />
                 )
             }
@@ -124,7 +124,7 @@ const DimensionMenu = ({
                         disabled
                         dense
                         label={assignedCategoriesItemLabel}
-                        dataTest={`${dataTest}-item-assigned-categories-menu`}
+                        dataTest={`${dataTest}-item-co-menu`}
                     />
                 </Tooltip>
             )

--- a/src/components/DimensionMenu.js
+++ b/src/components/DimensionMenu.js
@@ -19,14 +19,6 @@ const getAxisItemLabel = (axisName, isDimensionInLayout) =>
         ? i18n.t('Move to {{axisName}}', { axisName })
         : i18n.t('Add to {{axisName}}', { axisName })
 
-const getRemoveMenuItem = onClick => (
-    <MenuItem
-        key="remove-menu-item"
-        onClick={onClick}
-        label={i18n.t('Remove')}
-    />
-)
-
 const getDividerItem = key => <MenuDivider dense key={key} />
 
 const getUnavailableLabel = visType =>
@@ -45,6 +37,7 @@ const DimensionMenu = ({
     removeItemHandler,
     classes,
     onClose,
+    dataTest,
 }) => {
     const menuItems = []
 
@@ -65,6 +58,15 @@ const DimensionMenu = ({
         ? i18n.t('Remove Assigned Categories')
         : i18n.t('Add Assigned Categories')
 
+    const getRemoveMenuItem = onClick => (
+        <MenuItem
+            key="remove-menu-item"
+            onClick={onClick}
+            label={i18n.t('Remove')}
+            dataTest={`${dataTest}-item-remove-${dimensionId}`}
+        />
+    )
+
     // Assigned categories
     if (dimensionId === DIMENSION_ID_DATA && assignedCategoriesItemHandler) {
         if (assignedCategoriesAvailableDestinations.length) {
@@ -73,6 +75,7 @@ const DimensionMenu = ({
                     <MenuItem
                         label={assignedCategoriesItemLabel}
                         key={`assigned-categories-item-${dimensionId}`}
+                        dataTest={`${dataTest}-item-assigned-categories-menu`}
                     >
                         {assignedCategoriesAvailableDestinations.map(
                             destination => (
@@ -90,6 +93,7 @@ const DimensionMenu = ({
                                             getLayoutTypeByVisType(visType)
                                         )
                                     )}
+                                    dataTest={`${dataTest}-item-action-assigned-categories-to-${destination}`}
                                 />
                             )
                         )}
@@ -104,6 +108,7 @@ const DimensionMenu = ({
                             onClose()
                         }}
                         label={assignedCategoriesItemLabel}
+                        dataTest={`${dataTest}-item-remove-assigned-categories`}
                     />
                 )
             }
@@ -119,6 +124,7 @@ const DimensionMenu = ({
                         disabled
                         dense
                         label={assignedCategoriesItemLabel}
+                        dataTest={`${dataTest}-item-assigned-categories-menu`}
                     />
                 </Tooltip>
             )
@@ -153,6 +159,7 @@ const DimensionMenu = ({
                     ),
                     isDimensionInLayout
                 )}
+                dataTest={`${dataTest}-item-action-${dimensionId}-to-${axisId}`}
             />
         ))
     )
@@ -172,7 +179,11 @@ const DimensionMenu = ({
         )
     }
 
-    return <FlyoutMenu dense>{menuItems}</FlyoutMenu>
+    return (
+        <FlyoutMenu dense dataTest={dataTest}>
+            {menuItems}
+        </FlyoutMenu>
+    )
 }
 
 DimensionMenu.propTypes = {
@@ -183,6 +194,7 @@ DimensionMenu.propTypes = {
     assignedCategoriesItemHandler: PropTypes.func,
     classes: PropTypes.object,
     currentAxisId: PropTypes.string,
+    dataTest: PropTypes.string,
     dimensionId: PropTypes.string,
     isAssignedCategoriesInLayout: PropTypes.bool,
     visType: PropTypes.string,

--- a/src/components/DimensionsPanel/List/DimensionItem.js
+++ b/src/components/DimensionsPanel/List/DimensionItem.js
@@ -90,7 +90,10 @@ export class DimensionItem extends Component {
                     <div style={styles.iconWrapper}>{Icon}</div>
                     <div style={styles.labelWrapper}>
                         {Label}
-                        <RecommendedIcon isRecommended={isRecommended} />
+                        <RecommendedIcon
+                            isRecommended={isRecommended}
+                            dataTest={`${dataTest}-recommended-icon`}
+                        />
                     </div>
                     {isLocked && (
                         <div style={styles.iconWrapper}>

--- a/src/components/DimensionsPanel/List/DimensionItem.js
+++ b/src/components/DimensionsPanel/List/DimensionItem.js
@@ -102,7 +102,7 @@ export class DimensionItem extends Component {
                     <div
                         style={styles.optionsWrapper}
                         ref={optionsRef}
-                        dataTest={`${dataTest}-menu-${id}`}
+                        data-test={`${dataTest}-menu-${id}`}
                     >
                         {this.state.mouseOver && !isDeactivated && !isLocked ? (
                             <OptionsButton

--- a/src/components/DimensionsPanel/List/DimensionItem.js
+++ b/src/components/DimensionsPanel/List/DimensionItem.js
@@ -59,6 +59,7 @@ export class DimensionItem extends Component {
             onOptionsClick,
             innerRef,
             style,
+            dataTest,
             ...rest
         } = this.props
 
@@ -77,12 +78,14 @@ export class DimensionItem extends Component {
                 onMouseLeave={this.onMouseExit}
                 ref={innerRef}
                 style={Object.assign({}, itemStyle, style)}
+                data-test={dataTest}
                 {...rest}
             >
                 <DimensionLabel
                     id={id}
                     isDeactivated={isDeactivated}
                     onClick={onClick}
+                    dataTest={`${dataTest}-button-${id}`}
                 >
                     <div style={styles.iconWrapper}>{Icon}</div>
                     <div style={styles.labelWrapper}>
@@ -96,7 +99,11 @@ export class DimensionItem extends Component {
                     )}
                 </DimensionLabel>
                 {onOptionsClick ? (
-                    <div style={styles.optionsWrapper} ref={optionsRef}>
+                    <div
+                        style={styles.optionsWrapper}
+                        ref={optionsRef}
+                        dataTest={`${dataTest}-menu-${id}`}
+                    >
                         {this.state.mouseOver && !isDeactivated && !isLocked ? (
                             <OptionsButton
                                 style={styles.optionsButton}
@@ -114,6 +121,7 @@ DimensionItem.propTypes = {
     id: PropTypes.string.isRequired,
     isSelected: PropTypes.bool.isRequired, // XXX
     name: PropTypes.string.isRequired,
+    dataTest: PropTypes.string,
     innerRef: PropTypes.func,
     isDeactivated: PropTypes.bool,
     isLocked: PropTypes.bool,

--- a/src/components/DimensionsPanel/List/DimensionLabel.js
+++ b/src/components/DimensionsPanel/List/DimensionLabel.js
@@ -13,6 +13,7 @@ export class DimensionLabel extends Component {
         isDeactivated: PropTypes.bool.isRequired,
         onClick: PropTypes.func.isRequired,
         children: PropTypes.array,
+        dataTest: PropTypes.string,
     }
 
     onLabelClick = () => {
@@ -33,7 +34,7 @@ export class DimensionLabel extends Component {
     render() {
         return (
             <div
-                data-test={`dimension-id-${this.props.id}`}
+                data-test={this.props.dataTest}
                 className="label"
                 onClick={this.onLabelClick}
                 onKeyPress={this.onKeyPress}

--- a/src/components/DimensionsPanel/List/RecommendedIcon.js
+++ b/src/components/DimensionsPanel/List/RecommendedIcon.js
@@ -37,6 +37,7 @@ export class RecommendedIcon extends Component {
                 style={styles.recommendedIcon}
                 onMouseOver={this.onMouseOver}
                 onMouseLeave={this.onMouseExit}
+                data-test={this.props.dataTest}
             >
                 {TooltipOnHover}
             </div>
@@ -46,6 +47,7 @@ export class RecommendedIcon extends Component {
 
 RecommendedIcon.propTypes = {
     isRecommended: PropTypes.bool.isRequired,
+    dataTest: PropTypes.string,
 }
 
 export default RecommendedIcon

--- a/src/components/DimensionsPanel/List/__tests__/__snapshots__/DimensionItem.spec.js.snap
+++ b/src/components/DimensionsPanel/List/__tests__/__snapshots__/DimensionItem.spec.js.snap
@@ -62,6 +62,7 @@ exports[`DimensionItem matches the snapshot 1`] = `
         Period
       </span>
       <RecommendedIcon
+        dataTest="undefined-recommended-icon"
         isRecommended={false}
       />
     </div>
@@ -131,6 +132,7 @@ exports[`DimensionItem matches the snapshot with locked 1`] = `
         Period
       </span>
       <RecommendedIcon
+        dataTest="undefined-recommended-icon"
         isRecommended={false}
       />
     </div>
@@ -218,6 +220,7 @@ exports[`DimensionItem matches the snapshot with onOptionsClick 1`] = `
         Period
       </span>
       <RecommendedIcon
+        dataTest="undefined-recommended-icon"
         isRecommended={false}
       />
     </div>
@@ -299,6 +302,7 @@ exports[`DimensionItem matches the snapshot with recommended 1`] = `
         Period
       </span>
       <RecommendedIcon
+        dataTest="undefined-recommended-icon"
         isRecommended={true}
       />
     </div>
@@ -370,6 +374,7 @@ exports[`DimensionItem matches the snapshot with selected 1`] = `
         Period
       </span>
       <RecommendedIcon
+        dataTest="undefined-recommended-icon"
         isRecommended={false}
       />
     </div>

--- a/src/components/DimensionsPanel/List/__tests__/__snapshots__/DimensionItem.spec.js.snap
+++ b/src/components/DimensionsPanel/List/__tests__/__snapshots__/DimensionItem.spec.js.snap
@@ -17,6 +17,7 @@ exports[`DimensionItem matches the snapshot 1`] = `
   }
 >
   <DimensionLabel
+    dataTest="undefined-button-pe"
     id="pe"
     isDeactivated={false}
     onClick={[Function]}
@@ -85,6 +86,7 @@ exports[`DimensionItem matches the snapshot with locked 1`] = `
   }
 >
   <DimensionLabel
+    dataTest="undefined-button-pe"
     id="pe"
     isDeactivated={false}
     onClick={[Function]}
@@ -171,6 +173,7 @@ exports[`DimensionItem matches the snapshot with onOptionsClick 1`] = `
   }
 >
   <DimensionLabel
+    dataTest="undefined-button-pe"
     id="pe"
     isDeactivated={false}
     onClick={[Function]}
@@ -220,6 +223,7 @@ exports[`DimensionItem matches the snapshot with onOptionsClick 1`] = `
     </div>
   </DimensionLabel>
   <div
+    dataTest="undefined-menu-pe"
     style={
       Object {
         "alignSelf": "start",
@@ -250,6 +254,7 @@ exports[`DimensionItem matches the snapshot with recommended 1`] = `
   }
 >
   <DimensionLabel
+    dataTest="undefined-button-pe"
     id="pe"
     isDeactivated={false}
     onClick={[Function]}
@@ -320,6 +325,7 @@ exports[`DimensionItem matches the snapshot with selected 1`] = `
   }
 >
   <DimensionLabel
+    dataTest="undefined-button-pe"
     id="pe"
     isDeactivated={false}
     onClick={[Function]}

--- a/src/components/DimensionsPanel/List/__tests__/__snapshots__/DimensionItem.spec.js.snap
+++ b/src/components/DimensionsPanel/List/__tests__/__snapshots__/DimensionItem.spec.js.snap
@@ -223,7 +223,7 @@ exports[`DimensionItem matches the snapshot with onOptionsClick 1`] = `
     </div>
   </DimensionLabel>
   <div
-    dataTest="undefined-menu-pe"
+    data-test="undefined-menu-pe"
     style={
       Object {
         "alignSelf": "start",

--- a/src/components/Filter/Filter.js
+++ b/src/components/Filter/Filter.js
@@ -2,13 +2,21 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { InputField } from '@dhis2/ui'
 
-export const Filter = ({ text, onChange, onClear, placeholder, type }) => (
+export const Filter = ({
+    text,
+    onChange,
+    onClear,
+    placeholder,
+    type,
+    dataTest,
+}) => (
     <InputField
         placeholder={placeholder}
         onChange={ref => (ref.value.length ? onChange(ref.value) : onClear())}
         value={text}
         dense
         type={type}
+        dataTest={dataTest}
     />
 )
 
@@ -17,6 +25,7 @@ Filter.propTypes = {
     type: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
     onClear: PropTypes.func.isRequired,
+    dataTest: PropTypes.string,
     text: PropTypes.string,
 }
 

--- a/src/components/FilterField.js
+++ b/src/components/FilterField.js
@@ -5,13 +5,19 @@ import i18n from '@dhis2/d2-i18n'
 import Filter from './Filter/Filter'
 import styles from './styles/FilterField.style'
 
-export const FilterField = ({ text, onFilterTextChange, onClearFilter }) => (
+export const FilterField = ({
+    text,
+    onFilterTextChange,
+    onClearFilter,
+    dataTest,
+}) => (
     <div className="container">
         <Filter
             placeholder={i18n.t('Search')}
             text={text}
             onChange={onFilterTextChange}
             onClear={onClearFilter}
+            dataTest={dataTest}
         />
         <style jsx>{styles}</style>
     </div>
@@ -21,6 +27,7 @@ FilterField.propTypes = {
     text: PropTypes.string.isRequired,
     onClearFilter: PropTypes.func.isRequired,
     onFilterTextChange: PropTypes.func.isRequired,
+    dataTest: PropTypes.string,
 }
 
 export default FilterField

--- a/src/components/ItemSelector/ItemSelector.js
+++ b/src/components/ItemSelector/ItemSelector.js
@@ -8,16 +8,27 @@ import styles from './styles/ItemSelector.style'
 
 class ItemSelector extends Component {
     render() {
-        const { unselected, selected, children: filterZone } = this.props
+        const {
+            unselected,
+            selected,
+            children: filterZone,
+            dataTest,
+        } = this.props
 
         return (
-            <div className="item-selector-container">
+            <div className="item-selector-container" data-test={dataTest}>
                 <div className={cx('section', 'unselected')}>
                     {filterZone}
-                    <UnselectedItems {...unselected} />
+                    <UnselectedItems
+                        {...unselected}
+                        dataTest={`${dataTest}-unselected-items`}
+                    />
                 </div>
                 <div className={cx('section', 'selected')}>
-                    <SelectedItems {...selected} />
+                    <SelectedItems
+                        {...selected}
+                        dataTest={`${dataTest}-selected-items`}
+                    />
                 </div>
                 <style jsx>{styles}</style>
             </div>
@@ -27,6 +38,7 @@ class ItemSelector extends Component {
 
 ItemSelector.propTypes = {
     children: PropTypes.object,
+    dataTest: PropTypes.string,
     selected: PropTypes.shape({
         items: PropTypes.arrayOf(
             PropTypes.shape({

--- a/src/components/ItemSelector/SelectedItems.js
+++ b/src/components/ItemSelector/SelectedItems.js
@@ -244,7 +244,10 @@ export class SelectedItems extends Component {
                     </Droppable>
                 </DragDropContext>
                 <div className="deselect-all-button">
-                    <Button onClick={this.onDeselectAll}>
+                    <Button
+                        onClick={this.onDeselectAll}
+                        dataTest={`${this.props.dataTest}-deselect-all-button`}
+                    >
                         {i18n.t('Deselect All')}
                     </Button>
                 </div>

--- a/src/components/ItemSelector/SelectedItems.js
+++ b/src/components/ItemSelector/SelectedItems.js
@@ -27,7 +27,11 @@ const InfoBox = ({ message }) => (
 )
 
 const ItemsList = ({ innerRef, children }) => (
-    <ul className="selected-list" ref={innerRef}>
+    <ul
+        className="selected-list"
+        ref={innerRef}
+        dataTest={`${this.props.dataTest}-list`}
+    >
         {children}
         <style jsx>{styles}</style>
     </ul>
@@ -144,6 +148,7 @@ export class SelectedItems extends Component {
                         {...provided.draggableProps}
                         {...provided.dragHandleProps}
                         ref={provided.innerRef}
+                        dataTest={`${this.props.dataTest}-list-item`}
                     >
                         <Item
                             id={id}
@@ -271,6 +276,7 @@ SelectedItems.propTypes = {
     items: PropTypes.array.isRequired,
     onDeselect: PropTypes.func.isRequired,
     onReorder: PropTypes.func.isRequired,
+    dataTest: PropTypes.string,
     infoBoxMessage: PropTypes.string,
 }
 

--- a/src/components/ItemSelector/SelectedItems.js
+++ b/src/components/ItemSelector/SelectedItems.js
@@ -27,7 +27,7 @@ const InfoBox = ({ message }) => (
 )
 
 const ItemsList = ({ innerRef, children, dataTest }) => (
-    <ul className="selected-list" ref={innerRef} dataTest={dataTest}>
+    <ul className="selected-list" ref={innerRef} data-test={dataTest}>
         {children}
         <style jsx>{styles}</style>
     </ul>
@@ -144,7 +144,7 @@ export class SelectedItems extends Component {
                         {...provided.draggableProps}
                         {...provided.dragHandleProps}
                         ref={provided.innerRef}
-                        dataTest={`${this.props.dataTest}-list-item`}
+                        data-test={`${this.props.dataTest}-list-item`}
                     >
                         <Item
                             id={id}

--- a/src/components/ItemSelector/SelectedItems.js
+++ b/src/components/ItemSelector/SelectedItems.js
@@ -26,12 +26,8 @@ const InfoBox = ({ message }) => (
     </div>
 )
 
-const ItemsList = ({ innerRef, children }) => (
-    <ul
-        className="selected-list"
-        ref={innerRef}
-        dataTest={`${this.props.dataTest}-list`}
-    >
+const ItemsList = ({ innerRef, children, dataTest }) => (
+    <ul className="selected-list" ref={innerRef} dataTest={dataTest}>
         {children}
         <style jsx>{styles}</style>
     </ul>
@@ -238,6 +234,7 @@ export class SelectedItems extends Component {
                         {provided => (
                             <ItemsList
                                 innerRef={provided.innerRef}
+                                dataTest={`${this.props.dataTest}-list`}
                                 {...provided.droppableProps}
                             >
                                 {itemList}
@@ -269,6 +266,7 @@ InfoBox.propTypes = {
 
 ItemsList.propTypes = {
     children: PropTypes.array,
+    dataTest: PropTypes.string,
     innerRef: PropTypes.func,
 }
 

--- a/src/components/ItemSelector/UnselectedItems.js
+++ b/src/components/ItemSelector/UnselectedItems.js
@@ -66,6 +66,7 @@ export class UnselectedItems extends Component {
             className="unselected-list-item"
             key={dataDim.id}
             onDoubleClick={() => this.onDoubleClickItem(dataDim.id)}
+            dataTest={`${this.props.dataTest}-list-item`}
         >
             <Item
                 id={dataDim.id}
@@ -104,7 +105,13 @@ export class UnselectedItems extends Component {
                     onScroll={this.requestMoreItems}
                     className="unselected-list-container"
                 >
-                    <ul className="unselected-list">{listItems}</ul>
+                    <ul
+                        className="unselected-list"
+                        data-test="item-selector-unselected-list"
+                        dataTest={`${this.props.dataTest}-list`}
+                    >
+                        {listItems}
+                    </ul>
                 </div>
                 <div className="select-all-button">
                     <Button onClick={this.onSelectAllClick}>
@@ -131,6 +138,7 @@ UnselectedItems.propTypes = {
         })
     ).isRequired,
     onSelect: PropTypes.func.isRequired,
+    dataTest: PropTypes.string,
     filterText: PropTypes.string,
     requestMoreItems: PropTypes.func,
 }

--- a/src/components/ItemSelector/UnselectedItems.js
+++ b/src/components/ItemSelector/UnselectedItems.js
@@ -66,7 +66,7 @@ export class UnselectedItems extends Component {
             className="unselected-list-item"
             key={dataDim.id}
             onDoubleClick={() => this.onDoubleClickItem(dataDim.id)}
-            dataTest={`${this.props.dataTest}-list-item`}
+            data-test={`${this.props.dataTest}-list-item`}
         >
             <Item
                 id={dataDim.id}
@@ -107,8 +107,7 @@ export class UnselectedItems extends Component {
                 >
                     <ul
                         className="unselected-list"
-                        data-test="item-selector-unselected-list"
-                        dataTest={`${this.props.dataTest}-list`}
+                        data-test={`${this.props.dataTest}-list`}
                     >
                         {listItems}
                     </ul>

--- a/src/components/ItemSelector/UnselectedItems.js
+++ b/src/components/ItemSelector/UnselectedItems.js
@@ -113,7 +113,10 @@ export class UnselectedItems extends Component {
                     </ul>
                 </div>
                 <div className="select-all-button">
-                    <Button onClick={this.onSelectAllClick}>
+                    <Button
+                        onClick={this.onSelectAllClick}
+                        dataTest={`${this.props.dataTest}-select-all-button`}
+                    >
                         {i18n.t('Select all')}
                     </Button>
                 </div>

--- a/src/components/ItemSelector/__tests__/__snapshots__/SelectedItems.spec.js.snap
+++ b/src/components/ItemSelector/__tests__/__snapshots__/SelectedItems.spec.js.snap
@@ -79,7 +79,7 @@ exports[`The SelectedItems component list with items matches the snapshot with l
             >
               <ul
                 className="selected-list"
-                dataTest="undefined-list"
+                data-test="undefined-list"
               >
                 <Connect(Draggable)
                   disableInteractiveElementBlocking={false}
@@ -160,7 +160,7 @@ exports[`The SelectedItems component list with items matches the snapshot with l
                           className="selected-list-item"
                           data-react-beautiful-dnd-drag-handle="1"
                           data-react-beautiful-dnd-draggable="1"
-                          dataTest="undefined-list-item"
+                          data-test="undefined-list-item"
                           draggable={false}
                           id="rb"
                           onBlur={[Function]}
@@ -395,7 +395,7 @@ exports[`The SelectedItems component list with items matches the snapshot with l
                           className="selected-list-item"
                           data-react-beautiful-dnd-drag-handle="1"
                           data-react-beautiful-dnd-draggable="1"
-                          dataTest="undefined-list-item"
+                          data-test="undefined-list-item"
                           draggable={false}
                           id="rr"
                           onBlur={[Function]}
@@ -718,7 +718,7 @@ exports[`The SelectedItems component matches the snapshot when list is empty 1`]
             >
               <ul
                 className="selected-list"
-                dataTest="undefined-list"
+                data-test="undefined-list"
               >
                 <AnimateInOut
                   on={null}

--- a/src/components/ItemSelector/__tests__/__snapshots__/SelectedItems.spec.js.snap
+++ b/src/components/ItemSelector/__tests__/__snapshots__/SelectedItems.spec.js.snap
@@ -567,13 +567,13 @@ exports[`The SelectedItems component list with items matches the snapshot with l
     className="deselect-all-button"
   >
     <Button
-      dataTest="dhis2-uicore-button"
+      dataTest="undefined-deselect-all-button"
       onClick={[Function]}
       type="button"
     >
       <button
         className="jsx-1653853836 "
-        data-test="dhis2-uicore-button"
+        data-test="undefined-deselect-all-button"
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
@@ -736,13 +736,13 @@ exports[`The SelectedItems component matches the snapshot when list is empty 1`]
     className="deselect-all-button"
   >
     <Button
-      dataTest="dhis2-uicore-button"
+      dataTest="undefined-deselect-all-button"
       onClick={[Function]}
       type="button"
     >
       <button
         className="jsx-1653853836 "
-        data-test="dhis2-uicore-button"
+        data-test="undefined-deselect-all-button"
         onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}

--- a/src/components/ItemSelector/__tests__/__snapshots__/SelectedItems.spec.js.snap
+++ b/src/components/ItemSelector/__tests__/__snapshots__/SelectedItems.spec.js.snap
@@ -74,10 +74,12 @@ exports[`The SelectedItems component list with items matches the snapshot with l
           >
             <ItemsList
               data-react-beautiful-dnd-droppable="1"
+              dataTest="undefined-list"
               innerRef={[Function]}
             >
               <ul
                 className="selected-list"
+                dataTest="undefined-list"
               >
                 <Connect(Draggable)
                   disableInteractiveElementBlocking={false}
@@ -158,6 +160,7 @@ exports[`The SelectedItems component list with items matches the snapshot with l
                           className="selected-list-item"
                           data-react-beautiful-dnd-drag-handle="1"
                           data-react-beautiful-dnd-draggable="1"
+                          dataTest="undefined-list-item"
                           draggable={false}
                           id="rb"
                           onBlur={[Function]}
@@ -392,6 +395,7 @@ exports[`The SelectedItems component list with items matches the snapshot with l
                           className="selected-list-item"
                           data-react-beautiful-dnd-drag-handle="1"
                           data-react-beautiful-dnd-draggable="1"
+                          dataTest="undefined-list-item"
                           draggable={false}
                           id="rr"
                           onBlur={[Function]}
@@ -709,10 +713,12 @@ exports[`The SelectedItems component matches the snapshot when list is empty 1`]
           >
             <ItemsList
               data-react-beautiful-dnd-droppable="0"
+              dataTest="undefined-list"
               innerRef={[Function]}
             >
               <ul
                 className="selected-list"
+                dataTest="undefined-list"
               >
                 <AnimateInOut
                   on={null}

--- a/src/components/ItemSelector/__tests__/__snapshots__/UnselectedItems.spec.js.snap
+++ b/src/components/ItemSelector/__tests__/__snapshots__/UnselectedItems.spec.js.snap
@@ -8,12 +8,11 @@ exports[`UnselectedItems component list with items matches the snapshot when lis
   >
     <ul
       className="unselected-list"
-      data-test="item-selector-unselected-list"
-      dataTest="undefined-list"
+      data-test="undefined-list"
     >
       <li
         className="unselected-list-item"
-        dataTest="undefined-list-item"
+        data-test="undefined-list-item"
         key="rb"
         onDoubleClick={[Function]}
       >
@@ -28,7 +27,7 @@ exports[`UnselectedItems component list with items matches the snapshot when lis
       </li>
       <li
         className="unselected-list-item"
-        dataTest="undefined-list-item"
+        data-test="undefined-list-item"
         key="rr"
         onDoubleClick={[Function]}
       >
@@ -74,8 +73,7 @@ exports[`UnselectedItems component matches the snapshot when list is empty 1`] =
   >
     <ul
       className="unselected-list"
-      data-test="item-selector-unselected-list"
-      dataTest="undefined-list"
+      data-test="undefined-list"
     />
   </div>
   <div

--- a/src/components/ItemSelector/__tests__/__snapshots__/UnselectedItems.spec.js.snap
+++ b/src/components/ItemSelector/__tests__/__snapshots__/UnselectedItems.spec.js.snap
@@ -8,9 +8,12 @@ exports[`UnselectedItems component list with items matches the snapshot when lis
   >
     <ul
       className="unselected-list"
+      data-test="item-selector-unselected-list"
+      dataTest="undefined-list"
     >
       <li
         className="unselected-list-item"
+        dataTest="undefined-list-item"
         key="rb"
         onDoubleClick={[Function]}
       >
@@ -25,6 +28,7 @@ exports[`UnselectedItems component list with items matches the snapshot when lis
       </li>
       <li
         className="unselected-list-item"
+        dataTest="undefined-list-item"
         key="rr"
         onDoubleClick={[Function]}
       >
@@ -70,6 +74,8 @@ exports[`UnselectedItems component matches the snapshot when list is empty 1`] =
   >
     <ul
       className="unselected-list"
+      data-test="item-selector-unselected-list"
+      dataTest="undefined-list"
     />
   </div>
   <div

--- a/src/components/ItemSelector/__tests__/__snapshots__/UnselectedItems.spec.js.snap
+++ b/src/components/ItemSelector/__tests__/__snapshots__/UnselectedItems.spec.js.snap
@@ -46,7 +46,7 @@ exports[`UnselectedItems component list with items matches the snapshot when lis
     className="select-all-button"
   >
     <Button
-      dataTest="dhis2-uicore-button"
+      dataTest="undefined-select-all-button"
       onClick={[Function]}
       type="button"
     >
@@ -80,7 +80,7 @@ exports[`UnselectedItems component matches the snapshot when list is empty 1`] =
     className="select-all-button"
   >
     <Button
-      dataTest="dhis2-uicore-button"
+      dataTest="undefined-select-all-button"
       onClick={[Function]}
       type="button"
     >

--- a/src/components/PeriodDimension/FixedPeriodFilter.js
+++ b/src/components/PeriodDimension/FixedPeriodFilter.js
@@ -12,6 +12,7 @@ const FixedPeriodFilter = ({
     currentYear,
     onSelectPeriodType,
     onSelectYear,
+    dataTest,
 }) => {
     const onlyAllowedTypeIsSelected =
         Array.isArray(allowedPeriodTypes) &&
@@ -28,6 +29,7 @@ const FixedPeriodFilter = ({
                     selected={currentPeriodType}
                     disabled={onlyAllowedTypeIsSelected}
                     className="filterElement"
+                    dataTest={`${dataTest}-period-type`}
                 >
                     {getFixedPeriodsOptions()
                         .filter(
@@ -42,6 +44,7 @@ const FixedPeriodFilter = ({
                                 key={option.id}
                                 value={option.id}
                                 label={option.name}
+                                dataTest={`${dataTest}-period-type-option-${option.id}`}
                             />
                         ))}
                 </SingleSelectField>
@@ -55,6 +58,7 @@ const FixedPeriodFilter = ({
                     value={currentYear}
                     onChange={({ value }) => onSelectYear(value)}
                     dense
+                    dataTest={`${dataTest}-year`}
                 ></InputField>
             </div>
             <style jsx>{styles}</style>
@@ -68,6 +72,7 @@ FixedPeriodFilter.propTypes = {
     onSelectPeriodType: PropTypes.func.isRequired,
     onSelectYear: PropTypes.func.isRequired,
     allowedPeriodTypes: PropTypes.arrayOf(PropTypes.string),
+    dataTest: PropTypes.string,
 }
 
 export default FixedPeriodFilter

--- a/src/components/PeriodDimension/PeriodDimension.js
+++ b/src/components/PeriodDimension/PeriodDimension.js
@@ -17,6 +17,7 @@ export const PeriodDimension = ({ onSelect, selectedPeriods, rightFooter }) => {
             onSelect={selectPeriods}
             initialSelectedPeriods={selectedPeriods}
             rightFooter={rightFooter}
+            dataTest={'period-dimension'}
         />
     )
 }

--- a/src/components/PeriodDimension/PeriodTransfer.js
+++ b/src/components/PeriodDimension/PeriodTransfer.js
@@ -68,12 +68,14 @@ class PeriodTransfer extends Component {
                 <Tab
                     selected={this.state.isRelative}
                     onClick={() => this.onIsRelativeClick(true)}
+                    dataTest={`${this.props.dataTest}-relative-periods-button`}
                 >
                     {i18n.t('Relative periods')}
                 </Tab>
                 <Tab
                     selected={!this.state.isRelative}
                     onClick={() => this.onIsRelativeClick(false)}
+                    dataTest={`${this.props.dataTest}-fixed-periods-button`}
                 >
                     {i18n.t('Fixed periods')}
                 </Tab>
@@ -92,6 +94,7 @@ class PeriodTransfer extends Component {
                                 ).getPeriods(),
                             })
                         }}
+                        dataTest={`${this.props.dataTest}-relative-period-filter`}
                     />
                 ) : (
                     <FixedPeriodFilter
@@ -109,6 +112,7 @@ class PeriodTransfer extends Component {
                                 year,
                             })
                         }}
+                        dataTest={`${this.props.dataTest}-fixed-period-filter`}
                     />
                 )}
             </div>
@@ -177,6 +181,7 @@ class PeriodTransfer extends Component {
 
 PeriodTransfer.propTypes = {
     onSelect: PropTypes.func.isRequired,
+    dataTest: PropTypes.string,
     initialSelectedPeriods: PropTypes.arrayOf(
         PropTypes.shape({
             id: PropTypes.string,

--- a/src/components/PeriodDimension/RelativePeriodFilter.js
+++ b/src/components/PeriodDimension/RelativePeriodFilter.js
@@ -6,7 +6,7 @@ import { SingleSelectField, SingleSelectOption } from '@dhis2/ui'
 import { getRelativePeriodsOptions } from './utils/relativePeriods'
 import styles from './styles/PeriodFilter.style'
 
-const RelativePeriodFilter = ({ currentFilter, onSelectFilter }) => (
+const RelativePeriodFilter = ({ currentFilter, onSelectFilter, dataTest }) => (
     <div className="leftSection">
         <SingleSelectField
             label={i18n.t('Period type')}
@@ -14,12 +14,14 @@ const RelativePeriodFilter = ({ currentFilter, onSelectFilter }) => (
             dense
             selected={currentFilter}
             className="filterElement"
+            dataTest={dataTest}
         >
             {getRelativePeriodsOptions().map(option => (
                 <SingleSelectOption
                     key={option.id}
                     value={option.id}
                     label={option.name}
+                    dataTest={`${dataTest}-option-${option.id}`}
                 />
             ))}
         </SingleSelectField>
@@ -30,6 +32,7 @@ const RelativePeriodFilter = ({ currentFilter, onSelectFilter }) => (
 RelativePeriodFilter.propTypes = {
     currentFilter: PropTypes.string.isRequired,
     onSelectFilter: PropTypes.func.isRequired,
+    dataTest: PropTypes.string,
 }
 
 export default RelativePeriodFilter

--- a/src/components/PeriodDimension/__tests__/__snapshots__/PeriodDimension.spec.js.snap
+++ b/src/components/PeriodDimension/__tests__/__snapshots__/PeriodDimension.spec.js.snap
@@ -2,6 +2,7 @@
 
 exports[`The Period Dimension component matches the snapshot 1`] = `
 <PeriodTransfer
+  dataTest="period-dimension"
   initialSelectedPeriods={Array []}
   onSelect={[Function]}
   rightFooter={<React.Fragment />}

--- a/src/components/PeriodDimension/__tests__/__snapshots__/PeriodSelector.spec.js.snap
+++ b/src/components/PeriodDimension/__tests__/__snapshots__/PeriodSelector.spec.js.snap
@@ -15,14 +15,14 @@ exports[`The Period Selector component matches the snapshot 1`] = `
         dataTest="dhis2-uicore-tabbar"
       >
         <Tab
-          dataTest="dhis2-uicore-tab"
+          dataTest="undefined-relative-periods-button"
           onClick={[Function]}
           selected={true}
         >
           Relative periods
         </Tab>
         <Tab
-          dataTest="dhis2-uicore-tab"
+          dataTest="undefined-fixed-periods-button"
           onClick={[Function]}
           selected={false}
         >
@@ -34,6 +34,7 @@ exports[`The Period Selector component matches the snapshot 1`] = `
       >
         <RelativePeriodFilter
           currentFilter="Months"
+          dataTest="undefined-relative-period-filter"
           onSelectFilter={[Function]}
         />
       </div>

--- a/src/components/PivotTable/PivotTableCell.js
+++ b/src/components/PivotTable/PivotTableCell.js
@@ -5,7 +5,10 @@ import { cell as cellStyle } from './styles/PivotTable.style'
 import { usePivotTableEngine } from './PivotTableEngineContext'
 
 export const PivotTableCell = React.forwardRef(
-    ({ classes, isColumnHeader, children, style = {}, ...props }, ref) => {
+    (
+        { classes, isColumnHeader, children, dataTest, style = {}, ...props },
+        ref
+    ) => {
         const engine = usePivotTableEngine()
         style.height = style.minHeight = style.maxHeight =
             style.height || engine.fontSize + engine.cellPadding * 2 + 2
@@ -17,12 +20,23 @@ export const PivotTableCell = React.forwardRef(
         )
 
         return isColumnHeader ? (
-            <th className={className} style={style} {...props}>
+            <th
+                className={className}
+                style={style}
+                data-test={dataTest}
+                {...props}
+            >
                 <style jsx>{cellStyle}</style>
                 {children}
             </th>
         ) : (
-            <td ref={ref} className={className} style={style} {...props}>
+            <td
+                ref={ref}
+                className={className}
+                style={style}
+                data-test={dataTest}
+                {...props}
+            >
                 <style jsx>{cellStyle}</style>
                 {children}
             </td>
@@ -42,6 +56,7 @@ PivotTableCell.propTypes = {
         PropTypes.object,
         PropTypes.string,
     ]),
+    dataTest: PropTypes.string,
     isColumnHeader: PropTypes.bool,
     style: PropTypes.object,
 }

--- a/src/components/PivotTable/PivotTableColumnHeaderCell.js
+++ b/src/components/PivotTable/PivotTableColumnHeaderCell.js
@@ -55,7 +55,10 @@ export const PivotTableColumnHeaderCell = ({
                     >
                         <style jsx>{cellStyle}</style>
                         <div className="column-header-inner">
-                            <span className="column-header-label">
+                            <span
+                                className="column-header-label"
+                                data-test="visualization-column-header"
+                            >
                                 {header.label}
                             </span>
                             {isSortable ? (

--- a/src/components/PivotTable/PivotTableContainer.js
+++ b/src/components/PivotTable/PivotTableContainer.js
@@ -8,6 +8,7 @@ export const PivotTableContainer = React.forwardRef(
             className="pivot-table-container"
             style={{ width, height }}
             ref={ref}
+            data-test="visualization-container"
         >
             <style jsx>{tableStyle}</style>
             {width === 0 || height === 0 ? null : <table>{children}</table>}

--- a/src/components/PivotTable/PivotTableRowHeaderCell.js
+++ b/src/components/PivotTable/PivotTableRowHeaderCell.js
@@ -32,6 +32,7 @@ export const PivotTableRowHeaderCell = ({
                     rowSpan={header.span}
                     title={header.label}
                     style={{ width, maxWidth: width, minWidth: width }}
+                    dataTest="visualization-row-header"
                 >
                     {header.label}
                 </PivotTableCell>

--- a/src/components/PivotTable/PivotTableTitleRow.js
+++ b/src/components/PivotTable/PivotTableTitleRow.js
@@ -32,6 +32,7 @@ export const PivotTableTitleRow = ({
                         maxWidth: containerWidth,
                         textAlign: 'center',
                     }}
+                    data-test="visualization-title"
                 >
                     {title}
                 </div>

--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -121,6 +121,7 @@ const generateDVItem = (config, legendSet, parentEl, fontStyle) => {
     svg.setAttribute('viewBox', `0 0 ${width} ${height}`)
     svg.setAttribute('width', '100%')
     svg.setAttribute('height', '100%')
+    svg.setAttribute('data-test', 'visualization-container')
 
     const title = document.createElementNS(svgNS, 'text')
     const titleFontStyle = fontStyle[FONT_STYLE_VISUALIZATION_TITLE]

--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -44,6 +44,7 @@ const generateValueSVG = (value, formattedValue, legendSet, y) => {
     text.setAttribute('letter-spacing', '-5')
     text.setAttribute('x', '50%')
     text.setAttribute('fill', fillColor)
+    text.setAttribute('data-test', 'visualization-primary-value')
     text.appendChild(document.createTextNode(formattedValue))
 
     svgValue.appendChild(text)
@@ -150,6 +151,8 @@ const generateDVItem = (config, legendSet, parentEl, fontStyle) => {
     )
     title.setAttribute('fill', titleFontStyle[FONT_STYLE_OPTION_TEXT_COLOR])
 
+    title.setAttribute('data-test', 'visualization-title')
+
     if (config.title) {
         title.appendChild(document.createTextNode(config.title))
 
@@ -190,6 +193,9 @@ const generateDVItem = (config, legendSet, parentEl, fontStyle) => {
         'fill',
         subtitleFontStyle[FONT_STYLE_OPTION_TEXT_COLOR]
     )
+
+    subtitle.setAttribute('data-test', 'visualization-subtitle')
+
     if (config.subtitle) {
         subtitle.appendChild(document.createTextNode(config.subtitle))
 


### PR DESCRIPTION
**Relates to https://github.com/dhis2/data-visualizer-app/pull/1412**

---

### Key features

1. Add `data-test` to components

---

### Description

Increase support for external Cypress tests to run by adding the `data-test` prop to various components

_Note:_ No visual or functional changes, only the `dataTest` / `data-test` props are touched.
