### PR TITLE
refactor: replace MUI icons with ui-icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
         "@dhis2/d2-ui-sharing-dialog": "^7.1.5",
         "@dhis2/d2-ui-translation-dialog": "^7.1.5",
         "@material-ui/core": "^3.9.3",
-        "@material-ui/icons": "^3.0.2",
         "classnames": "^2.2.6",
         "d2-utilizr": "^0.2.16",
         "d3-color": "^1.2.3",

--- a/src/components/DimensionsPanel/List/DimensionItem.js
+++ b/src/components/DimensionsPanel/List/DimensionItem.js
@@ -1,6 +1,5 @@
 import React, { Component, createRef } from 'react'
 import PropTypes from 'prop-types'
-
 import { IconLock16 } from '@dhis2/ui'
 
 import DimensionLabel from './DimensionLabel'

--- a/src/components/DimensionsPanel/List/DimensionItem.js
+++ b/src/components/DimensionsPanel/List/DimensionItem.js
@@ -1,6 +1,7 @@
 import React, { Component, createRef } from 'react'
 import PropTypes from 'prop-types'
-import LockIcon from '@material-ui/icons/Lock'
+
+import { IconLock16 } from '@dhis2/ui'
 
 import DimensionLabel from './DimensionLabel'
 import RecommendedIcon from './RecommendedIcon'
@@ -97,7 +98,7 @@ export class DimensionItem extends Component {
                     </div>
                     {isLocked && (
                         <div style={styles.iconWrapper}>
-                            <LockIcon style={styles.lockIcon} />
+                            <IconLock16 />
                         </div>
                     )}
                 </DimensionLabel>

--- a/src/components/DimensionsPanel/List/__tests__/__snapshots__/DimensionItem.spec.js.snap
+++ b/src/components/DimensionsPanel/List/__tests__/__snapshots__/DimensionItem.spec.js.snap
@@ -145,14 +145,7 @@ exports[`DimensionItem matches the snapshot with locked 1`] = `
         }
       }
     >
-      <pure(LockIcon)
-        style={
-          Object {
-            "fontSize": "14px",
-            "marginTop": "1px",
-          }
-        }
-      />
+      <SvgLock16 />
     </div>
   </DimensionLabel>
 </li>

--- a/src/components/DimensionsPanel/List/styles/DimensionItem.style.js
+++ b/src/components/DimensionsPanel/List/styles/DimensionItem.style.js
@@ -40,10 +40,6 @@ export const styles = {
         flexDirection: 'column',
         padding: '3px 8px 0 8px',
     },
-    lockIcon: {
-        fontSize: '14px',
-        marginTop: '1px',
-    },
     optionsWrapper: {
         position: 'relative',
         height: '24px',

--- a/src/components/DynamicDimension/__tests__/DynamicDimension.spec.js
+++ b/src/components/DynamicDimension/__tests__/DynamicDimension.spec.js
@@ -21,6 +21,7 @@ describe('The Dynamic Dimension component ', () => {
             selectedItems: [],
             onSelect: jest.fn(),
             dimensionId: '123abc',
+            displayNameProp: 'displayName',
         }
         shallowSelector = undefined
     })

--- a/src/components/ItemSelector/SelectedItems.js
+++ b/src/components/ItemSelector/SelectedItems.js
@@ -1,9 +1,8 @@
 import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import i18n from '../../locales/index.js'
-import InfoIcon from '@material-ui/icons/InfoOutlined'
 import { DragDropContext, Droppable, Draggable } from 'react-beautiful-dnd'
-import { Button, colors } from '@dhis2/ui'
+import { Button, IconInfo16, colors } from '@dhis2/ui'
 
 import Item from './widgets/SelectedItem'
 import { ArrowButton as UnAssignButton } from './widgets/ArrowButton'
@@ -20,7 +19,7 @@ const Subtitle = () => (
 
 const InfoBox = ({ message, dataTest }) => (
     <div className="info-container" data-test={dataTest}>
-        <InfoIcon style={{ fontSize: 16, color: colors.grey600 }} />
+        <IconInfo16 color={colors.grey600} />
         <span className="info-text">{message}</span>
         <style jsx>{styles}</style>
     </div>

--- a/src/components/ItemSelector/__tests__/__snapshots__/SelectedItems.spec.js.snap
+++ b/src/components/ItemSelector/__tests__/__snapshots__/SelectedItems.spec.js.snap
@@ -223,86 +223,28 @@ exports[`The SelectedItems component list with items matches the snapshot with l
                                   className="deselect-icon-button"
                                   onClick={[Function]}
                                 >
-                                  <span>
-                                    <pure(CloseIcon)
-                                      style={
-                                        Object {
-                                          "fill": "#00796b",
-                                          "height": "13px",
-                                          "width": "10px",
-                                        }
+                                  <span
+                                    style={
+                                      Object {
+                                        "fill": "#00796b",
+                                        "height": "13px",
+                                        "width": "10px",
                                       }
-                                    >
-                                      <CloseIcon
-                                        style={
-                                          Object {
-                                            "fill": "#00796b",
-                                            "height": "13px",
-                                            "width": "10px",
-                                          }
-                                        }
+                                    }
+                                  >
+                                    <SvgCross16>
+                                      <svg
+                                        height={16}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
                                       >
-                                        <WithStyles(SvgIcon)
-                                          style={
-                                            Object {
-                                              "fill": "#00796b",
-                                              "height": "13px",
-                                              "width": "10px",
-                                            }
-                                          }
-                                        >
-                                          <SvgIcon
-                                            classes={
-                                              Object {
-                                                "colorAction": "MuiSvgIcon-colorAction-4",
-                                                "colorDisabled": "MuiSvgIcon-colorDisabled-6",
-                                                "colorError": "MuiSvgIcon-colorError-5",
-                                                "colorPrimary": "MuiSvgIcon-colorPrimary-2",
-                                                "colorSecondary": "MuiSvgIcon-colorSecondary-3",
-                                                "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-7",
-                                                "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-9",
-                                                "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-8",
-                                                "root": "MuiSvgIcon-root-1",
-                                              }
-                                            }
-                                            color="inherit"
-                                            component="svg"
-                                            fontSize="default"
-                                            style={
-                                              Object {
-                                                "fill": "#00796b",
-                                                "height": "13px",
-                                                "width": "10px",
-                                              }
-                                            }
-                                            viewBox="0 0 24 24"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              className="MuiSvgIcon-root-1"
-                                              focusable="false"
-                                              role="presentation"
-                                              style={
-                                                Object {
-                                                  "fill": "#00796b",
-                                                  "height": "13px",
-                                                  "width": "10px",
-                                                }
-                                              }
-                                              viewBox="0 0 24 24"
-                                            >
-                                              <path
-                                                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                                              />
-                                              <path
-                                                d="M0 0h24v24H0z"
-                                                fill="none"
-                                              />
-                                            </svg>
-                                          </SvgIcon>
-                                        </WithStyles(SvgIcon)>
-                                      </CloseIcon>
-                                    </pure(CloseIcon)>
+                                        <path
+                                          d="M4.284 3.589l.07.057L8 7.293l3.646-3.647a.5.5 0 01.765.638l-.057.07L8.707 8l3.647 3.646a.5.5 0 01-.638.765l-.07-.057L8 8.707l-3.646 3.647a.5.5 0 01-.765-.638l.057-.07L7.293 8 3.646 4.354a.5.5 0 01.638-.765z"
+                                          fill="currentColor"
+                                        />
+                                      </svg>
+                                    </SvgCross16>
                                   </span>
                                   <style />
                                 </button>
@@ -458,86 +400,28 @@ exports[`The SelectedItems component list with items matches the snapshot with l
                                   className="deselect-icon-button"
                                   onClick={[Function]}
                                 >
-                                  <span>
-                                    <pure(CloseIcon)
-                                      style={
-                                        Object {
-                                          "fill": "#00796b",
-                                          "height": "13px",
-                                          "width": "10px",
-                                        }
+                                  <span
+                                    style={
+                                      Object {
+                                        "fill": "#00796b",
+                                        "height": "13px",
+                                        "width": "10px",
                                       }
-                                    >
-                                      <CloseIcon
-                                        style={
-                                          Object {
-                                            "fill": "#00796b",
-                                            "height": "13px",
-                                            "width": "10px",
-                                          }
-                                        }
+                                    }
+                                  >
+                                    <SvgCross16>
+                                      <svg
+                                        height={16}
+                                        viewBox="0 0 16 16"
+                                        width={16}
+                                        xmlns="http://www.w3.org/2000/svg"
                                       >
-                                        <WithStyles(SvgIcon)
-                                          style={
-                                            Object {
-                                              "fill": "#00796b",
-                                              "height": "13px",
-                                              "width": "10px",
-                                            }
-                                          }
-                                        >
-                                          <SvgIcon
-                                            classes={
-                                              Object {
-                                                "colorAction": "MuiSvgIcon-colorAction-4",
-                                                "colorDisabled": "MuiSvgIcon-colorDisabled-6",
-                                                "colorError": "MuiSvgIcon-colorError-5",
-                                                "colorPrimary": "MuiSvgIcon-colorPrimary-2",
-                                                "colorSecondary": "MuiSvgIcon-colorSecondary-3",
-                                                "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-7",
-                                                "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-9",
-                                                "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-8",
-                                                "root": "MuiSvgIcon-root-1",
-                                              }
-                                            }
-                                            color="inherit"
-                                            component="svg"
-                                            fontSize="default"
-                                            style={
-                                              Object {
-                                                "fill": "#00796b",
-                                                "height": "13px",
-                                                "width": "10px",
-                                              }
-                                            }
-                                            viewBox="0 0 24 24"
-                                          >
-                                            <svg
-                                              aria-hidden="true"
-                                              className="MuiSvgIcon-root-1"
-                                              focusable="false"
-                                              role="presentation"
-                                              style={
-                                                Object {
-                                                  "fill": "#00796b",
-                                                  "height": "13px",
-                                                  "width": "10px",
-                                                }
-                                              }
-                                              viewBox="0 0 24 24"
-                                            >
-                                              <path
-                                                d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                                              />
-                                              <path
-                                                d="M0 0h24v24H0z"
-                                                fill="none"
-                                              />
-                                            </svg>
-                                          </SvgIcon>
-                                        </WithStyles(SvgIcon)>
-                                      </CloseIcon>
-                                    </pure(CloseIcon)>
+                                        <path
+                                          d="M4.284 3.589l.07.057L8 7.293l3.646-3.647a.5.5 0 01.765.638l-.057.07L8.707 8l3.647 3.646a.5.5 0 01-.638.765l-.07-.057L8 8.707l-3.646 3.647a.5.5 0 01-.765-.638l.057-.07L7.293 8 3.646 4.354a.5.5 0 01.638-.765z"
+                                          fill="currentColor"
+                                        />
+                                      </svg>
+                                    </SvgCross16>
                                   </span>
                                   <style />
                                 </button>
@@ -600,47 +484,19 @@ exports[`The SelectedItems component list with items matches the snapshot with l
         <span
           className="arrow-icon"
         >
-          <pure(ArrowBackIcon)>
-            <ArrowBackIcon>
-              <WithStyles(SvgIcon)>
-                <SvgIcon
-                  classes={
-                    Object {
-                      "colorAction": "MuiSvgIcon-colorAction-4",
-                      "colorDisabled": "MuiSvgIcon-colorDisabled-6",
-                      "colorError": "MuiSvgIcon-colorError-5",
-                      "colorPrimary": "MuiSvgIcon-colorPrimary-2",
-                      "colorSecondary": "MuiSvgIcon-colorSecondary-3",
-                      "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-7",
-                      "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-9",
-                      "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-8",
-                      "root": "MuiSvgIcon-root-1",
-                    }
-                  }
-                  color="inherit"
-                  component="svg"
-                  fontSize="default"
-                  viewBox="0 0 24 24"
-                >
-                  <svg
-                    aria-hidden="true"
-                    className="MuiSvgIcon-root-1"
-                    focusable="false"
-                    role="presentation"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M0 0h24v24H0z"
-                      fill="none"
-                    />
-                    <path
-                      d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
-                    />
-                  </svg>
-                </SvgIcon>
-              </WithStyles(SvgIcon)>
-            </ArrowBackIcon>
-          </pure(ArrowBackIcon)>
+          <SvgArrowLeft24>
+            <svg
+              height={24}
+              viewBox="0 0 24 24"
+              width={24}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M11.707 5.293a1 1 0 01.083 1.32l-.083.094L7.414 11H18a1 1 0 01.117 1.993L18 13H7.414l4.293 4.293a1 1 0 01.083 1.32l-.083.094a1 1 0 01-1.32.083l-.094-.083-6-6-.073-.082a1.005 1.005 0 01-.007-.008l.08.09A1.008 1.008 0 014 12.02v-.037c0-.024.002-.048.004-.071L4 12a1.008 1.008 0 01.21-.613c.028-.035.054-.066.083-.094l6-6a1 1 0 011.414 0z"
+                fill="currentColor"
+              />
+            </svg>
+          </SvgArrowLeft24>
         </span>
         <style />
       </button>
@@ -769,47 +625,19 @@ exports[`The SelectedItems component matches the snapshot when list is empty 1`]
         <span
           className="arrow-icon"
         >
-          <pure(ArrowBackIcon)>
-            <ArrowBackIcon>
-              <WithStyles(SvgIcon)>
-                <SvgIcon
-                  classes={
-                    Object {
-                      "colorAction": "MuiSvgIcon-colorAction-4",
-                      "colorDisabled": "MuiSvgIcon-colorDisabled-6",
-                      "colorError": "MuiSvgIcon-colorError-5",
-                      "colorPrimary": "MuiSvgIcon-colorPrimary-2",
-                      "colorSecondary": "MuiSvgIcon-colorSecondary-3",
-                      "fontSizeInherit": "MuiSvgIcon-fontSizeInherit-7",
-                      "fontSizeLarge": "MuiSvgIcon-fontSizeLarge-9",
-                      "fontSizeSmall": "MuiSvgIcon-fontSizeSmall-8",
-                      "root": "MuiSvgIcon-root-1",
-                    }
-                  }
-                  color="inherit"
-                  component="svg"
-                  fontSize="default"
-                  viewBox="0 0 24 24"
-                >
-                  <svg
-                    aria-hidden="true"
-                    className="MuiSvgIcon-root-1"
-                    focusable="false"
-                    role="presentation"
-                    viewBox="0 0 24 24"
-                  >
-                    <path
-                      d="M0 0h24v24H0z"
-                      fill="none"
-                    />
-                    <path
-                      d="M20 11H7.83l5.59-5.59L12 4l-8 8 8 8 1.41-1.41L7.83 13H20v-2z"
-                    />
-                  </svg>
-                </SvgIcon>
-              </WithStyles(SvgIcon)>
-            </ArrowBackIcon>
-          </pure(ArrowBackIcon)>
+          <SvgArrowLeft24>
+            <svg
+              height={24}
+              viewBox="0 0 24 24"
+              width={24}
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M11.707 5.293a1 1 0 01.083 1.32l-.083.094L7.414 11H18a1 1 0 01.117 1.993L18 13H7.414l4.293 4.293a1 1 0 01.083 1.32l-.083.094a1 1 0 01-1.32.083l-.094-.083-6-6-.073-.082a1.005 1.005 0 01-.007-.008l.08.09A1.008 1.008 0 014 12.02v-.037c0-.024.002-.048.004-.071L4 12a1.008 1.008 0 01.21-.613c.028-.035.054-.066.083-.094l6-6a1 1 0 011.414 0z"
+                fill="currentColor"
+              />
+            </svg>
+          </SvgArrowLeft24>
         </span>
         <style />
       </button>

--- a/src/components/ItemSelector/widgets/ArrowButton.js
+++ b/src/components/ItemSelector/widgets/ArrowButton.js
@@ -1,14 +1,17 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import ArrowForward from '@material-ui/icons/ArrowForward'
-import ArrowBack from '@material-ui/icons/ArrowBack'
+import { IconArrowLeft24, IconArrowRight24 } from '@dhis2/ui'
 
 import styles from './styles/ArrowButton.style'
 
 export const ArrowButton = ({ onClick, iconType }) => (
     <button className="arrow-button" onClick={onClick}>
         <span className="arrow-icon">
-            {iconType === 'arrowForward' ? <ArrowForward /> : <ArrowBack />}
+            {iconType === 'arrowForward' ? (
+                <IconArrowRight24 />
+            ) : (
+                <IconArrowLeft24 />
+            )}
         </span>
         <style jsx>{styles}</style>
     </button>

--- a/src/components/ItemSelector/widgets/DeselectIconButton.js
+++ b/src/components/ItemSelector/widgets/DeselectIconButton.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import DeselectIcon from '@material-ui/icons/Close'
+import { IconCross16 } from '@dhis2/ui'
 import styles from './styles/DeselectIconButton.style'
 
 export const DeselectIconButton = ({ fill, onClick }) => {
@@ -18,8 +18,8 @@ export const DeselectIconButton = ({ fill, onClick }) => {
                 onClick()
             }}
         >
-            <span>
-                <DeselectIcon style={iconStyle} />
+            <span style={iconStyle}>
+                <IconCross16 />
             </span>
             <style jsx>{styles}</style>
         </button>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2211,7 +2211,7 @@
     recompose "0.28.0 - 0.30.0"
     warning "^4.0.1"
 
-"@material-ui/icons@^3.0.1", "@material-ui/icons@^3.0.2":
+"@material-ui/icons@^3.0.1":
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-3.0.2.tgz#d67a6dd1ec8312d3a88ec97944a63daeef24fe10"
   integrity sha512-QY/3gJnObZQ3O/e6WjH+0ah2M3MOgLOzCy8HTUoUx9B6dDrS18vP7Ycw3qrDEKlB6q1KNxy6CZHm5FCauWGy2g==


### PR DESCRIPTION
### Key features

1. Remove the last MUI icons and use ui-icons instead

---

### Notes

-   `ItemSelector` is actually not used anywhere and should be removed

---

### Screenshots

Padlock icon in data dimension:
before:
![Screenshot 2021-04-14 at 11 30 12](https://user-images.githubusercontent.com/150978/114688318-df86eb00-9d14-11eb-8cc4-2887f9e7b69a.png)

after:
![Screenshot 2021-04-14 at 11 30 03](https://user-images.githubusercontent.com/150978/114688338-e31a7200-9d14-11eb-8726-a3417ccb0d38.png)
