### PR TITLE
fix: check number of points

### DIFF
--- a/src/modules/outliers/index.js
+++ b/src/modules/outliers/index.js
@@ -60,6 +60,10 @@ const getExtremeLines = (percentage, xyStats) => {
 }
 
 export const getOutlierHelper = (data, userConfig = {}) => {
+    if (data.length < 3) {
+        return null
+    }
+
     const config = {
         ...defaultConfig,
         ...userConfig,


### PR DESCRIPTION
This avoids a crash when less than 3 orgunits are selected.