### PR TITLE
fix: tooltip placement and only for data type all

### DIFF
--- a/src/components/DataDimension/ItemSelector.js
+++ b/src/components/DataDimension/ItemSelector.js
@@ -439,11 +439,15 @@ const ItemSelector = ({
                             props.value /* eslint-disable-line react/prop-types */
                         )
                     )}
-                    tooltipText={getTooltipText(
-                        getItemType(
-                            props.value /* eslint-disable-line react/prop-types */
-                        )
-                    )}
+                    tooltipText={
+                        state.filter.dataType === ALL_ID
+                            ? getTooltipText(
+                                  getItemType(
+                                      props.value /* eslint-disable-line react/prop-types */
+                                  )
+                              )
+                            : undefined
+                    }
                     dataTest={`${dataTest}-transfer-option`}
                 />
             )}

--- a/src/components/TransferOption.js
+++ b/src/components/TransferOption.js
@@ -48,7 +48,7 @@ export const TransferOption = ({
                 <Tooltip
                     key={`${value}`}
                     content={tooltipText}
-                    placement={'top-start'}
+                    placement={'top'}
                     openDelay={750}
                     closeDelay={150}
                 >


### PR DESCRIPTION
### Key features

1. Tooltip is only shown for data type `all`
2. Tooltip placement changed to `top`
