### PR TITLE
feat: drill down org units in bar and column charts (DHIS2-11061)

### DIFF
--- a/src/components/PivotTable/PivotTableValueCell.js
+++ b/src/components/PivotTable/PivotTableValueCell.js
@@ -33,7 +33,7 @@ export const PivotTableValueCell = ({
         isClickable && 'clickable',
     ]
     const onClick = () => {
-        onToggleContextualMenu(cellRef, cellContent)
+        onToggleContextualMenu(cellRef.current, { ouId: cellContent.ouId })
     }
 
     if (!cellContent || cellContent.empty) {

--- a/src/visualizations/config/adapters/dhis_highcharts/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/index.js
@@ -153,6 +153,13 @@ export default function ({ store, layout, el, extraConfig, extraOptions }) {
             showLabels: _layout.showValues || _layout.showData,
             tooltipData: _extraOptions.scatterData,
         })
+    } else {
+        config.plotOptions = getPlotOptions({
+            visType: _layout.type,
+            ...(_extraOptions.onToggleContextualMenu
+                ? { onClick: _extraOptions.onToggleContextualMenu }
+                : {}),
+        })
     }
 
     // hide empty categories

--- a/src/visualizations/config/adapters/dhis_highcharts/plotOptions.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/plotOptions.js
@@ -1,10 +1,23 @@
 import i18n from '../../../../locales/index.js'
 
-import { VIS_TYPE_SCATTER } from '../../../../modules/visTypes'
+import {
+    VIS_TYPE_COLUMN,
+    VIS_TYPE_SCATTER,
+    VIS_TYPE_STACKED_COLUMN,
+    VIS_TYPE_BAR,
+    VIS_TYPE_STACKED_BAR,
+} from '../../../../modules/visTypes'
 
 const MAX_LABELS = 10
 
-export default ({ visType, xAxisName, yAxisName, showLabels, tooltipData }) => {
+export default ({
+    visType,
+    xAxisName,
+    yAxisName,
+    showLabels,
+    tooltipData,
+    onClick,
+}) => {
     const series = {
         dataLabels: {
             enabled: showLabels,
@@ -45,6 +58,27 @@ export default ({ visType, xAxisName, yAxisName, showLabels, tooltipData }) => {
                     boostThreshold: 1,
                 },
             }
+        case VIS_TYPE_COLUMN:
+        case VIS_TYPE_STACKED_COLUMN:
+        case VIS_TYPE_BAR:
+        case VIS_TYPE_STACKED_BAR:
+            return onClick
+                ? {
+                      series: {
+                          cursor: 'pointer',
+                          point: {
+                              events: {
+                                  click: function () {
+                                      onClick(this.dataLabel?.element, {
+                                          category: this.category,
+                                          series: this.series.name,
+                                      })
+                                  },
+                              },
+                          },
+                      },
+                  }
+                : {}
         default:
             return {}
     }


### PR DESCRIPTION
Implements [DHIS2-11061](https://jira.dhis2.org/browse/DHIS2-11061)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/1720**

---

### Key features

1. Add `onClick` handler to column and bar charts

---

### Description

Adds an `onClick` handler to `series` items in the `plotOptions`, to support the drill down menu from pivot table. The actual function is passed as in `extraOptions`.

To make the actual function more generic, the params for `onToggleContextualMenu` has been changed. Previously `cellRef` was passed and `current` was extracted on the app side, as well as `cellContent` which is a large object where only `ouId` was used. So instead those two props are reduced to the parts that were actually used (`cellRef.current` and `cellContent.ouId`).
