### PR TITLE
fix: pass insertTheme to d2-ui components to fix narrow dialogs

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,10 +57,10 @@
         "styled-jsx": "^3.3.2"
     },
     "dependencies": {
-        "@dhis2/d2-ui-favorites-dialog": "^7.1.8",
-        "@dhis2/d2-ui-org-unit-dialog": "^7.1.8",
-        "@dhis2/d2-ui-sharing-dialog": "^7.1.8",
-        "@dhis2/d2-ui-translation-dialog": "^7.1.8",
+        "@dhis2/d2-ui-favorites-dialog": "^7.2.0",
+        "@dhis2/d2-ui-org-unit-dialog": "^7.2.0",
+        "@dhis2/d2-ui-sharing-dialog": "^7.2.0",
+        "@dhis2/d2-ui-translation-dialog": "^7.2.0",
         "classnames": "^2.2.6",
         "d2-utilizr": "^0.2.16",
         "d3-color": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -57,10 +57,10 @@
         "styled-jsx": "^3.3.2"
     },
     "dependencies": {
-        "@dhis2/d2-ui-favorites-dialog": "^7.1.5",
-        "@dhis2/d2-ui-org-unit-dialog": "^7.1.5",
-        "@dhis2/d2-ui-sharing-dialog": "^7.1.5",
-        "@dhis2/d2-ui-translation-dialog": "^7.1.5",
+        "@dhis2/d2-ui-favorites-dialog": "^7.1.8",
+        "@dhis2/d2-ui-org-unit-dialog": "^7.1.8",
+        "@dhis2/d2-ui-sharing-dialog": "^7.1.8",
+        "@dhis2/d2-ui-translation-dialog": "^7.1.8",
         "classnames": "^2.2.6",
         "d2-utilizr": "^0.2.16",
         "d3-color": "^1.2.3",

--- a/src/components/FileMenu/FileMenu.js
+++ b/src/components/FileMenu/FileMenu.js
@@ -82,6 +82,7 @@ export const FileMenu = ({
                         d2={d2}
                         onRequestClose={onDialogClose}
                         onFavoriteSelect={onOpen}
+                        insertTheme={true}
                     />
                 )
             case 'rename':

--- a/src/components/FileMenu/FileMenu.js
+++ b/src/components/FileMenu/FileMenu.js
@@ -109,6 +109,7 @@ export const FileMenu = ({
                         onRequestClose={onDialogClose}
                         onTranslationSaved={onTranslate}
                         onTranslationError={onError}
+                        insertTheme={true}
                     />
                 )
             case 'sharing':
@@ -119,6 +120,7 @@ export const FileMenu = ({
                         type={fileType}
                         id={fileObject.id}
                         onRequestClose={onDialogClose}
+                        insertTheme={true}
                     />
                 )
             case 'getlink':

--- a/yarn.lock
+++ b/yarn.lock
@@ -1506,10 +1506,10 @@
     i18next "^10.3"
     moment "^2.24.0"
 
-"@dhis2/d2-ui-core@7.1.8":
-  version "7.1.8"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-7.1.8.tgz#1339f91f4ce2e0a38897dab29de22db725d058a5"
-  integrity sha512-nd6Pfkm18WYbWC4M7HRkIkANuyeDMNQfVQt3nnUZ7Hje2O3hZmzsdOpTWYhtzxSx1uhQV4n/CPjJEWaqG7T+/g==
+"@dhis2/d2-ui-core@7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-7.2.0.tgz#932c9b2f439dc730ccb28a69129cfeeba15527ad"
+  integrity sha512-ox3//w5/sVwlEpOwp/h3NwMufd0bf653ZZmw4sWpH8t8oosuvt0F4bDGB7Vz0f8tidB09oLGiAsHmtvKTXpLpA==
   dependencies:
     babel-runtime "^6.26.0"
     d2 "~31.7"
@@ -1517,47 +1517,48 @@
     material-ui "^0.20.0"
     rxjs "^5.5.7"
 
-"@dhis2/d2-ui-favorites-dialog@^7.1.8":
-  version "7.1.8"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-favorites-dialog/-/d2-ui-favorites-dialog-7.1.8.tgz#b961a0aa5f28d039141670fdd3e99afb2b89aaf1"
-  integrity sha512-YLap6LYhLBtVMFYdxiU21UUYqQQ2xTPJamgZh5ynS+g3j2VD+DROw7achWxxSuQf8RwvhTW1zrVOQWyL718YKA==
+"@dhis2/d2-ui-favorites-dialog@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-favorites-dialog/-/d2-ui-favorites-dialog-7.2.0.tgz#b1f853c63d3e352af81b44b275c3881d2dea3c6d"
+  integrity sha512-//sKtdKspCAPEGQbIU6EMpSsPU+RzyvSXaRZplxQc69iRBQwoB2HO3ZajU4u0fwn0uxlB7FGUywQ1olqnIuv1A==
   dependencies:
-    "@dhis2/d2-ui-sharing-dialog" "7.1.8"
+    "@dhis2/d2-ui-sharing-dialog" "7.2.0"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"
+    lodash "^4.17.10"
     prop-types "^15.6.0"
     react-redux "^5.0.7"
     redux "^3.7.2"
     redux-logger "^3.0.6"
     redux-thunk "^2.2.0"
 
-"@dhis2/d2-ui-org-unit-dialog@^7.1.8":
-  version "7.1.8"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-dialog/-/d2-ui-org-unit-dialog-7.1.8.tgz#2ca71f5e59e4809bd3390fd07a5d493e8a8e70bd"
-  integrity sha512-qe4T88oFTyksCtYjTU9yIGFH1/aPb43fl8mqonKXHEEEpLUhHWMghtwXwm2WtguKI0LTZMKMZ6TqPJAL3Jv8IA==
+"@dhis2/d2-ui-org-unit-dialog@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-dialog/-/d2-ui-org-unit-dialog-7.2.0.tgz#24182b874148080976a52adc3983e8e40249cd14"
+  integrity sha512-P9SZL8EfJy4pvJlMz671IbYG5KhdVPUs7ID/cKZcDOr8keQ8JNOMkT1vMM1PVFJKt8qFKJ1wg5FJ26uXDkA2TQ==
   dependencies:
-    "@dhis2/d2-ui-org-unit-tree" "7.1.8"
+    "@dhis2/d2-ui-org-unit-tree" "7.2.0"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     prop-types "^15.5.10"
 
-"@dhis2/d2-ui-org-unit-tree@7.1.8":
-  version "7.1.8"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-7.1.8.tgz#cc4c143889cfc5f516b73a7107f56a9e9d382452"
-  integrity sha512-yj7DxBQ9j96BKc1cl1KSY6m4/QB2L/m+eyHzzlKlnSv5ckFPqqrnGAeMt2BVGz7q6sUvAGiVG56jRtGwlOJdxQ==
+"@dhis2/d2-ui-org-unit-tree@7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-7.2.0.tgz#039fcff0c056064aea054e9f41305277b8b0c1c4"
+  integrity sha512-0wgLyitzL1qxiarB6vYpMmhhDnVdjAYWQnTSxbVJhKpY4WnkoZY4Qfp4q9IjDFmpYrP2MPF3m1WTo3woshGpCA==
   dependencies:
-    "@dhis2/d2-ui-core" "7.1.8"
+    "@dhis2/d2-ui-core" "7.2.0"
     "@material-ui/core" "^3.3.1"
     babel-runtime "^6.26.0"
     prop-types "^15.5.10"
 
-"@dhis2/d2-ui-sharing-dialog@7.1.8", "@dhis2/d2-ui-sharing-dialog@^7.1.8":
-  version "7.1.8"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-sharing-dialog/-/d2-ui-sharing-dialog-7.1.8.tgz#3e0819b128553872d23a522de230e9a46e16a44f"
-  integrity sha512-m6YKknbZ94KJ6+MD26gGZBmx0qA7tcQTrhP/Bvjb25VeUV+nvf/InZxO0+AMIkui0XCgzv3xUqxJxjwXhAGGNg==
+"@dhis2/d2-ui-sharing-dialog@7.2.0", "@dhis2/d2-ui-sharing-dialog@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-sharing-dialog/-/d2-ui-sharing-dialog-7.2.0.tgz#18ad372864bc26451ac58f3488b2d68bd235c185"
+  integrity sha512-l12r7yoI9lU5NWxH6yWBlPdXVpIqqRQ96oq5M5taRG/r1UxLNf3KTigOjT8Ghg+LtCnJGFebyXi5ZTFCwN0c/Q==
   dependencies:
-    "@dhis2/d2-ui-core" "7.1.8"
+    "@dhis2/d2-ui-core" "7.2.0"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"
@@ -1566,12 +1567,12 @@
     recompose "^0.26.0"
     rxjs "^5.5.7"
 
-"@dhis2/d2-ui-translation-dialog@^7.1.8":
-  version "7.1.8"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-translation-dialog/-/d2-ui-translation-dialog-7.1.8.tgz#d4e74bda9f99e9de20b2159b68ec95b4f3d8aa28"
-  integrity sha512-vQFiF2VTNnnv/xWYse0RFlvO4JwUfDV16V+1/94vCxgBAf+222URqQoPQraEUVJSLewUTtxcpNzWZ4WhANhUjw==
+"@dhis2/d2-ui-translation-dialog@^7.2.0":
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-translation-dialog/-/d2-ui-translation-dialog-7.2.0.tgz#4e990e6bf551213f1a514b560a211d3444bd34bd"
+  integrity sha512-hbe1QWGxo8bx+Ha5XNrN4ELVhJJPrwtJ89asybCot8InPjepYbf1U2QQYG6DX4GzEGZ3r+aSq+07QWfK9h9m+Q==
   dependencies:
-    "@dhis2/d2-ui-core" "7.1.8"
+    "@dhis2/d2-ui-core" "7.2.0"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1506,10 +1506,10 @@
     i18next "^10.3"
     moment "^2.24.0"
 
-"@dhis2/d2-ui-core@7.1.5":
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-7.1.5.tgz#38fd0d74004c23d5cb85e84a003e709c5d400ad6"
-  integrity sha512-L3zCO8JdW0yhBqWghZOrXeQG5oSVXdFBXIEGcedM8QAe0FG42Ch0MNjzP9FNFpCpCNhjOPO2SlX3sCT8BpQKWg==
+"@dhis2/d2-ui-core@7.1.8":
+  version "7.1.8"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-core/-/d2-ui-core-7.1.8.tgz#1339f91f4ce2e0a38897dab29de22db725d058a5"
+  integrity sha512-nd6Pfkm18WYbWC4M7HRkIkANuyeDMNQfVQt3nnUZ7Hje2O3hZmzsdOpTWYhtzxSx1uhQV4n/CPjJEWaqG7T+/g==
   dependencies:
     babel-runtime "^6.26.0"
     d2 "~31.7"
@@ -1517,12 +1517,12 @@
     material-ui "^0.20.0"
     rxjs "^5.5.7"
 
-"@dhis2/d2-ui-favorites-dialog@^7.1.5":
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-favorites-dialog/-/d2-ui-favorites-dialog-7.1.5.tgz#e4b879dd607ab5b71989fe7b8c2bd7e97eae4309"
-  integrity sha512-ywyVGaGyFm4L4oKWReAWOfRhyn2tAsJXPFWPYloV2I+cMZ4w8/CSLxRjsbrp21YlJy5QYnMu9RyuF/6qBzDR9A==
+"@dhis2/d2-ui-favorites-dialog@^7.1.8":
+  version "7.1.8"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-favorites-dialog/-/d2-ui-favorites-dialog-7.1.8.tgz#b961a0aa5f28d039141670fdd3e99afb2b89aaf1"
+  integrity sha512-YLap6LYhLBtVMFYdxiU21UUYqQQ2xTPJamgZh5ynS+g3j2VD+DROw7achWxxSuQf8RwvhTW1zrVOQWyL718YKA==
   dependencies:
-    "@dhis2/d2-ui-sharing-dialog" "7.1.5"
+    "@dhis2/d2-ui-sharing-dialog" "7.1.8"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"
@@ -1532,32 +1532,32 @@
     redux-logger "^3.0.6"
     redux-thunk "^2.2.0"
 
-"@dhis2/d2-ui-org-unit-dialog@^7.1.5":
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-dialog/-/d2-ui-org-unit-dialog-7.1.5.tgz#aa6b9257a25ff1a238f77a9638323b6cf0ee37d8"
-  integrity sha512-kN+494W2ttNNPHHbY4glXg6QwreJYqmkOKDbl/lrKZ/ReWBG6Ry6t3omB2w8yEX20KPPyf5WiJBv7L9eLgKnlQ==
+"@dhis2/d2-ui-org-unit-dialog@^7.1.8":
+  version "7.1.8"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-dialog/-/d2-ui-org-unit-dialog-7.1.8.tgz#2ca71f5e59e4809bd3390fd07a5d493e8a8e70bd"
+  integrity sha512-qe4T88oFTyksCtYjTU9yIGFH1/aPb43fl8mqonKXHEEEpLUhHWMghtwXwm2WtguKI0LTZMKMZ6TqPJAL3Jv8IA==
   dependencies:
-    "@dhis2/d2-ui-org-unit-tree" "7.1.5"
+    "@dhis2/d2-ui-org-unit-tree" "7.1.8"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     prop-types "^15.5.10"
 
-"@dhis2/d2-ui-org-unit-tree@7.1.5":
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-7.1.5.tgz#5d5258d5f802cc4cd158f14e61ec37a9e43100b3"
-  integrity sha512-IswS0TZSnOUISQlHjPns8JLo+3CW6P+13ZTOtMyiJAgDumSQtEibqzZU+SNP4GPZOasOjuRBbUXrWoQOjZRIRQ==
+"@dhis2/d2-ui-org-unit-tree@7.1.8":
+  version "7.1.8"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-org-unit-tree/-/d2-ui-org-unit-tree-7.1.8.tgz#cc4c143889cfc5f516b73a7107f56a9e9d382452"
+  integrity sha512-yj7DxBQ9j96BKc1cl1KSY6m4/QB2L/m+eyHzzlKlnSv5ckFPqqrnGAeMt2BVGz7q6sUvAGiVG56jRtGwlOJdxQ==
   dependencies:
-    "@dhis2/d2-ui-core" "7.1.5"
+    "@dhis2/d2-ui-core" "7.1.8"
     "@material-ui/core" "^3.3.1"
     babel-runtime "^6.26.0"
     prop-types "^15.5.10"
 
-"@dhis2/d2-ui-sharing-dialog@7.1.5", "@dhis2/d2-ui-sharing-dialog@^7.1.5":
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-sharing-dialog/-/d2-ui-sharing-dialog-7.1.5.tgz#1915832ed070a0278ee9f7830a8814744142336e"
-  integrity sha512-JT6MY1B69maT9znkCk3+cjnzg5zRNr8HvCSibFddZZN0j+HmKfkEHMfMv88tEUpOHskgmniNykWxtwBEVOkRTg==
+"@dhis2/d2-ui-sharing-dialog@7.1.8", "@dhis2/d2-ui-sharing-dialog@^7.1.8":
+  version "7.1.8"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-sharing-dialog/-/d2-ui-sharing-dialog-7.1.8.tgz#3e0819b128553872d23a522de230e9a46e16a44f"
+  integrity sha512-m6YKknbZ94KJ6+MD26gGZBmx0qA7tcQTrhP/Bvjb25VeUV+nvf/InZxO0+AMIkui0XCgzv3xUqxJxjwXhAGGNg==
   dependencies:
-    "@dhis2/d2-ui-core" "7.1.5"
+    "@dhis2/d2-ui-core" "7.1.8"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"
@@ -1566,12 +1566,12 @@
     recompose "^0.26.0"
     rxjs "^5.5.7"
 
-"@dhis2/d2-ui-translation-dialog@^7.1.5":
-  version "7.1.5"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-translation-dialog/-/d2-ui-translation-dialog-7.1.5.tgz#f27f496b597e97a839847b1f82cca8ca8a7293eb"
-  integrity sha512-fiFinyYqij+wOFOtpOuGefjG87i0W5r6SvSdghkBOd+ET5s6GWdB6ETLG3sq3uOzN++tIa/FLnY6xlEAge5Khg==
+"@dhis2/d2-ui-translation-dialog@^7.1.8":
+  version "7.1.8"
+  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-translation-dialog/-/d2-ui-translation-dialog-7.1.8.tgz#d4e74bda9f99e9de20b2159b68ec95b4f3d8aa28"
+  integrity sha512-vQFiF2VTNnnv/xWYse0RFlvO4JwUfDV16V+1/94vCxgBAf+222URqQoPQraEUVJSLewUTtxcpNzWZ4WhANhUjw==
   dependencies:
-    "@dhis2/d2-ui-core" "7.1.5"
+    "@dhis2/d2-ui-core" "7.1.8"
     "@material-ui/core" "^3.3.1"
     "@material-ui/icons" "^3.0.1"
     babel-runtime "^6.26.0"


### PR DESCRIPTION
**Relates to https://github.com/dhis2/d2-ui/pull/688**

---

### Key features

1. fix the d2-ui narrow dialogs: FavoritesDialog, SharingDialog, TranslateDialog

---

### Description

MUI dependencies have been removed from analytics apps, but some shared component still depends on MUI.
Without the `MUIThemeProvider` the dialogs look much narrower than before.
The above `d2-ui` PR fixes the issue by adding the theme around the components when `insertTheme` is passed in the props.
The `FileMenu` still uses 3 components from `d2-ui` and they all happen to be dialogs, thus they now show the same problem.
This PR passes the `insertTheme` prop to the `d2-ui` components to solve the issue.

---

### Screenshots

Before:
![Screenshot 2021-04-22 at 14 44 12](https://user-images.githubusercontent.com/150978/115716261-493c7000-a379-11eb-936a-33acc461b682.png)
![Screenshot 2021-04-22 at 14 45 37](https://user-images.githubusercontent.com/150978/115717567-95d47b00-a37a-11eb-855a-71d10a8138ec.png)
![Screenshot 2021-04-22 at 14 51 05](https://user-images.githubusercontent.com/150978/115717580-98cf6b80-a37a-11eb-85aa-8c0d35310fa8.png)

After:
![Screenshot 2021-04-22 at 14 44 20](https://user-images.githubusercontent.com/150978/115716275-4e012400-a379-11eb-98ea-ff6cce908ae8.png)
![Screenshot 2021-04-22 at 14 53 42](https://user-images.githubusercontent.com/150978/115717599-9d941f80-a37a-11eb-9cf9-4554a19446c8.png)
![Screenshot 2021-04-22 at 14 53 48](https://user-images.githubusercontent.com/150978/115717610-a127a680-a37a-11eb-9256-bbe5e745dbb1.png)

