### PR TITLE
fix: data dim selector improvements (DHIS2-7943)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-02-10T14:32:21.690Z\n"
-"PO-Revision-Date: 2021-02-10T14:32:21.690Z\n"
+"POT-Creation-Date: 2021-02-19T13:51:23.537Z\n"
+"PO-Revision-Date: 2021-02-19T13:51:23.537Z\n"
 
 msgid "Data Type"
 msgstr ""
@@ -53,22 +53,22 @@ msgstr ""
 msgid "No program indicators found"
 msgstr ""
 
-msgid "No indicators found for \"{{searchTerm}}\""
+msgid "No indicators found for \"{{- searchTerm}}\""
 msgstr ""
 
-msgid "No data elements found for \"{{searchTerm}}\""
+msgid "No data elements found for \"{{- searchTerm}}\""
 msgstr ""
 
-msgid "No data sets found for \"{{searchTerm}}\""
+msgid "No data sets found for \"{{- searchTerm}}\""
 msgstr ""
 
-msgid "No event data items found for \"{{searchTerm}}\""
+msgid "No event data items found for \"{{- searchTerm}}\""
 msgstr ""
 
-msgid "No program indicators found for \"{{searchTerm}}\""
+msgid "No program indicators found for \"{{- searchTerm}}\""
 msgstr ""
 
-msgid "Nothing found for \"{{searchTerm}}\""
+msgid "Nothing found for \"{{- searchTerm}}\""
 msgstr ""
 
 msgid "Metric type"

--- a/src/api/dimensions.js
+++ b/src/api/dimensions.js
@@ -48,7 +48,7 @@ export const dataItemsQuery = {
     resource: 'dataItems',
     params: ({ nameProp, filter, searchTerm, page }) => {
         const filters = []
-        const shouldSearch = (searchTerm || '').length >= 2
+        const shouldSearch = searchTerm && searchTerm.length
 
         // TODO: Extract all of this logic out of the query?
         if (filter?.dataType === EVENT_DATA_ITEMS) {

--- a/src/api/dimensions.js
+++ b/src/api/dimensions.js
@@ -69,6 +69,7 @@ export const dataItemsQuery = {
         if (shouldSearch) {
             filters.push(`${nameProp}:ilike:${searchTerm}`)
             filters.push(`id:eq:${searchTerm}`)
+            // TODO: Replace both with `identifiable:token:${searchTerm}` and remove rootJunction below
         }
 
         return objectClean({
@@ -92,7 +93,7 @@ export const indicatorsQuery = {
         }
 
         if (searchTerm) {
-            filters.push(`${nameProp}:ilike:${searchTerm}`)
+            filters.push(`identifiable:token:${searchTerm}`)
         }
 
         return {
@@ -126,7 +127,7 @@ export const dataElementsQuery = {
         }
 
         if (searchTerm) {
-            filters.push(`${nameProp}:ilike:${searchTerm}`)
+            filters.push(`identifiable:token:${searchTerm}`)
         }
 
         return {
@@ -180,7 +181,7 @@ export const dataElementOperandsQuery = {
         }
 
         if (searchTerm) {
-            filters.push(`${nameProp}:ilike:${searchTerm}`)
+            filters.push(`identifiable:token:${searchTerm}`)
         }
 
         return {
@@ -199,7 +200,7 @@ export const dataSetsQuery = {
         const filters = []
 
         if (searchTerm) {
-            filters.push(`${nameProp}:ilike:${searchTerm}`)
+            filters.push(`identifiable:token:${searchTerm}`)
         }
 
         if (filter?.group && filter.group !== ALL_ID) {

--- a/src/components/DataDimension/ItemSelector.js
+++ b/src/components/DataDimension/ItemSelector.js
@@ -159,6 +159,7 @@ const SourceEmptyPlaceholder = ({
             case INDICATORS:
                 message = i18n.t('No indicators found for "{{searchTerm}}"', {
                     searchTerm: searchTerm,
+                    interpolation: { escapeValue: false },
                 })
                 break
             case DATA_ELEMENTS:
@@ -166,12 +167,14 @@ const SourceEmptyPlaceholder = ({
                     'No data elements found for "{{searchTerm}}"',
                     {
                         searchTerm: searchTerm,
+                        interpolation: { escapeValue: false },
                     }
                 )
                 break
             case DATA_SETS:
                 message = i18n.t('No data sets found for "{{searchTerm}}"', {
                     searchTerm: searchTerm,
+                    interpolation: { escapeValue: false },
                 })
                 break
             case EVENT_DATA_ITEMS:
@@ -179,6 +182,7 @@ const SourceEmptyPlaceholder = ({
                     'No event data items found for "{{searchTerm}}"',
                     {
                         searchTerm: searchTerm,
+                        interpolation: { escapeValue: false },
                     }
                 )
                 break
@@ -187,12 +191,14 @@ const SourceEmptyPlaceholder = ({
                     'No program indicators found for "{{searchTerm}}"',
                     {
                         searchTerm: searchTerm,
+                        interpolation: { escapeValue: false },
                     }
                 )
                 break
             default:
                 message = i18n.t('Nothing found for "{{searchTerm}}"', {
                     searchTerm: searchTerm,
+                    interpolation: { escapeValue: false },
                 })
                 break
         }
@@ -258,7 +264,7 @@ const ItemSelector = ({
                         item => item.id === state.filter.subGroup
                     )
                     newOptions.push({
-                        label: `${item.name} – ${metric.getName()}`,
+                        label: `${item.name} - ${metric.getName()}`,
                         value: `${item.id}.${metric.id}`,
                         disabled: item.disabled,
                         type: item.dimensionItemType,
@@ -266,7 +272,7 @@ const ItemSelector = ({
                 } else {
                     DATA_SETS_CONSTANTS.forEach(metric => {
                         newOptions.push({
-                            label: `${item.name} – ${metric.getName()}`,
+                            label: `${item.name} - ${metric.getName()}`,
                             value: `${item.id}.${metric.id}`,
                             disabled: item.disabled,
                             type: item.dimensionItemType,

--- a/src/components/DataDimension/ItemSelector.js
+++ b/src/components/DataDimension/ItemSelector.js
@@ -157,48 +157,42 @@ const SourceEmptyPlaceholder = ({
     } else if (!loading && !options.length && searchTerm) {
         switch (dataType) {
             case INDICATORS:
-                message = i18n.t('No indicators found for "{{searchTerm}}"', {
+                message = i18n.t('No indicators found for "{{- searchTerm}}"', {
                     searchTerm: searchTerm,
-                    interpolation: { escapeValue: false },
                 })
                 break
             case DATA_ELEMENTS:
                 message = i18n.t(
-                    'No data elements found for "{{searchTerm}}"',
+                    'No data elements found for "{{- searchTerm}}"',
                     {
                         searchTerm: searchTerm,
-                        interpolation: { escapeValue: false },
                     }
                 )
                 break
             case DATA_SETS:
-                message = i18n.t('No data sets found for "{{searchTerm}}"', {
+                message = i18n.t('No data sets found for "{{- searchTerm}}"', {
                     searchTerm: searchTerm,
-                    interpolation: { escapeValue: false },
                 })
                 break
             case EVENT_DATA_ITEMS:
                 message = i18n.t(
-                    'No event data items found for "{{searchTerm}}"',
+                    'No event data items found for "{{- searchTerm}}"',
                     {
                         searchTerm: searchTerm,
-                        interpolation: { escapeValue: false },
                     }
                 )
                 break
             case PROGRAM_INDICATORS:
                 message = i18n.t(
-                    'No program indicators found for "{{searchTerm}}"',
+                    'No program indicators found for "{{- searchTerm}}"',
                     {
                         searchTerm: searchTerm,
-                        interpolation: { escapeValue: false },
                     }
                 )
                 break
             default:
-                message = i18n.t('Nothing found for "{{searchTerm}}"', {
+                message = i18n.t('Nothing found for "{{- searchTerm}}"', {
                     searchTerm: searchTerm,
-                    interpolation: { escapeValue: false },
                 })
                 break
         }

--- a/src/visualizations/config/adapters/dhis_highcharts/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/index.js
@@ -139,7 +139,7 @@ export default function ({ store, layout, el, extraConfig, extraOptions }) {
             xAxisName,
             yAxisName,
             showLabels: _layout.showValues || _layout.showData,
-            tooltipData: getScatterData(series, store),
+            tooltipData: _extraOptions.scatterData,
         })
     }
 


### PR DESCRIPTION
Implements [DHIS2-7943](https://jira.dhis2.org/browse/DHIS2-7943)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/1619**


---

### Key features

1. Enable search for 1 char
2. Use correct dash for dataset items
3. Avoid double-escaping search term
4. Search backend with `identifiable:token` instead of `ilike`