### PR TITLE
fix: legendset bugs (DHIS2-147)

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/series/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/index.js
@@ -18,10 +18,15 @@ import {
     isYearOverYear,
     VIS_TYPE_LINE,
     VIS_TYPE_SCATTER,
+    isLegendSetType,
 } from '../../../../../modules/visTypes'
 import { hasCustomAxes } from '../../../../../modules/axis'
 import { getAxisStringFromId } from '../../../../util/axisId'
 import { axisHasRelativeItems } from '../../../../../modules/layout/axisHasRelativeItems'
+import {
+    LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM,
+    LEGEND_DISPLAY_STRATEGY_FIXED,
+} from '../../../../../modules/legends'
 
 const DEFAULT_ANIMATION_DURATION = 200
 
@@ -168,16 +173,29 @@ function getDefault(series, metaData, layout, isStacked, extraOptions) {
             seriesObj.groupPadding = 0
         }
 
-        const legendSet = extraOptions?.legendSets?.find(
-            legendSet =>
-                legendSet.id === metaData.items[seriesObj.id]?.legendSet
-        )
+        let legendSet
+        if (isLegendSetType(layout.type)) {
+            const legendSets = extraOptions?.legendSets || []
+            if (
+                layout.legendDisplayStrategy ===
+                LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM
+            ) {
+                legendSet = legendSets.find(
+                    legendSet =>
+                        legendSet.id === metaData.items[seriesObj.id]?.legendSet
+                )
+            } else if (
+                layout.legendDisplayStrategy === LEGEND_DISPLAY_STRATEGY_FIXED
+            ) {
+                legendSet = legendSets[0]
+            }
+        }
 
         // color
         if (isYearOverYear(layout.type)) {
             // YearOverYear: Fetch colors directly from color sets
             seriesObj.color = indexColorPatternMap[index]
-        } else if (legendSet && legendSet.legends?.length) {
+        } else if (legendSet?.legends?.length) {
             // Legendset: Fetch the middle color of the set
             seriesObj.color = legendSet.legends.sort(
                 (a, b) => a.startValue - b.startValue


### PR DESCRIPTION
Implements [DHIS2-147](https://jira.dhis2.org/browse/DHIS2-147)

---

### Key features

1. Prevent legendset colors to be displayed for non-supported vistypes
2. Apply correct colors to series item bullets

---

### Description

Fixes the two issues described above. See screenshots of before and after for more info:

---

### Screenshots

_1: Before, unsupported type (Stacked column) incorrectly showed the legend color that was applied to a supported type and then persisted during the vis type switch_
![image](https://user-images.githubusercontent.com/12590483/107524051-a667b880-6bb5-11eb-8612-c27247c29698.png)



_1: After, unsupported type (Stacked column) is prevented from receiving the legend color_
![image](https://user-images.githubusercontent.com/12590483/107524125-c0090000-6bb5-11eb-932c-6387720995f1.png)



_2: Before, using a single legend for the visualization didn't color the series item bullets correctly_
![image](https://user-images.githubusercontent.com/12590483/107523238-ce0a5100-6bb4-11eb-9833-6b9cea2e42f5.png)



_2: After, both series items get the proper color_
![image](https://user-images.githubusercontent.com/12590483/107523323-e4b0a800-6bb4-11eb-986c-76fd3346c4eb.png)

