### PR TITLE
fix: add default color for values out of bounds (DHIS2-147)

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/legendSet.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/legendSet.js
@@ -3,6 +3,8 @@ import i18n from '@dhis2/d2-i18n'
 
 import { getLegendByValueFromLegendSet } from '../../../../modules/legends'
 
+const OUT_OF_BOUNDS_COLOR = '#CCCCCC'
+
 const getLegend = (value, legendSet) =>
     value && legendSet ? getLegendByValueFromLegendSet(legendSet, value) : {}
 
@@ -14,7 +16,9 @@ export const applyLegendSet = (seriesObj, legendSet) =>
                   isNumeric(value) // Single category pass data as [value1, value2]
                       ? {
                             y: value,
-                            color: getLegend(value, legendSet)?.color,
+                            color:
+                                getLegend(value, legendSet)?.color ||
+                                OUT_OF_BOUNDS_COLOR,
                             legend: getLegend(value, legendSet)?.name || '-',
                             legendSet: legendSet.name,
                         }
@@ -22,7 +26,9 @@ export const applyLegendSet = (seriesObj, legendSet) =>
                       ? {
                             x: value[0],
                             y: value[1],
-                            color: getLegend(value[1], legendSet)?.color,
+                            color:
+                                getLegend(value[1], legendSet)?.color ||
+                                OUT_OF_BOUNDS_COLOR,
                             legend: getLegend(value[1], legendSet)?.name || '-',
                             legendSet: legendSet.name,
                         }


### PR DESCRIPTION
Fix for [DHIS2-147](https://jira.dhis2.org/browse/DHIS2-147)

---

### Key features

1. Add a default color for values that are out of bounds

---

### Description

Previously, when a legend set was applied and a value was out of bounds of its range no color change would be applied. This was changed to apply a default color for those types of values. As discussed on [Slack](https://dhis2.slack.com/archives/G3TL0J145/p1610552136022500?thread_ts=1610541490.014900&cid=G3TL0J145).

---

### Screenshots

_before fix: values out of bounds used their original colors (red and orange)._
![image](https://user-images.githubusercontent.com/12590483/104564069-c190e800-564a-11eb-862e-bd71f6013899.png)

_after fix: values out of bounds are coloured gray._
![image](https://user-images.githubusercontent.com/12590483/104564403-25b3ac00-564b-11eb-8d64-8b5e5b9851be.png)

