### PR TITLE
fix: always load locale-aware i18n

### DIFF
--- a/src/components/DataDimension/DataTypesSelector.js
+++ b/src/components/DataDimension/DataTypesSelector.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 import { SingleSelectField, SingleSelectOption } from '@dhis2/ui'
 
 import { ALL_ID, dataTypes } from '../../modules/dataTypes'

--- a/src/components/DataDimension/DetailSelector.js
+++ b/src/components/DataDimension/DetailSelector.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 import { SingleSelectField, SingleSelectOption } from '@dhis2/ui'
 import { TOTALS, DETAIL } from '../../modules/dataTypes'
 

--- a/src/components/DataDimension/GroupSelector.js
+++ b/src/components/DataDimension/GroupSelector.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react'
 import PropTypes from 'prop-types'
 import { SingleSelectField, SingleSelectOption } from '@dhis2/ui'
 import { useDataEngine } from '@dhis2/app-runtime'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 
 import { DetailSelector } from './DetailSelector'
 import {

--- a/src/components/DataDimension/ItemSelector.js
+++ b/src/components/DataDimension/ItemSelector.js
@@ -9,7 +9,7 @@ import {
     IconDimensionEventDataItem16,
     IconDimensionProgramIndicator16,
 } from '@dhis2/ui'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 import { useDataEngine } from '@dhis2/app-runtime'
 
 import styles from '../styles/DimensionSelector.style'

--- a/src/components/DataDimension/MetricSelector.js
+++ b/src/components/DataDimension/MetricSelector.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 import { SingleSelectField, SingleSelectOption } from '@dhis2/ui'
 import { ALL_ID } from '../../modules/dataTypes'
 

--- a/src/components/DimensionsPanel/DimensionsPanel.js
+++ b/src/components/DimensionsPanel/DimensionsPanel.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 
 import Filter from '../Filter/Filter'
 import DimensionList from './List/DimensionList'

--- a/src/components/DimensionsPanel/List/DimensionList.js
+++ b/src/components/DimensionsPanel/List/DimensionList.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { withStyles } from '@material-ui/core/styles'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../../locales/index.js'
 
 import DimensionItem from './DimensionItem'
 import { styles } from './styles/DimensionList.style'

--- a/src/components/DimensionsPanel/List/RecommendedIcon.js
+++ b/src/components/DimensionsPanel/List/RecommendedIcon.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import Paper from '@material-ui/core/Paper'
 import Popper from '@material-ui/core/Popper'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../../locales/index.js'
 
 import { styles } from './styles/RecommendedIcon.style'
 

--- a/src/components/DynamicDimension/DynamicDimension.js
+++ b/src/components/DynamicDimension/DynamicDimension.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 import { useDataEngine } from '@dhis2/app-runtime'
 
 import ItemSelector from './ItemSelector'

--- a/src/components/DynamicDimension/ItemSelector.js
+++ b/src/components/DynamicDimension/ItemSelector.js
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react'
 import PropTypes from 'prop-types'
 import { Transfer, InputField } from '@dhis2/ui'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 
 import styles from '../styles/DimensionSelector.style'
 import { TransferOption } from '../TransferOption'

--- a/src/components/FileMenu/DeleteDialog.js
+++ b/src/components/FileMenu/DeleteDialog.js
@@ -1,7 +1,7 @@
 import React, { useMemo } from 'react'
 
 import PropTypes from '@dhis2/prop-types'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 import { useDataMutation } from '@dhis2/app-runtime'
 import {
     Modal,

--- a/src/components/FileMenu/FileMenu.js
+++ b/src/components/FileMenu/FileMenu.js
@@ -1,7 +1,7 @@
 import React, { createRef, useState } from 'react'
 
 import PropTypes from '@dhis2/prop-types'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 import FavoritesDialog from '@dhis2/d2-ui-favorites-dialog'
 import TranslationDialog from '@dhis2/d2-ui-translation-dialog'
 import SharingDialog from '@dhis2/d2-ui-sharing-dialog'

--- a/src/components/FileMenu/GetLinkDialog.js
+++ b/src/components/FileMenu/GetLinkDialog.js
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import PropTypes from '@dhis2/prop-types'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 import { useConfig } from '@dhis2/app-runtime'
 import {
     Modal,

--- a/src/components/FileMenu/RenameDialog.js
+++ b/src/components/FileMenu/RenameDialog.js
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react'
 
 import PropTypes from '@dhis2/prop-types'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 import { useDataMutation } from '@dhis2/app-runtime'
 import {
     Modal,

--- a/src/components/FileMenu/SaveAsDialog.js
+++ b/src/components/FileMenu/SaveAsDialog.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react'
 
 import PropTypes from '@dhis2/prop-types'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 import {
     Modal,
     ModalTitle,

--- a/src/components/ItemSelector/SelectedItems.js
+++ b/src/components/ItemSelector/SelectedItems.js
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 import InfoIcon from '@material-ui/icons/InfoOutlined'
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd'
 import { Button, colors } from '@dhis2/ui'

--- a/src/components/ItemSelector/UnselectedItems.js
+++ b/src/components/ItemSelector/UnselectedItems.js
@@ -1,6 +1,6 @@
 import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 import { Button } from '@dhis2/ui'
 import throttle from 'lodash/throttle'
 

--- a/src/components/PeriodDimension/FixedPeriodFilter.js
+++ b/src/components/PeriodDimension/FixedPeriodFilter.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 import { SingleSelectField, InputField, SingleSelectOption } from '@dhis2/ui'
 
 import { getFixedPeriodsOptions } from './utils/fixedPeriods'

--- a/src/components/PeriodDimension/FixedPeriodSelect.js
+++ b/src/components/PeriodDimension/FixedPeriodSelect.js
@@ -1,6 +1,6 @@
 import React, { Component } from 'react'
 import propTypes from '@dhis2/prop-types'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 import { SingleSelectField, SingleSelectOption } from '@dhis2/ui'
 import FixedPeriodFilter from './FixedPeriodFilter.js'
 import {

--- a/src/components/PeriodDimension/PeriodTransfer.js
+++ b/src/components/PeriodDimension/PeriodTransfer.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { TabBar, Tab, Transfer } from '@dhis2/ui'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 
 import FixedPeriodFilter from './FixedPeriodFilter'
 import RelativePeriodFilter from './RelativePeriodFilter'

--- a/src/components/PeriodDimension/RelativePeriodFilter.js
+++ b/src/components/PeriodDimension/RelativePeriodFilter.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 import { SingleSelectField, SingleSelectOption } from '@dhis2/ui'
 
 import { getRelativePeriodsOptions } from './utils/relativePeriods'

--- a/src/components/PeriodDimension/utils/fixedPeriods.js
+++ b/src/components/PeriodDimension/utils/fixedPeriods.js
@@ -1,4 +1,4 @@
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../../locales/index.js'
 // generate periods config object: { boolean offset, boolean filterFuturePeriods, boolean reversePeriods }
 
 export const DAILY = 'DAILY'

--- a/src/components/PeriodDimension/utils/relativePeriods.js
+++ b/src/components/PeriodDimension/utils/relativePeriods.js
@@ -1,4 +1,4 @@
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../../locales/index.js'
 
 export const DAYS = 'Days'
 export const WEEKS = 'Weeks'

--- a/src/modules/axis.js
+++ b/src/modules/axis.js
@@ -1,4 +1,4 @@
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../locales/index.js'
 import { AXIS_ID_COLUMNS, AXIS_ID_ROWS, AXIS_ID_FILTERS } from './layout/axis'
 import {
     LAYOUT_TYPE_DEFAULT,

--- a/src/modules/dataSets.js
+++ b/src/modules/dataSets.js
@@ -1,4 +1,4 @@
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../locales/index.js'
 
 export const REPORTING_RATE = 'REPORTING_RATE'
 export const REPORTING_RATE_ON_TIME = 'REPORTING_RATE_ON_TIME'

--- a/src/modules/dataTypes.js
+++ b/src/modules/dataTypes.js
@@ -1,4 +1,4 @@
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../locales/index.js'
 
 export const CHART_AGGREGATE_AGGREGATABLE_TYPES = [
     'BOOLEAN',

--- a/src/modules/fontStyle.js
+++ b/src/modules/fontStyle.js
@@ -1,5 +1,5 @@
 /*eslint no-unused-vars: ["error", { "ignoreRestSiblings": true }]*/
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../locales/index.js'
 import { colors } from '@dhis2/ui'
 
 // Font styles

--- a/src/modules/getOuLevelAndGroupText.js
+++ b/src/modules/getOuLevelAndGroupText.js
@@ -1,4 +1,4 @@
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../locales/index.js'
 import { ouIdHelper } from './ouIdHelper'
 import { dimensionIs } from './layout/dimensionIs'
 import { dimensionGetItems } from './layout/dimensionGetItems'

--- a/src/modules/outliers/index.js
+++ b/src/modules/outliers/index.js
@@ -1,4 +1,4 @@
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 import isNumeric from 'd2-utilizr/lib/isNumeric'
 
 import { getZScoreHelper, STANDARD_Z_SCORE } from './zScore'

--- a/src/modules/outliers/iqr.js
+++ b/src/modules/outliers/iqr.js
@@ -1,4 +1,4 @@
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 
 import { PROP_THRESHOLD_FACTOR } from './index'
 

--- a/src/modules/outliers/modZScore.js
+++ b/src/modules/outliers/modZScore.js
@@ -1,4 +1,4 @@
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 import isNumber from 'd2-utilizr/lib/isNumber'
 
 import { PROP_THRESHOLD_FACTOR } from './index'

--- a/src/modules/outliers/zScore.js
+++ b/src/modules/outliers/zScore.js
@@ -1,4 +1,4 @@
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 import { std, mean } from 'mathjs'
 import { PROP_THRESHOLD_FACTOR } from './index'
 

--- a/src/modules/predefinedDimensions.js
+++ b/src/modules/predefinedDimensions.js
@@ -1,4 +1,4 @@
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../locales/index.js'
 import DataIcon from '../assets/DataIcon'
 import PeriodIcon from '../assets/PeriodIcon'
 import OrgUnitIcon from '../assets/OrgUnitIcon'

--- a/src/modules/visTypes.js
+++ b/src/modules/visTypes.js
@@ -1,4 +1,4 @@
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../locales/index.js'
 import BarIcon from '../assets/BarIcon'
 import StackedBarIcon from '../assets/StackedBarIcon'
 import ColumnIcon from '../assets/ColumnIcon'

--- a/src/visualizations/config/adapters/dhis_highcharts/addTrendLines.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/addTrendLines.js
@@ -1,6 +1,6 @@
 import arrayContains from 'd2-utilizr/lib/arrayContains'
 import { rgb } from 'd3-color'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../../../locales/index.js'
 
 import { colorSets, COLOR_SET_PATTERNS } from '../../../util/colors/colorSets'
 import getStackedData from './getStackedData'

--- a/src/visualizations/config/adapters/dhis_highcharts/legendSet.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/legendSet.js
@@ -1,5 +1,5 @@
 import isNumeric from 'd2-utilizr/lib/isNumeric'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../../../locales/index.js'
 
 import { getLegendByValueFromLegendSet } from '../../../../modules/legends'
 

--- a/src/visualizations/config/adapters/dhis_highcharts/plotOptions.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/plotOptions.js
@@ -1,4 +1,4 @@
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../../../locales/index.js'
 
 import { VIS_TYPE_SCATTER } from '../../../../modules/visTypes'
 

--- a/src/visualizations/config/adapters/dhis_highcharts/series/scatter.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/scatter.js
@@ -1,4 +1,4 @@
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../../../../locales/index.js'
 
 const DEFAULT_COLOR = '#a8bf24'
 const OUTLIER_COLOR = 'red'

--- a/src/visualizations/config/adapters/dhis_highcharts/yAxis/gauge.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/yAxis/gauge.js
@@ -1,7 +1,7 @@
 import arrayClean from 'd2-utilizr/lib/arrayClean'
 import isNumber from 'd2-utilizr/lib/isNumber'
 import objectClean from 'd2-utilizr/lib/objectClean'
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../../../../locales/index.js'
 import {
     getColorByValueFromLegendSet,
     LEGEND_DISPLAY_STYLE_FILL,

--- a/src/visualizations/config/adapters/dhis_highcharts/yAxis/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/yAxis/index.js
@@ -1,4 +1,4 @@
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../../../../locales/index.js'
 import arrayClean from 'd2-utilizr/lib/arrayClean'
 import objectClean from 'd2-utilizr/lib/objectClean'
 

--- a/src/visualizations/config/index.js
+++ b/src/visualizations/config/index.js
@@ -1,4 +1,4 @@
-import i18n from '@dhis2/d2-i18n'
+import i18n from '../../locales/index.js'
 import validators from './validators'
 import adapters from './adapters'
 import generators from './generators'


### PR DESCRIPTION
We weren't initializing locales in analytics, which when treeshaken would cause untranslated components (notably the file menu) - fixed by always loading `locales/index.js`