### PR TITLE
fix: render trendlines in front of columns (DHIS2-9829) v35

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/addTrendLines.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/addTrendLines.js
@@ -20,6 +20,7 @@ const DEFAULT_TRENDLINE = {
         symbol: 'circle',
         radius: 2,
     },
+    zIndex: 1,
 }
 
 export const isRegressionIneligible = type =>


### PR DESCRIPTION
Backports [DHIS2-9829](https://jira.dhis2.org/browse/DHIS2-9829) to v35

Original PR: https://github.com/dhis2/analytics/pull/657