### PR TITLE
fix: add custom title and subtitle for scatter (DHIS2-10170)

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/subtitle/gauge.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/subtitle/gauge.js
@@ -1,5 +1,6 @@
 import isString from 'd2-utilizr/lib/isString'
 
+// TODO: This file is unused, delete?
 export default function (series, layout, dashboard, filterTitle) {
     const seriesName = series[0].name
 

--- a/src/visualizations/config/adapters/dhis_highcharts/subtitle/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/subtitle/index.js
@@ -3,6 +3,7 @@ import getFilterText from '../../../../util/getFilterText'
 import {
     VIS_TYPE_YEAR_OVER_YEAR_LINE,
     VIS_TYPE_YEAR_OVER_YEAR_COLUMN,
+    VIS_TYPE_SCATTER,
 } from '../../../../../modules/visTypes'
 import getYearOverYearTitle from '../title/yearOverYear'
 import {
@@ -58,6 +59,9 @@ export default function (series, layout, metaData, dashboard) {
                     metaData,
                     Boolean(!dashboard)
                 )
+                break
+            case VIS_TYPE_SCATTER:
+                subtitle.text = dashboard || filterTitle
                 break
             default:
                 subtitle = getDefault(layout, dashboard, filterTitle)

--- a/src/visualizations/config/adapters/dhis_highcharts/subtitle/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/subtitle/index.js
@@ -61,7 +61,7 @@ export default function (series, layout, metaData, dashboard) {
                 )
                 break
             case VIS_TYPE_SCATTER:
-                subtitle.text = dashboard || filterTitle
+                subtitle.text = filterTitle
                 break
             default:
                 subtitle = getDefault(layout, dashboard, filterTitle)

--- a/src/visualizations/config/adapters/dhis_highcharts/title/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/title/index.js
@@ -1,11 +1,14 @@
 import isString from 'd2-utilizr/lib/isString'
+
 import getFilterText from '../../../../util/getFilterText'
 import {
     VIS_TYPE_YEAR_OVER_YEAR_LINE,
     VIS_TYPE_YEAR_OVER_YEAR_COLUMN,
     VIS_TYPE_GAUGE,
+    VIS_TYPE_SCATTER,
 } from '../../../../../modules/visTypes'
 import getYearOverYearTitle from './yearOverYear'
+import getScatterTitle from './scatter'
 import {
     FONT_STYLE_OPTION_ITALIC,
     FONT_STYLE_OPTION_BOLD,
@@ -57,6 +60,9 @@ export default function (layout, metaData, dashboard) {
             case VIS_TYPE_YEAR_OVER_YEAR_LINE:
             case VIS_TYPE_YEAR_OVER_YEAR_COLUMN:
                 title.text = getYearOverYearTitle(layout, metaData, dashboard)
+                break
+            case VIS_TYPE_SCATTER:
+                title.text = getScatterTitle(layout, metaData, dashboard)
                 break
             default:
                 title.text = getDefault(layout, metaData, dashboard)

--- a/src/visualizations/config/adapters/dhis_highcharts/title/scatter.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/title/scatter.js
@@ -1,0 +1,10 @@
+import getFilterText from '../../../../util/getFilterText'
+
+export default function (layout, metaData, dashboard) {
+    if (layout.rows?.length && layout.columns?.length && !dashboard) {
+        const columns = getFilterText(layout.columns, metaData).split(', ')
+        return `${getFilterText(layout.rows, metaData)}: ${columns[0]} - ${
+            columns[1]
+        }`
+    }
+}


### PR DESCRIPTION
Implements [DHIS2-10170](https://jira.dhis2.org/browse/DHIS2-10170)

---

### Key features

1. New title and subtitle format for Scatter

---

### Description

Changes the format of the auto-generated title and subtitle for Scatter. Title now gets `Points: Vertical, Horizontal` and subtitle is always `Filters` (regardless if a user-defined title is present or not). 

---

### Screenshots

_auto generated_
![image](https://user-images.githubusercontent.com/12590483/104292311-f707cb00-54bc-11eb-97bd-a69be1a29dcb.png)

_with user-defined title_
![image](https://user-images.githubusercontent.com/12590483/104292330-fcfdac00-54bc-11eb-87a8-562ec7ac9d50.png)

_with user-defined subtitle (but default title)_
![image](https://user-images.githubusercontent.com/12590483/104292360-0a1a9b00-54bd-11eb-988a-ec5ce9d386eb.png)
