### PR TITLE
fix: axis min max values

### DIFF
--- a/src/modules/outliers/index.js
+++ b/src/modules/outliers/index.js
@@ -59,7 +59,7 @@ const getExtremeLines = (percentage, xyStats) => {
     return lines
 }
 
-const getMinMaxValue = (outlierHelper, prop) => [
+const getMinMaxValue = (outlierHelper, prop, sortFn) => [
     [
         ...outlierHelper.thresholds.map(
             t => getXYStats([t.line[0], t.line[t.line.length - 1]])[prop]
@@ -67,7 +67,7 @@ const getMinMaxValue = (outlierHelper, prop) => [
         outlierHelper.extremeLines && outlierHelper.extremeLines[0].value * 1.1,
     ]
         .filter(isNumeric)
-        .sort((a, b) => b - a)[0],
+        .sort(sortFn)[0],
 ]
 
 export const getOutlierHelper = (data, userConfig = {}) => {
@@ -118,35 +118,17 @@ export const getOutlierHelper = (data, userConfig = {}) => {
     }
 
     // if data is the highest value return undefined to let highcharts decide
-    const lineXMax = getMinMaxValue(helper, 'xMax')
+    const lineXMax = getMinMaxValue(helper, 'xMax', (a, b) => b - a)
     helper.xAxisMax = lineXMax > options.xyStats.xMax ? lineXMax : undefined
 
-    const lineYMax = getMinMaxValue(helper, 'yMax')
+    const lineYMax = getMinMaxValue(helper, 'yMax', (a, b) => b - a)
     helper.yAxisMax = lineYMax > options.xyStats.yMax ? lineYMax : undefined
 
-    console.log(
-        'lineYMax',
-        lineYMax,
-        'options.xyStats.yMax',
-        options.xyStats.yMax,
-        'RES',
-        helper.yAxisMax
-    )
-
-    const lineXMin = getMinMaxValue(helper, 'xMin')
+    const lineXMin = getMinMaxValue(helper, 'xMin', (a, b) => a - b)
     helper.xAxisMin = lineXMin < options.xyStats.xMin ? lineXMin : undefined
 
-    const lineYMin = getMinMaxValue(helper, 'yMin')
+    const lineYMin = getMinMaxValue(helper, 'yMin', (a, b) => a - b)
     helper.yAxisMin = lineYMin < options.xyStats.yMin ? lineYMin : undefined
-
-    console.log(
-        'lineYMin',
-        lineYMin,
-        'options.xyStats.yMin',
-        options.xyStats.yMin,
-        'RES',
-        helper.yAxisMin
-    )
 
     return helper
 }

--- a/src/modules/outliers/index.js
+++ b/src/modules/outliers/index.js
@@ -59,6 +59,17 @@ const getExtremeLines = (percentage, xyStats) => {
     return lines
 }
 
+const getMinMaxValue = (outlierHelper, prop) => [
+    [
+        ...outlierHelper.thresholds.map(
+            t => getXYStats([t.line[0], t.line[t.line.length - 1]])[prop]
+        ),
+        outlierHelper.extremeLines && outlierHelper.extremeLines[0].value * 1.1,
+    ]
+        .filter(isNumeric)
+        .sort((a, b) => b - a)[0],
+]
+
 export const getOutlierHelper = (data, userConfig = {}) => {
     if (data.length < 3) {
         return null
@@ -106,47 +117,36 @@ export const getOutlierHelper = (data, userConfig = {}) => {
         )
     }
 
-    const lineXMax = [
-        helper.thresholds[0].line[0][0],
-        helper.thresholds[0].line[1][0],
-        helper.thresholds[1].line[0][0],
-        helper.thresholds[1].line[1][0],
-        helper.extremeLines && helper.extremeLines[0].value * 1.1,
-    ]
-        .filter(isNumeric)
-        .sort((a, b) => b - a)[0]
-
+    // if data is the highest value return undefined to let highcharts decide
+    const lineXMax = getMinMaxValue(helper, 'xMax')
     helper.xAxisMax = lineXMax > options.xyStats.xMax ? lineXMax : undefined
 
-    const lineYMax = [
-        helper.thresholds[0].line[0][1],
-        helper.thresholds[0].line[1][1],
-        helper.thresholds[1].line[0][1],
-        helper.thresholds[1].line[1][1],
-        helper.extremeLines && helper.extremeLines[1].value * 1.1,
-    ]
-        .filter(isNumeric)
-        .sort((a, b) => b - a)[0]
-
+    const lineYMax = getMinMaxValue(helper, 'yMax')
     helper.yAxisMax = lineYMax > options.xyStats.yMax ? lineYMax : undefined
 
-    const lineXMin = [
-        helper.thresholds[0].line[0][0],
-        helper.thresholds[0].line[1][0],
-        helper.thresholds[1].line[0][0],
-        helper.thresholds[1].line[1][0],
-    ].sort((a, b) => a - b)[0]
+    console.log(
+        'lineYMax',
+        lineYMax,
+        'options.xyStats.yMax',
+        options.xyStats.yMax,
+        'RES',
+        helper.yAxisMax
+    )
 
+    const lineXMin = getMinMaxValue(helper, 'xMin')
     helper.xAxisMin = lineXMin < options.xyStats.xMin ? lineXMin : undefined
 
-    const lineYMin = [
-        helper.thresholds[0].line[0][1],
-        helper.thresholds[0].line[1][1],
-        helper.thresholds[1].line[0][1],
-        helper.thresholds[1].line[1][1],
-    ].sort((a, b) => a - b)[0]
-
+    const lineYMin = getMinMaxValue(helper, 'yMin')
     helper.yAxisMin = lineYMin < options.xyStats.yMin ? lineYMin : undefined
+
+    console.log(
+        'lineYMin',
+        lineYMin,
+        'options.xyStats.yMin',
+        options.xyStats.yMin,
+        'RES',
+        helper.yAxisMin
+    )
 
     return helper
 }


### PR DESCRIPTION
Fixes the issue reported during team testing where threshold lines were running out of the viewport.

Before:
![Screenshot from 2021-03-05 11-29-58](https://user-images.githubusercontent.com/1010094/110311442-1544ff80-8004-11eb-91e0-7b1181920af9.png)

After (threshold factor: 100):
![Screenshot from 2021-03-08 11-45-13](https://user-images.githubusercontent.com/1010094/110311475-1d9d3a80-8004-11eb-902a-14b0b6fab7eb.png)
