### PR TITLE
fix: add data test to the data dim info box (DHIS2-10003)

### DIFF
--- a/src/components/ItemSelector/SelectedItems.js
+++ b/src/components/ItemSelector/SelectedItems.js
@@ -18,8 +18,8 @@ const Subtitle = () => (
     </div>
 )
 
-const InfoBox = ({ message }) => (
-    <div className="info-container">
+const InfoBox = ({ message, dataTest }) => (
+    <div className="info-container" data-test={dataTest}>
         <InfoIcon style={{ fontSize: 16, color: colors.grey600 }} />
         <span className="info-text">{message}</span>
         <style jsx>{styles}</style>
@@ -224,7 +224,10 @@ export class SelectedItems extends Component {
             <Fragment>
                 <Subtitle />
                 {this.props.infoBoxMessage ? (
-                    <InfoBox message={this.props.infoBoxMessage} />
+                    <InfoBox
+                        message={this.props.infoBoxMessage}
+                        dataTest={`${this.props.dataTest}-info-box`}
+                    />
                 ) : null}
                 <DragDropContext
                     onDragStart={this.onDragStart}
@@ -264,6 +267,7 @@ export class SelectedItems extends Component {
 }
 
 InfoBox.propTypes = {
+    dataTest: PropTypes.string,
     message: PropTypes.string,
 }
 


### PR DESCRIPTION
Supports [DHIS2-10003](https://jira.dhis2.org/browse/DHIS2-10003)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/1501**

---

### Key features

1. Add a `dataTest` prop to the data dimension info box

---

### Screenshots

_supporting text_
![image](https://user-images.githubusercontent.com/12590483/101507832-47987f80-3977-11eb-8e14-8ff276d4ed86.png)

