### PR TITLE
fix: fix hide empty categories with non-available data DHIS2-8174

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/getTrimmedConfig.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/getTrimmedConfig.js
@@ -19,7 +19,8 @@ function getEmptySeriesIndexes(series) {
         seriesValues = []
 
         series.forEach(seriesObj => {
-            seriesValues.push(seriesObj.data[index])
+            // handle undefined values due to empty (or shorter) serie data
+            seriesValues.push(seriesObj.data[index] || null)
         })
 
         if (arrayNullsOnly(seriesValues)) {

--- a/src/visualizations/config/adapters/dhis_highcharts/getTrimmedConfig.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/getTrimmedConfig.js
@@ -18,9 +18,10 @@ function getEmptySeriesIndexes(series) {
     series[0].data.forEach((value, index) => {
         seriesValues = []
 
-        series.forEach(seriesObj => {
+        series.forEach(({ data }) => {
             // handle undefined values due to empty (or shorter) serie data
-            seriesValues.push(seriesObj.data[index] || null)
+            // preserve 0 as valid value
+            seriesValues.push(data[index] === undefined ? null : data[index])
         })
 
         if (arrayNullsOnly(seriesValues)) {


### PR DESCRIPTION
Fixed [DHIS2-8174](https://jira.dhis2.org/browse/DHIS2-8174)


---

### Key features

1. Fixes a bug when using Hide empty categories option in DV in some circumstances

---

### Description

The bug caused the Hide empty categories option in DV to not work when
one or more of the dx dimensions had no data (ie. empty array in the
response from analytics).

Empty data caused `undefined` values to be added to the list checked for
all `null` values.
With this check failing, the index in the category list
was never added to the list of empty category indexes, thus the chart
was not "filtered".

---

### Screenshots
In this example, *ART enrollment data 4* has no values in `data`, while the other dimensions have `null` corresponding to the empty categories:
![Screenshot 2021-01-20 at 17 08 38](https://user-images.githubusercontent.com/150978/105202331-27490c80-5b42-11eb-8c4b-0d6ad5150306.png)
![Screenshot 2021-01-20 at 17 10 26](https://user-images.githubusercontent.com/150978/105202555-670ff400-5b42-11eb-80a6-3166f94c0836.png)

Before:
![Screenshot 2021-01-20 at 17 04 57](https://user-images.githubusercontent.com/150978/105201861-a2f68980-5b41-11eb-8052-165775c47dc6.png)

After:
![Screenshot 2021-01-20 at 17 05 50](https://user-images.githubusercontent.com/150978/105201972-c28db200-5b41-11eb-9d87-2a2b567f059f.png)
