### PR TITLE
fix: pin styled-jsx to 3.3.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.eslintcache
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
         "enzyme-adapter-react-16": "^1.15.5",
         "fs-extra": "^9.0.1",
         "jest-enzyme": "^7.0.2",
-        "typeface-roboto": "^0.0.75",
-        "styled-jsx": "^3.3.2"
+        "styled-jsx": "3.3.2",
+        "typeface-roboto": "^0.0.75"
     },
     "peerDependencies": {
         "@dhis2/app-runtime": "^2.6.1",
@@ -70,6 +70,7 @@
         "build"
     ],
     "resolutions": {
-        "@dhis2/ui": "^6.1.3"
+        "@dhis2/ui": "^6.1.3",
+        "styled-jsx": "3.3.2"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -178,7 +178,7 @@
   dependencies:
     "@babel/types" "^7.12.7"
 
-"@babel/helper-module-imports@7.12.5", "@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.12.1", "@babel/helper-module-imports@^7.12.5":
+"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.12.1", "@babel/helper-module-imports@^7.12.5":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz#1bfc0229f794988f76ed0a4d4e90860850b54dfb"
   integrity sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==
@@ -17184,12 +17184,11 @@ style-loader@1.3.0, style-loader@^1.0.0, style-loader@^1.2.1:
     loader-utils "^2.0.0"
     schema-utils "^2.7.0"
 
-styled-jsx@^3.2.2, styled-jsx@^3.2.5, styled-jsx@^3.3.2:
-  version "3.4.3"
-  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.4.3.tgz#0cffde2f979329ed2ed53ab79548af33ce5f7504"
-  integrity sha512-2ry6bKgCrW7LMRGdJsnm6OmOItihb/zTM7R6aOpURSQjJQI25mJY/WpIYgI2MPXiUMncTBo/5dVUwVQxZVyQHw==
+styled-jsx@3.3.2, styled-jsx@^3.2.2, styled-jsx@^3.2.5:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/styled-jsx/-/styled-jsx-3.3.2.tgz#2474601a26670a6049fb4d3f94bd91695b3ce018"
+  integrity sha512-daAkGd5mqhbBhLd6jYAjYBa9LpxYCzsgo/f6qzPdFxVB8yoGbhxvzQgkC0pfmCVvW3JuAEBn0UzFLBfkHVZG1g==
   dependencies:
-    "@babel/helper-module-imports" "7.12.5"
     "@babel/types" "7.8.3"
     babel-plugin-syntax-jsx "6.18.0"
     convert-source-map "1.7.0"


### PR DESCRIPTION
We need to pin version 3.3.2 of `styled-jsx` (particularly the babel plugin used by `@dhis2/cli-app-scripts`) to avoid [this bug](https://github.com/vercel/styled-jsx/issues/695) (again, @martinkrulltott already fixed this but then I upgraded `styled-jsx` and here we are)

We should pin this version in github.com/dhis2/app-platform directly, then this resolution won't be needed