### PR TITLE
fix: only pass fixed dimensions as dimension for data value sets (DHIS2-9789)

### DIFF
--- a/src/api/analytics/AnalyticsRequest.js
+++ b/src/api/analytics/AnalyticsRequest.js
@@ -2,6 +2,7 @@ import AnalyticsRequestDimensionsMixin from './AnalyticsRequestDimensionsMixin'
 import AnalyticsRequestFiltersMixin from './AnalyticsRequestFiltersMixin'
 import AnalyticsRequestPropertiesMixin from './AnalyticsRequestPropertiesMixin'
 import AnalyticsRequestBase from './AnalyticsRequestBase'
+import { getFixedDimensions } from '../../modules/predefinedDimensions'
 
 /**
  * @description
@@ -63,16 +64,20 @@ class AnalyticsRequest extends AnalyticsRequestDimensionsMixin(
         // extract filters from visualization
         const filters = visualization.filters || []
 
+        // only pass dx/pe/ou as dimension
+        const fixedIds = Object.keys(getFixedDimensions())
+
         filters.forEach(f => {
-            request = passFilterAsDimension
-                ? request.addDimension(
-                      f.dimension,
-                      f.items.map(item => item.id)
-                  )
-                : request.addFilter(
-                      f.dimension,
-                      f.items.map(item => item.id)
-                  )
+            request =
+                passFilterAsDimension && fixedIds.includes(f.dimension)
+                    ? request.addDimension(
+                          f.dimension,
+                          f.items.map(item => item.id)
+                      )
+                    : request.addFilter(
+                          f.dimension,
+                          f.items.map(item => item.id)
+                      )
         })
 
         return request


### PR DESCRIPTION
Implements the analytics part of [DHIS2-9789](https://jira.dhis2.org/browse/DHIS2-9789)

### Description

For data value sets we want to always pass data, period and orgunits as dimensions. Currently all filters were requested as dimensions. This fix makes sure that dynamic dimensions that is set as filter are still requested as filters.