### PR TITLE
fix: correct texts for outlier strings

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-02-25T08:47:22.024Z\n"
-"PO-Revision-Date: 2021-02-25T08:47:22.024Z\n"
+"POT-Creation-Date: 2021-03-01T13:18:57.193Z\n"
+"PO-Revision-Date: 2021-03-01T13:18:57.193Z\n"
 
 msgid "Data Type"
 msgstr ""
@@ -612,6 +612,30 @@ msgid "{{allDynamicOuNames}} levels in {{staticOuNames}}"
 msgstr ""
 
 msgid "{{allDynamicOuNames}} groups in {{staticOuNames}}"
+msgstr ""
+
+msgid "{{percentage}}% of total x values"
+msgstr ""
+
+msgid "{{percentage}}% of total y values"
+msgstr ""
+
+msgid "{{thresholdFactor}} × IQR Q1"
+msgstr ""
+
+msgid "{{thresholdFactor}} × IQR Q3"
+msgstr ""
+
+msgid "{{thresholdFactor}} × Modified Z-score low"
+msgstr ""
+
+msgid "{{thresholdFactor}} × Modified Z-score high"
+msgstr ""
+
+msgid "{{thresholdFactor}} × Z-score low"
+msgstr ""
+
+msgid "{{thresholdFactor}} × Z-score high"
 msgstr ""
 
 msgid "Data"

--- a/src/modules/outliers/index.js
+++ b/src/modules/outliers/index.js
@@ -53,7 +53,7 @@ const getExtremeLines = (percentage, xyStats) => {
     const yExtremeValue = xyStats.ySum * (percentage / 100)
 
     lines.push({
-        name: i18n.t('{{percentage}}% of Total X Values', {
+        name: i18n.t('{{percentage}}% of total x values', {
             percentage,
         }),
         value: xExtremeValue,
@@ -61,7 +61,7 @@ const getExtremeLines = (percentage, xyStats) => {
     })
 
     lines.push({
-        name: i18n.t('{{percentage}}% of Total Y Values', {
+        name: i18n.t('{{percentage}}% of total y values', {
             percentage,
         }),
         value: yExtremeValue,

--- a/src/modules/outliers/iqr.js
+++ b/src/modules/outliers/iqr.js
@@ -70,14 +70,14 @@ export const getIQRHelper = (dataWithNormalization, config, { xyStats }) => {
         name: IQR,
         thresholds: [
             {
-                name: i18n.t('{{thresholdFactor}} x IQR Q1', {
+                name: i18n.t('{{thresholdFactor}} × IQR Q1', {
                     thresholdFactor: config[PROP_THRESHOLD_FACTOR],
                 }),
                 value: q1Threshold,
                 line: q1ThresholdLine,
             },
             {
-                name: i18n.t('{{thresholdFactor}} x IQR Q3', {
+                name: i18n.t('{{thresholdFactor}} × IQR Q3', {
                     thresholdFactor: config[PROP_THRESHOLD_FACTOR],
                 }),
                 value: q3Threshold,

--- a/src/modules/outliers/modZScore.js
+++ b/src/modules/outliers/modZScore.js
@@ -140,14 +140,14 @@ export const getModZScoreHelper = (
         name: MODIFIED_Z_SCORE,
         thresholds: [
             {
-                name: i18n.t('{{thresholdFactor}} x Modified Z-score Low', {
+                name: i18n.t('{{thresholdFactor}} × Modified Z-score low', {
                     thresholdFactor: config[PROP_THRESHOLD_FACTOR],
                 }),
                 value: lowThreshold,
                 line: lowThresholdLine,
             },
             {
-                name: i18n.t('{{thresholdFactor}} x Modified Z-score High', {
+                name: i18n.t('{{thresholdFactor}} × Modified Z-score high', {
                     thresholdFactor: config[PROP_THRESHOLD_FACTOR],
                 }),
                 value: highThreshold,

--- a/src/modules/outliers/zScore.js
+++ b/src/modules/outliers/zScore.js
@@ -42,14 +42,14 @@ export const getZScoreHelper = (dataWithNormalization, config, { xyStats }) => {
         name: STANDARD_Z_SCORE,
         thresholds: [
             {
-                name: i18n.t('{{thresholdFactor}} x Z-score Low', {
+                name: i18n.t('{{thresholdFactor}} × Z-score low', {
                     thresholdFactor: config[PROP_THRESHOLD_FACTOR],
                 }),
                 value: lowZScoreThreshold,
                 line: lowThresholdLine,
             },
             {
-                name: i18n.t('{{thresholdFactor}} x Z-score High', {
+                name: i18n.t('{{thresholdFactor}} × Z-score high', {
                     thresholdFactor: config[PROP_THRESHOLD_FACTOR],
                 }),
                 value: highZScoreThreshold,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1641,7 +1641,7 @@
     "@dhis2/prop-types" "^1.6.4"
     classnames "^2.2.6"
 
-"@dhis2/ui@^5.7.2", "@dhis2/ui@^6.4.1", "@dhis2/ui@^6.5.0":
+"@dhis2/ui@^5.7.2", "@dhis2/ui@^6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@dhis2/ui/-/ui-6.5.0.tgz#8972d1c42f6445976965b6653571070d8e588726"
   integrity sha512-zW6jl3qMDe6D29WuZtqd4p43mDsKTo49rYEgccbCx7S/ZEfs8KNi/aQsvhkphjjrtp6QqncBmp853WAvGxfdvw==


### PR DESCRIPTION

### Key features

1. Swap Letter Case for Sentence case and change the `x` used
