### PR TITLE
fix: use nameprop for dynamic dimension

### DIFF
--- a/src/api/dimensions.js
+++ b/src/api/dimensions.js
@@ -148,16 +148,16 @@ export const dataElementGroupsQuery = {
 export const itemsByDimensionQuery = {
     resource: `dimensions`,
     id: ({ id }) => `${id}/items`,
-    params: ({ searchTerm, page }) => {
+    params: ({ searchTerm, page, nameProp }) => {
         const filters = []
 
         if (searchTerm) {
-            filters.push(`name:ilike:${searchTerm}`)
+            filters.push(`${nameProp}:ilike:${searchTerm}`)
         }
 
         return {
-            fields: 'id,displayName~rename(name)',
-            order: 'displayName:asc',
+            fields: `id,${nameProp}~rename(name)`,
+            order: `${nameProp}:asc`,
             filter: filters,
             paging: true,
             page,
@@ -461,6 +461,7 @@ export const apiFetchItemsByDimension = async ({
     dimensionId,
     searchTerm,
     page,
+    nameProp,
 }) => {
     const itemsByDimensionData = await dataEngine.query(
         { itemsByDimensions: itemsByDimensionQuery },
@@ -469,6 +470,7 @@ export const apiFetchItemsByDimension = async ({
                 id: dimensionId,
                 searchTerm,
                 page,
+                nameProp,
             },
             onError,
         }

--- a/src/components/DynamicDimension/DynamicDimension.js
+++ b/src/components/DynamicDimension/DynamicDimension.js
@@ -12,6 +12,7 @@ export const DynamicDimension = ({
     selectedItems,
     rightFooter,
     dimensionTitle,
+    displayNameProp,
 }) => {
     const dataEngine = useDataEngine()
 
@@ -21,6 +22,7 @@ export const DynamicDimension = ({
             dimensionId,
             searchTerm,
             page,
+            nameProp: displayNameProp,
         })
 
     const onSelectItems = selectedItem =>
@@ -51,6 +53,7 @@ export const DynamicDimension = ({
 DynamicDimension.propTypes = {
     dimensionId: PropTypes.string.isRequired,
     dimensionTitle: PropTypes.string.isRequired,
+    displayNameProp: PropTypes.string.isRequired,
     selectedItems: PropTypes.arrayOf(
         PropTypes.shape({
             id: PropTypes.string,


### PR DESCRIPTION
**Relates to https://github.com/dhis2/data-visualizer-app/pull/1634**

---

### Key features

1. Dynamic dimension uses `displayNameProp`. 

---

### Description

`displayNameProp` was previously missing for Dynamic dimension so `displayName` was hardcoded and the user setting wasn't respected.

---

### BREAKING CHANGE

DynamicDimension requires displayNameProp

---


### Screenshots

_see DV task_
