### PR TITLE
fix: restore buildUrl and buildQuery functions

### DIFF
--- a/src/api/analytics/AnalyticsRequestBase.js
+++ b/src/api/analytics/AnalyticsRequestBase.js
@@ -1,3 +1,6 @@
+import sortBy from 'lodash/sortBy'
+import { customEncodeURIComponent } from './utils'
+
 /**
  * @private
  * @description
@@ -26,6 +29,87 @@ class AnalyticsRequestBase {
         this.dimensions = dimensions
         this.filters = filters
         this.parameters = { ...parameters }
+    }
+
+    /**
+     * @private
+     * @description
+     * Builds the URL to pass to the Api object.
+     * The URL includes the dimension(s) parameters.
+     * Used internally.
+     *
+     * @param {Object} options Optional configurations
+     *
+     * @returns {String} URL URL for the request with dimensions included
+     */
+    buildUrl(options) {
+        // at least 1 dimension is required
+        let dimensions = this.dimensions
+
+        if (options && options.sorted) {
+            dimensions = sortBy(dimensions, 'dimension')
+        }
+
+        const encodedDimensions = dimensions.map(({ dimension, items }) => {
+            if (Array.isArray(items) && items.length) {
+                const encodedItems = items.map(customEncodeURIComponent)
+                if (options && options.sorted) {
+                    encodedItems.sort()
+                }
+
+                return `${dimension}:${encodedItems.join(';')}`
+            }
+
+            return dimension
+        })
+
+        const endPoint = [this.endPoint, this.path, this.program]
+            .filter(e => !!e)
+            .join('/')
+
+        return `${endPoint}.${this.format}?dimension=${encodedDimensions.join(
+            '&dimension='
+        )}`
+    }
+
+    /**
+     * @private
+     * @description
+     * Builds the query object passed to the API instance.
+     * The object includes all the parameters added via with*() methods
+     * and the filters added via addDataFilter(), addPeriodFilter(), addOrgUnitFilter(), addFilter().
+     * The filters are handled by the API instance when building the final URL.
+     * Used internally.
+     *
+     * @param {Object} options Optional configurations
+     *
+     * @returns {Object} Query parameters
+     */
+    buildQuery(options) {
+        let filters = this.filters
+
+        if (options && options.sorted) {
+            filters = sortBy(filters, 'dimension')
+        }
+
+        const encodedFilters = filters.map(({ dimension, items }) => {
+            if (Array.isArray(items) && items.length) {
+                const encodedItems = items.map(customEncodeURIComponent)
+                if (options && options.sorted) {
+                    encodedItems.sort()
+                }
+
+                return `${dimension}:${encodedItems.join(';')}`
+            }
+
+            return dimension
+        })
+
+        if (filters.length) {
+            this.parameters.filter = encodedFilters
+        }
+
+        return this.parameters
     }
 }
 

--- a/src/api/analytics/__tests__/AnalyticsRequestBase.spec.js
+++ b/src/api/analytics/__tests__/AnalyticsRequestBase.spec.js
@@ -1,0 +1,101 @@
+import AnalyticsRequestBase from '../AnalyticsRequestBase'
+import { customEncodeURIComponent } from '../utils'
+
+jest.mock('../utils', () => ({
+    customEncodeURIComponent: jest.fn(x => `<${x}>`),
+}))
+
+const endPoint = 'foo'
+const path = 'bar'
+const program = 'census'
+const format = 'json'
+
+const basePath = `${endPoint}/${path}/${program}.${format}`
+const dimensions = [
+    { dimension: 'ou', items: ['mars', 'earth'] },
+    { dimension: 'dx', items: ['population'] },
+    { dimension: 'question' },
+    { dimension: 'answer', items: ['42'] },
+]
+const buildRequest = overrides => {
+    return new AnalyticsRequestBase({
+        endPoint,
+        path,
+        program,
+        format,
+        parameters: {
+            foo: 'bar',
+        },
+        ...overrides,
+    })
+}
+
+describe('AnalyticsRequestBase', () => {
+    beforeEach(() => {
+        customEncodeURIComponent.mockClear()
+    })
+
+    it('Should build a URL of encoded dimension parameters', () => {
+        const request = buildRequest({ dimensions })
+        const url = request.buildUrl()
+        expect(customEncodeURIComponent).toHaveBeenCalledTimes(4)
+        expect(url).toBe(
+            `${basePath}?dimension=ou:<mars>;<earth>&dimension=dx:<population>&dimension=question&dimension=answer:<42>`
+        )
+    })
+
+    it('Should build a URL with sorted dimension parameters when options.sorted=true', () => {
+        const request = buildRequest({ dimensions })
+        const url = request.buildUrl({ sorted: true })
+        expect(customEncodeURIComponent).toHaveBeenCalledTimes(4)
+        expect(url).toBe(
+            `${basePath}?dimension=answer:<42>&dimension=dx:<population>&dimension=ou:<earth>;<mars>&dimension=question`
+        )
+    })
+
+    it('Should not choke on a null or empty filter array', () => {
+        const request = buildRequest()
+        const query = request.buildQuery()
+        expect(customEncodeURIComponent).toHaveBeenCalledTimes(0)
+        expect(query).toMatchObject({
+            foo: 'bar',
+        })
+
+        const request2 = buildRequest({ filters: [] })
+        const query2 = request2.buildQuery()
+        expect(customEncodeURIComponent).toHaveBeenCalledTimes(0)
+        expect(query2).toMatchObject({
+            foo: 'bar',
+        })
+    })
+
+    it('Should build a query with encoded filter parameters', () => {
+        const request = buildRequest({ filters: dimensions })
+        const query = request.buildQuery()
+        expect(customEncodeURIComponent).toHaveBeenCalledTimes(4)
+        expect(query).toMatchObject({
+            foo: 'bar',
+            filter: [
+                'ou:<mars>;<earth>',
+                'dx:<population>',
+                'question',
+                'answer:<42>',
+            ],
+        })
+    })
+
+    it('Should build a query with sorted filter parameters when options.sorted=true', () => {
+        const request = buildRequest({ filters: dimensions })
+        const query = request.buildQuery({ sorted: true })
+        expect(customEncodeURIComponent).toHaveBeenCalledTimes(4)
+        expect(query).toMatchObject({
+            foo: 'bar',
+            filter: [
+                'answer:<42>',
+                'dx:<population>',
+                'ou:<earth>;<mars>',
+                'question',
+            ],
+        })
+    })
+})

--- a/src/api/analytics/utils.js
+++ b/src/api/analytics/utils.js
@@ -1,0 +1,7 @@
+// Define our very own special list of characters that we don't want to encode in the URI
+const whitelistURI = ',&$=/;:'
+const whitelistURICodes = whitelistURI.split('').map(c => encodeURIComponent(c))
+const whitelistRegExp = new RegExp(`(?:${whitelistURICodes.join('|')})`, 'g')
+
+export const customEncodeURIComponent = uri =>
+    encodeURIComponent(uri).replace(whitelistRegExp, decodeURIComponent)


### PR DESCRIPTION
Part of the fix for [DHIS2-9789](https://jira.dhis2.org/browse/DHIS2-9789)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/1581**

---

### Key features

1. restore `buildUrl` and `buildQuery` functions

---

### Description

These functions are needed for building the URLs used in the download menu in
DV.