### PR TITLE
fix: add data-test attributes for testing, fixed delete callback

### DIFF
--- a/src/components/FileMenu/DeleteDialog.js
+++ b/src/components/FileMenu/DeleteDialog.js
@@ -30,12 +30,11 @@ export const DeleteDialog = ({ type, id, onClose, onDelete, onError }) => {
         },
         onComplete: () => {
             onDelete()
-            onClose()
         },
     })
 
     return (
-        <Modal onClose={onClose}>
+        <Modal onClose={onClose} dataTest="file-menu-delete-modal">
             <ModalTitle>
                 {i18n.t('Delete {{fileType}}', { fileType: type })}
             </ModalTitle>
@@ -46,10 +45,18 @@ export const DeleteDialog = ({ type, id, onClose, onDelete, onError }) => {
             </ModalContent>
             <ModalActions>
                 <ButtonStrip>
-                    <Button onClick={onClose} secondary>
+                    <Button
+                        onClick={onClose}
+                        secondary
+                        dataTest="file-menu-delete-modal-cancel"
+                    >
                         {i18n.t('Cancel')}
                     </Button>
-                    <Button onClick={mutate} destructive>
+                    <Button
+                        onClick={mutate}
+                        destructive
+                        dataTest="file-menu-delete-modal-delete"
+                    >
                         {i18n.t('Delete')}
                     </Button>
                 </ButtonStrip>

--- a/src/components/FileMenu/FileMenu.js
+++ b/src/components/FileMenu/FileMenu.js
@@ -48,6 +48,12 @@ export const FileMenu = ({
     const [menuIsOpen, setMenuIsOpen] = useState(false)
     const [openDialog, setOpenDialog] = useState(null)
 
+    // Escape key press closes the menu
+    const onKeyDown = e => {
+        if (e?.keyCode === 27) {
+            setMenuIsOpen(false)
+        }
+    }
     const onMenuItemClick = dialogToOpen => () => {
         setMenuIsOpen(false)
         setOpenDialog(dialogToOpen)
@@ -151,7 +157,7 @@ export const FileMenu = ({
     const iconInactiveColor = colors.grey500
 
     return (
-        <>
+        <div onKeyDown={onKeyDown}>
             <style jsx>{fileMenuStyles}</style>
             <div ref={buttonRef}>
                 <button
@@ -341,7 +347,7 @@ export const FileMenu = ({
                 </Layer>
             )}
             {renderDialog()}
-        </>
+        </div>
     )
 }
 

--- a/src/components/FileMenu/FileMenu.js
+++ b/src/components/FileMenu/FileMenu.js
@@ -54,6 +54,14 @@ export const FileMenu = ({
     }
     const onDialogClose = () => setOpenDialog(null)
     const toggleMenu = () => setMenuIsOpen(!menuIsOpen)
+    const onDeleteConfirm = () => {
+        // The dialog must be closed before calling the callback
+        // otherwise the fileObject is changed to null before the
+        // dialog is closed causing a crash in renderDialog() below
+        // due to fileObject.id not being available
+        onDialogClose()
+        onDelete()
+    }
 
     const buttonRef = createRef()
 
@@ -120,7 +128,7 @@ export const FileMenu = ({
                     <DeleteDialog
                         type={fileType}
                         id={fileObject.id}
-                        onDelete={onDelete}
+                        onDelete={onDeleteConfirm}
                         onError={onError}
                         onClose={onDialogClose}
                     />
@@ -146,14 +154,23 @@ export const FileMenu = ({
         <>
             <style jsx>{fileMenuStyles}</style>
             <div ref={buttonRef}>
-                <button className="menu-toggle" onClick={toggleMenu}>
+                <button
+                    className="menu-toggle"
+                    onClick={toggleMenu}
+                    data-test="file-menu-toggle"
+                >
                     {i18n.t('File')}
                 </button>
             </div>
             {menuIsOpen && (
-                <Layer onClick={toggleMenu} position="fixed" level={2000}>
+                <Layer
+                    onClick={toggleMenu}
+                    position="fixed"
+                    level={2000}
+                    dataTest="file-menu-toggle-layer"
+                >
                     <Popper reference={buttonRef} placement="bottom-start">
-                        <FlyoutMenu>
+                        <FlyoutMenu dataTest="file-menu-container">
                             <MenuItem
                                 label={i18n.t('New')}
                                 icon={<IconAdd24 color={iconActiveColor} />}
@@ -161,12 +178,14 @@ export const FileMenu = ({
                                     toggleMenu()
                                     onNew()
                                 }}
+                                dataTest="file-menu-new"
                             />
                             <MenuDivider />
                             <MenuItem
                                 label={i18n.t('Open…')}
                                 icon={<IconLaunch24 color={iconActiveColor} />}
                                 onClick={onMenuItemClick('open')}
+                                dataTest="file-menu-open"
                             />
                             <MenuItem
                                 label={
@@ -185,16 +204,20 @@ export const FileMenu = ({
                                     />
                                 }
                                 disabled={
-                                    !(!fileObject || fileObject?.access?.update)
+                                    !(
+                                        !fileObject?.id ||
+                                        fileObject?.access?.update
+                                    )
                                 }
                                 onClick={
-                                    fileObject
+                                    fileObject?.id
                                         ? () => {
                                               toggleMenu()
                                               onSave()
                                           }
                                         : onMenuItemClick('saveas')
                                 }
+                                dataTest="file-menu-save"
                             />
                             <MenuItem
                                 label={i18n.t('Save as…')}
@@ -207,8 +230,9 @@ export const FileMenu = ({
                                         }
                                     />
                                 }
-                                disabled={!fileObject}
+                                disabled={!fileObject?.id}
                                 onClick={onMenuItemClick('saveas')}
+                                dataTest="file-menu-saveas"
                             />
                             <MenuItem
                                 label={i18n.t('Rename…')}
@@ -229,6 +253,7 @@ export const FileMenu = ({
                                     )
                                 }
                                 onClick={onMenuItemClick('rename')}
+                                dataTest="file-menu-rename"
                             />
                             <MenuItem
                                 label={i18n.t('Translate…')}
@@ -249,6 +274,7 @@ export const FileMenu = ({
                                     )
                                 }
                                 onClick={onMenuItemClick('translate')}
+                                dataTest="file-menu-translate"
                             />
                             <MenuDivider />
                             <MenuItem
@@ -270,6 +296,7 @@ export const FileMenu = ({
                                     )
                                 }
                                 onClick={onMenuItemClick('sharing')}
+                                dataTest="file-menu-sharing"
                             />
                             <MenuItem
                                 label={i18n.t('Get link…')}
@@ -284,6 +311,7 @@ export const FileMenu = ({
                                 }
                                 disabled={!fileObject?.id}
                                 onClick={onMenuItemClick('getlink')}
+                                dataTest="file-menu-getlink"
                             />
                             <MenuDivider />
                             <MenuItem
@@ -306,6 +334,7 @@ export const FileMenu = ({
                                     )
                                 }
                                 onClick={onMenuItemClick('delete')}
+                                dataTest="file-menu-delete"
                             />
                         </FlyoutMenu>
                     </Popper>

--- a/src/components/FileMenu/SaveAsDialog.js
+++ b/src/components/FileMenu/SaveAsDialog.js
@@ -30,7 +30,7 @@ export const SaveAsDialog = ({ type, object, onClose, onSaveAs }) => {
     }
 
     return (
-        <Modal onClose={onClose}>
+        <Modal onClose={onClose} dataTest="file-menu-saveas-modal">
             <ModalTitle>
                 {i18n.t('Save {{fileType}} as', { fileType: type })}
             </ModalTitle>
@@ -40,20 +40,30 @@ export const SaveAsDialog = ({ type, object, onClose, onSaveAs }) => {
                     required
                     value={name}
                     onChange={({ value }) => setName(value)}
+                    dataTest="file-menu-saveas-modal-name"
                 />
                 <TextAreaField
                     label={i18n.t('Description')}
                     value={description}
                     rows={3}
                     onChange={({ value }) => setDescription(value)}
+                    dataTest="file-menu-saveas-modal-description"
                 />
             </ModalContent>
             <ModalActions>
                 <ButtonStrip>
-                    <Button onClick={onClose} secondary>
+                    <Button
+                        onClick={onClose}
+                        secondary
+                        dataTest="file-menu-saveas-modal-cancel"
+                    >
                         {i18n.t('Cancel')}
                     </Button>
-                    <Button onClick={saveObjectAs} primary>
+                    <Button
+                        onClick={saveObjectAs}
+                        primary
+                        dataTest="file-menu-saveas-modal-save"
+                    >
                         {i18n.t('Save')}
                     </Button>
                 </ButtonStrip>


### PR DESCRIPTION
Part of the implementation of [DHIS2-9821](https://jira.dhis2.org/browse/DHIS2-9821)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/1361**

---

### Key features

1. Add `data-test` attributes to elements for testing purposes
2. Changed the way the delete callback is triggered, to avoid a crash if the AO is deleted before the delete dialog is closed
3. Support Escape key for closing the menu

---

### Description

This changes are necessary for the DV cypress tests to pass.
