### PR TITLE
fix: series item color set color of middle legend in legendset (DHIS2-147)

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/index.js
@@ -91,7 +91,7 @@ export default function ({ store, layout, el, extraConfig, extraOptions }) {
         // series
         series: getSeries(
             series.slice(),
-            store,
+            store.data[0].metaData,
             _layout,
             stacked,
             _extraOptions

--- a/src/visualizations/config/adapters/dhis_highcharts/series/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/index.js
@@ -175,12 +175,15 @@ function getDefault(series, metaData, layout, isStacked, extraOptions) {
 
         // color
         if (isYearOverYear(layout.type)) {
+            // YearOverYear: Fetch colors directly from color sets
             seriesObj.color = indexColorPatternMap[index]
         } else if (legendSet && legendSet.legends?.length) {
+            // Legendset: Fetch the middle color of the set
             seriesObj.color = legendSet.legends.sort(
                 (a, b) => a.startValue - b.startValue
             )[Math.ceil(legendSet.legends.length / 2) - 1]?.color
         } else {
+            // Default: Either generate colors or fetch from color sets
             seriesObj.color = idColorMap[seriesObj.id]
         }
 

--- a/src/visualizations/config/adapters/dhis_highcharts/series/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/index.js
@@ -181,7 +181,7 @@ function getDefault(series, metaData, layout, isStacked, extraOptions) {
             // Legendset: Fetch the middle color of the set
             seriesObj.color = legendSet.legends.sort(
                 (a, b) => a.startValue - b.startValue
-            )[Math.ceil(legendSet.legends.length / 2) - 1]?.color
+            )[Math.ceil(legendSet.legends.length / 2) - 1].color
         } else {
             // Default: Either generate colors or fetch from color sets
             seriesObj.color = idColorMap[seriesObj.id]


### PR DESCRIPTION
Implements [DHIS2-147](https://jira.dhis2.org/browse/DHIS2-147)

---

### Key features

1. Sets the series item to the color of the legend in the middle of a legendset


---

### Description

When a legendset is used for a series item, the colored bullet in the legend needs to reflect the legendset color somehow. This is now done by using the color of the legend in the middle of the legendset. E.g. if a legendset contains legends `1, 2, 3, 4, 5` then the bullet will be in the color of `legend 3`.

---

### Screenshots

_example of the color being applied to series items when [this legend](https://debug.dhis2.org/dev/dhis-web-maintenance/index.html#/edit/otherSection/legendSet/fqs276KXCXi) is in use_
![image](https://user-images.githubusercontent.com/12590483/107229863-a1bccc00-6a1e-11eb-9429-8b5e7d512447.png)

