### PR TITLE
feat: hide periods based on excludedPeriodTypes (DHIS2-11161) (#920) mk2

### DIFF
--- a/src/__demo__/PeriodDimension.stories.js
+++ b/src/__demo__/PeriodDimension.stories.js
@@ -2,6 +2,17 @@ import React from 'react'
 import { storiesOf } from '@storybook/react'
 
 import PeriodDimension from '../components/PeriodDimension/PeriodDimension'
+import {
+    MONTHLY,
+    WEEKLY,
+    WEEKLYWED,
+    WEEKLYTHU,
+    WEEKLYSAT,
+    WEEKLYSUN,
+    DAILY,
+    BIWEEKLY,
+    BIMONTHLY,
+} from '../components/PeriodDimension/utils'
 
 const selectedPeriods = [{ id: 'LAST_12_MONTHS', name: 'Last 12 months' }]
 
@@ -13,6 +24,68 @@ storiesOf('PeriodDimension', module).add('One selected', () => {
     return (
         <PeriodDimension
             selectedPeriods={selectedPeriods}
+            onSelect={selected => console.log(selected)}
+        />
+    )
+})
+
+storiesOf('PeriodDimension', module).add('Monthly excluded', () => {
+    return (
+        <PeriodDimension
+            excludedPeriodTypes={[MONTHLY]}
+            onSelect={selected => console.log(selected)}
+        />
+    )
+})
+
+storiesOf('PeriodDimension', module).add('Weekly excluded', () => {
+    return (
+        <PeriodDimension
+            excludedPeriodTypes={[
+                WEEKLY,
+                WEEKLYWED,
+                WEEKLYTHU,
+                WEEKLYSAT,
+                WEEKLYSUN,
+            ]}
+            onSelect={selected => console.log(selected)}
+        />
+    )
+})
+
+storiesOf('PeriodDimension', module).add('All below Quarterly excluded', () => {
+    return (
+        <PeriodDimension
+            excludedPeriodTypes={[
+                DAILY,
+                WEEKLY,
+                WEEKLYWED,
+                WEEKLYTHU,
+                WEEKLYSAT,
+                WEEKLYSUN,
+                BIWEEKLY,
+                MONTHLY,
+                BIMONTHLY,
+            ]}
+            onSelect={selected => console.log(selected)}
+        />
+    )
+})
+
+storiesOf('PeriodDimension', module).add('Right footer', () => {
+    return (
+        <PeriodDimension
+            rightFooter={
+                <div
+                    style={{
+                        padding: '8px',
+                        margin: '8px 0',
+                        border: '1px solid #f79533',
+                    }}
+                >
+                    <p>Right footer goes here</p>
+                </div>
+            }
             onSelect={selected => console.log(selected)}
         />
     )

--- a/src/__demo__/PeriodDimension.stories.js
+++ b/src/__demo__/PeriodDimension.stories.js
@@ -72,7 +72,7 @@ storiesOf('PeriodDimension', module).add('All below Quarterly excluded', () => {
     )
 })
 
-storiesOf('PeriodDimension', module).add('Right footer', () => {
+storiesOf('PeriodDimension', module).add('Using right footer', () => {
     return (
         <PeriodDimension
             rightFooter={

--- a/src/components/DynamicDimension/DynamicDimension.js
+++ b/src/components/DynamicDimension/DynamicDimension.js
@@ -46,6 +46,9 @@ export const DynamicDimension = ({
             onFetch={fetchItems}
             onSelect={onSelectItems}
             rightFooter={rightFooter}
+            dataTest={`${dimensionTitle
+                .replace(/\s+/g, '-')
+                .toLowerCase()}-dimension`}
         />
     )
 }

--- a/src/components/DynamicDimension/ItemSelector.js
+++ b/src/components/DynamicDimension/ItemSelector.js
@@ -82,6 +82,7 @@ const ItemSelector = ({
     onFetch,
     onSelect,
     rightFooter,
+    dataTest,
 }) => {
     const [state, setState] = useState({
         filter: '',
@@ -161,8 +162,13 @@ const ItemSelector = ({
             rightHeader={<RightHeader />}
             rightFooter={rightFooter}
             renderOption={props => (
-                <TransferOption {...props} icon={GenericIcon} />
+                <TransferOption
+                    {...props}
+                    icon={GenericIcon}
+                    dataTest={`${dataTest}-transfer-option`}
+                />
             )}
+            dataTest={`${dataTest}-transfer`}
         />
     )
 }
@@ -170,6 +176,7 @@ const ItemSelector = ({
 ItemSelector.propTypes = {
     onFetch: PropTypes.func.isRequired,
     onSelect: PropTypes.func.isRequired,
+    dataTest: PropTypes.string,
     initialSelected: PropTypes.arrayOf(
         PropTypes.exact({
             label: PropTypes.string.isRequired,

--- a/src/components/PeriodDimension/FixedPeriodFilter.js
+++ b/src/components/PeriodDimension/FixedPeriodFilter.js
@@ -5,9 +5,11 @@ import { SingleSelectField, InputField, SingleSelectOption } from '@dhis2/ui'
 
 import { getFixedPeriodsOptions } from './utils/fixedPeriods'
 import styles from './styles/PeriodFilter.style'
+import { filterPeriodTypesById } from './utils/index.js'
 
 const FixedPeriodFilter = ({
     allowedPeriodTypes,
+    excludedPeriodTypes,
     currentPeriodType,
     currentYear,
     onSelectPeriodType,
@@ -31,22 +33,24 @@ const FixedPeriodFilter = ({
                     className="filterElement"
                     dataTest={`${dataTest}-period-type`}
                 >
-                    {getFixedPeriodsOptions()
-                        .filter(
-                            option =>
-                                !allowedPeriodTypes ||
-                                allowedPeriodTypes.some(
-                                    type => type === option.id
-                                )
-                        )
-                        .map(option => (
-                            <SingleSelectOption
-                                key={option.id}
-                                value={option.id}
-                                label={option.name}
-                                dataTest={`${dataTest}-period-type-option-${option.id}`}
-                            />
-                        ))}
+                    {(allowedPeriodTypes
+                        ? getFixedPeriodsOptions().filter(option =>
+                              allowedPeriodTypes.some(
+                                  type => type === option.id
+                              )
+                          )
+                        : filterPeriodTypesById(
+                              getFixedPeriodsOptions(),
+                              excludedPeriodTypes
+                          )
+                    ).map(option => (
+                        <SingleSelectOption
+                            key={option.id}
+                            value={option.id}
+                            label={option.name}
+                            dataTest={`${dataTest}-period-type-option-${option.id}`}
+                        />
+                    ))}
                 </SingleSelectField>
             </div>
             <div className="rightSection">
@@ -73,6 +77,7 @@ FixedPeriodFilter.propTypes = {
     onSelectYear: PropTypes.func.isRequired,
     allowedPeriodTypes: PropTypes.arrayOf(PropTypes.string),
     dataTest: PropTypes.string,
+    excludedPeriodTypes: PropTypes.arrayOf(PropTypes.string),
 }
 
 export default FixedPeriodFilter

--- a/src/components/PeriodDimension/PeriodDimension.js
+++ b/src/components/PeriodDimension/PeriodDimension.js
@@ -4,26 +4,32 @@ import PropTypes from 'prop-types'
 import PeriodTransfer from './PeriodTransfer'
 import { DIMENSION_ID_PERIOD } from '../../modules/predefinedDimensions'
 
-export const PeriodDimension = ({ onSelect, selectedPeriods, rightFooter }) => {
+export const PeriodDimension = ({
+    onSelect,
+    selectedPeriods,
+    rightFooter,
+    excludedPeriodTypes,
+}) => {
     const selectPeriods = periods => {
         onSelect({
             dimensionId: DIMENSION_ID_PERIOD,
             items: periods,
         })
     }
-
     return (
         <PeriodTransfer
             onSelect={selectPeriods}
             initialSelectedPeriods={selectedPeriods}
             rightFooter={rightFooter}
             dataTest={'period-dimension'}
+            excludedPeriodTypes={excludedPeriodTypes}
         />
     )
 }
 
 PeriodDimension.propTypes = {
     onSelect: PropTypes.func.isRequired,
+    excludedPeriodTypes: PropTypes.arrayOf(PropTypes.string),
     rightFooter: PropTypes.node,
     selectedPeriods: PropTypes.array,
 }

--- a/src/components/PeriodDimension/PeriodTransfer.js
+++ b/src/components/PeriodDimension/PeriodTransfer.js
@@ -1,12 +1,12 @@
-import React, { Component } from 'react'
+import React, { useState } from 'react'
 import PropTypes from 'prop-types'
 import { TabBar, Tab, Transfer } from '@dhis2/ui'
 import i18n from '../../locales/index.js'
 
 import FixedPeriodFilter from './FixedPeriodFilter'
 import RelativePeriodFilter from './RelativePeriodFilter'
-import { MONTHS, getRelativePeriodsOptionsById } from './utils/relativePeriods'
-import { MONTHLY, getFixedPeriodsOptionsById } from './utils/fixedPeriods'
+import { getRelativePeriodsOptionsById } from './utils/relativePeriods'
+import { getFixedPeriodsOptionsById } from './utils/fixedPeriods'
 import styles from '../styles/DimensionSelector.style'
 import { TransferOption } from '../TransferOption'
 import PeriodIcon from '../../assets/DimensionItemIcons/PeriodIcon' //TODO: Reimplement the icon
@@ -15,104 +15,109 @@ import {
     TRANSFER_OPTIONS_WIDTH,
     TRANSFER_SELECTED_WIDTH,
 } from '../../modules/dimensionSelectorHelper'
+import { MONTHLY, QUARTERLY } from './utils/index.js'
 
-const defaultRelativePeriodType = getRelativePeriodsOptionsById(MONTHS)
-const defaultFixedPeriodType = getFixedPeriodsOptionsById(MONTHLY)
-const defaultFixedPeriodYear = new Date().getFullYear()
-const fixedPeriodConfig = year => ({
-    offset: year - defaultFixedPeriodYear,
-    filterFuturePeriods: false,
-    reversePeriods: false,
-})
+export const PeriodTransfer = ({
+    onSelect,
+    dataTest,
+    initialSelectedPeriods,
+    rightFooter,
+    excludedPeriodTypes,
+}) => {
+    const defaultRelativePeriodType = excludedPeriodTypes.includes(MONTHLY)
+        ? getRelativePeriodsOptionsById(QUARTERLY)
+        : getRelativePeriodsOptionsById(MONTHLY)
+    const defaultFixedPeriodType = excludedPeriodTypes.includes(MONTHLY)
+        ? getFixedPeriodsOptionsById(QUARTERLY)
+        : getFixedPeriodsOptionsById(MONTHLY)
+    const defaultFixedPeriodYear = new Date().getFullYear()
+    const fixedPeriodConfig = year => ({
+        offset: year - defaultFixedPeriodYear,
+        filterFuturePeriods: false,
+        reversePeriods: false,
+    })
 
-class PeriodTransfer extends Component {
-    state = {
-        allPeriods: defaultRelativePeriodType.getPeriods(),
-        selectedPeriods: [],
-        isRelative: true,
-        relativeFilter: {
-            periodType: defaultRelativePeriodType.id,
-        },
-        fixedFilter: {
-            periodType: defaultFixedPeriodType.id,
-            year: defaultFixedPeriodYear.toString(),
-        },
-    }
+    const [allPeriods, setAllPeriods] = useState(
+        defaultRelativePeriodType.getPeriods()
+    )
+    const [selectedPeriods, setSelectedPeriods] = useState(
+        initialSelectedPeriods
+    )
+    const [isRelative, setIsRelative] = useState(true)
+    const [relativeFilter, setRelativeFilter] = useState({
+        periodType: defaultRelativePeriodType.id,
+    })
+    const [fixedFilter, setFixedFilter] = useState({
+        periodType: defaultFixedPeriodType.id,
+        year: defaultFixedPeriodYear.toString(),
+    })
 
-    constructor(props) {
-        super(props)
-
-        this.state.selectedPeriods = this.props.initialSelectedPeriods
-    }
-
-    onIsRelativeClick = isRelative => {
-        if (this.state.isRelative !== isRelative) {
-            this.setState({ isRelative })
-            this.setState({
-                allPeriods: isRelative
+    const onIsRelativeClick = state => {
+        if (state !== isRelative) {
+            setIsRelative(state)
+            setAllPeriods(
+                state
                     ? getRelativePeriodsOptionsById(
-                          this.state.relativeFilter.periodType
+                          relativeFilter.periodType
                       ).getPeriods()
                     : getFixedPeriodsOptionsById(
-                          this.state.fixedFilter.periodType
-                      ).getPeriods(
-                          fixedPeriodConfig(Number(this.state.fixedFilter.year))
-                      ),
-            })
+                          fixedFilter.periodType
+                      ).getPeriods(fixedPeriodConfig(Number(fixedFilter.year)))
+            )
         }
     }
 
-    renderLeftHeader = () => (
+    const renderLeftHeader = () => (
         <>
             <TabBar>
                 <Tab
-                    selected={this.state.isRelative}
-                    onClick={() => this.onIsRelativeClick(true)}
-                    dataTest={`${this.props.dataTest}-relative-periods-button`}
+                    selected={isRelative}
+                    onClick={() => onIsRelativeClick(true)}
+                    dataTest={`${dataTest}-relative-periods-button`}
                 >
                     {i18n.t('Relative periods')}
                 </Tab>
                 <Tab
-                    selected={!this.state.isRelative}
-                    onClick={() => this.onIsRelativeClick(false)}
-                    dataTest={`${this.props.dataTest}-fixed-periods-button`}
+                    selected={!isRelative}
+                    onClick={() => onIsRelativeClick(false)}
+                    dataTest={`${dataTest}-fixed-periods-button`}
                 >
                     {i18n.t('Fixed periods')}
                 </Tab>
             </TabBar>
             <div className="filterContainer">
-                {this.state.isRelative ? (
+                {isRelative ? (
                     <RelativePeriodFilter
-                        currentFilter={this.state.relativeFilter.periodType}
+                        currentFilter={relativeFilter.periodType}
                         onSelectFilter={filter => {
-                            this.setState({
-                                relativeFilter: { periodType: filter },
-                            })
-                            this.setState({
-                                allPeriods: getRelativePeriodsOptionsById(
+                            setRelativeFilter({ periodType: filter })
+                            setAllPeriods(
+                                getRelativePeriodsOptionsById(
                                     filter
-                                ).getPeriods(),
-                            })
+                                ).getPeriods()
+                            )
                         }}
-                        dataTest={`${this.props.dataTest}-relative-period-filter`}
+                        dataTest={`${dataTest}-relative-period-filter`}
+                        excludedPeriodTypes={excludedPeriodTypes}
                     />
                 ) : (
                     <FixedPeriodFilter
-                        currentPeriodType={this.state.fixedFilter.periodType}
-                        currentYear={this.state.fixedFilter.year}
+                        currentPeriodType={fixedFilter.periodType}
+                        currentYear={fixedFilter.year}
                         onSelectPeriodType={periodType => {
-                            this.onSelectFixedPeriods({
+                            onSelectFixedPeriods({
                                 periodType,
-                                year: this.state.fixedFilter.year,
+                                year: fixedFilter.year,
                             })
                         }}
                         onSelectYear={year => {
-                            this.onSelectFixedPeriods({
-                                periodType: this.state.fixedFilter.periodType,
+                            onSelectFixedPeriods({
+                                periodType: fixedFilter.periodType,
                                 year,
                             })
                         }}
-                        dataTest={`${this.props.dataTest}-fixed-period-filter`}
+                        dataTest={`${dataTest}-fixed-period-filter`}
+                        excludedPeriodTypes={excludedPeriodTypes}
                     />
                 )}
             </div>
@@ -120,68 +125,77 @@ class PeriodTransfer extends Component {
         </>
     )
 
-    renderRightHeader = () => (
+    const renderRightHeader = () => (
         <>
             <p className="rightHeader">{i18n.t('Selected Periods')}</p>
             <style jsx>{styles}</style>
         </>
     )
 
-    onSelectFixedPeriods = fixedFilter => {
-        this.setState({
-            fixedFilter,
-            allPeriods: getFixedPeriodsOptionsById(
-                fixedFilter.periodType
-            ).getPeriods(fixedPeriodConfig(Number(fixedFilter.year))),
-        })
+    const onSelectFixedPeriods = filter => {
+        setFixedFilter(filter)
+        setAllPeriods(
+            getFixedPeriodsOptionsById(filter.periodType).getPeriods(
+                fixedPeriodConfig(Number(filter.year))
+            )
+        )
     }
 
-    renderEmptySelection = () => (
+    const renderEmptySelection = () => (
         <>
             <p className="emptyList">{i18n.t('No periods selected')}</p>
             <style jsx>{styles}</style>
         </>
     )
 
-    render = () => (
+    return (
         <Transfer
             onChange={({ selected }) => {
                 const formattedItems = selected.map(id => ({
                     id,
-                    name: [
-                        ...this.state.allPeriods,
-                        ...this.state.selectedPeriods,
-                    ].find(item => item.id === id).name,
+                    name: [...allPeriods, ...selectedPeriods].find(
+                        item => item.id === id
+                    ).name,
                 }))
-                this.setState({ selectedPeriods: formattedItems })
-                this.props.onSelect(formattedItems)
+                setSelectedPeriods(formattedItems)
+                onSelect(formattedItems)
             }}
-            selected={this.state.selectedPeriods.map(period => period.id)}
-            leftHeader={this.renderLeftHeader()}
+            selected={selectedPeriods.map(period => period.id)}
+            leftHeader={renderLeftHeader()}
             enableOrderChange
             height={TRANSFER_HEIGHT}
             optionsWidth={TRANSFER_OPTIONS_WIDTH}
             selectedWidth={TRANSFER_SELECTED_WIDTH}
-            selectedEmptyComponent={this.renderEmptySelection()}
-            rightHeader={this.renderRightHeader()}
-            rightFooter={this.props.rightFooter}
-            options={[
-                ...this.state.allPeriods,
-                ...this.state.selectedPeriods,
-            ].map(({ id, name }) => ({
-                label: name,
-                value: id,
-            }))}
-            renderOption={props => (
-                <TransferOption {...props} icon={PeriodIcon} />
+            selectedEmptyComponent={renderEmptySelection()}
+            rightHeader={renderRightHeader()}
+            rightFooter={rightFooter}
+            options={[...allPeriods, ...selectedPeriods].map(
+                ({ id, name }) => ({
+                    label: name,
+                    value: id,
+                })
             )}
+            renderOption={props => (
+                <TransferOption
+                    {...props}
+                    icon={PeriodIcon}
+                    dataTest={`${dataTest}-transfer-option`}
+                />
+            )}
+            dataTest={`${dataTest}-transfer`}
         ></Transfer>
     )
+}
+
+PeriodTransfer.defaultProps = {
+    initialSelectedPeriods: [],
+    excludedPeriodTypes: [],
 }
 
 PeriodTransfer.propTypes = {
     onSelect: PropTypes.func.isRequired,
     dataTest: PropTypes.string,
+    excludedPeriodTypes: PropTypes.arrayOf(PropTypes.string),
     initialSelectedPeriods: PropTypes.arrayOf(
         PropTypes.shape({
             id: PropTypes.string,
@@ -189,10 +203,6 @@ PeriodTransfer.propTypes = {
         })
     ),
     rightFooter: PropTypes.node,
-}
-
-PeriodTransfer.defaultProps = {
-    initialSelectedPeriods: [],
 }
 
 export default PeriodTransfer

--- a/src/components/PeriodDimension/RelativePeriodFilter.js
+++ b/src/components/PeriodDimension/RelativePeriodFilter.js
@@ -5,8 +5,14 @@ import { SingleSelectField, SingleSelectOption } from '@dhis2/ui'
 
 import { getRelativePeriodsOptions } from './utils/relativePeriods'
 import styles from './styles/PeriodFilter.style'
+import { filterPeriodTypesById } from './utils/index.js'
 
-const RelativePeriodFilter = ({ currentFilter, onSelectFilter, dataTest }) => (
+const RelativePeriodFilter = ({
+    currentFilter,
+    onSelectFilter,
+    dataTest,
+    excludedPeriodTypes,
+}) => (
     <div className="leftSection">
         <SingleSelectField
             label={i18n.t('Period type')}
@@ -16,7 +22,10 @@ const RelativePeriodFilter = ({ currentFilter, onSelectFilter, dataTest }) => (
             className="filterElement"
             dataTest={dataTest}
         >
-            {getRelativePeriodsOptions().map(option => (
+            {filterPeriodTypesById(
+                getRelativePeriodsOptions(),
+                excludedPeriodTypes
+            ).map(option => (
                 <SingleSelectOption
                     key={option.id}
                     value={option.id}
@@ -33,6 +42,7 @@ RelativePeriodFilter.propTypes = {
     currentFilter: PropTypes.string.isRequired,
     onSelectFilter: PropTypes.func.isRequired,
     dataTest: PropTypes.string,
+    excludedPeriodTypes: PropTypes.arrayOf(PropTypes.string),
 }
 
 export default RelativePeriodFilter

--- a/src/components/PeriodDimension/__tests__/PeriodSelector.spec.js
+++ b/src/components/PeriodDimension/__tests__/PeriodSelector.spec.js
@@ -18,6 +18,7 @@ describe('The Period Selector component', () => {
             initialSelectedPeriods: [],
             onSelect: jest.fn(),
             rightFooter: <></>,
+            dataTest: 'period-dimension',
         }
         shallowPeriodTransfer = undefined
     })

--- a/src/components/PeriodDimension/__tests__/__snapshots__/PeriodDimension.spec.js.snap
+++ b/src/components/PeriodDimension/__tests__/__snapshots__/PeriodDimension.spec.js.snap
@@ -3,6 +3,7 @@
 exports[`The Period Dimension component matches the snapshot 1`] = `
 <PeriodTransfer
   dataTest="period-dimension"
+  excludedPeriodTypes={Array []}
   initialSelectedPeriods={Array []}
   onSelect={[Function]}
   rightFooter={<React.Fragment />}

--- a/src/components/PeriodDimension/__tests__/__snapshots__/PeriodSelector.spec.js.snap
+++ b/src/components/PeriodDimension/__tests__/__snapshots__/PeriodSelector.spec.js.snap
@@ -2,7 +2,7 @@
 
 exports[`The Period Selector component matches the snapshot 1`] = `
 <Transfer
-  dataTest="dhis2-uicore-transfer"
+  dataTest="period-dimension-transfer"
   enableOrderChange={true}
   filterCallback={[Function]}
   filterCallbackPicked={[Function]}
@@ -15,14 +15,14 @@ exports[`The Period Selector component matches the snapshot 1`] = `
         dataTest="dhis2-uicore-tabbar"
       >
         <Tab
-          dataTest="undefined-relative-periods-button"
+          dataTest="period-dimension-relative-periods-button"
           onClick={[Function]}
           selected={true}
         >
           Relative periods
         </Tab>
         <Tab
-          dataTest="undefined-fixed-periods-button"
+          dataTest="period-dimension-fixed-periods-button"
           onClick={[Function]}
           selected={false}
         >
@@ -33,8 +33,9 @@ exports[`The Period Selector component matches the snapshot 1`] = `
         className="filterContainer"
       >
         <RelativePeriodFilter
-          currentFilter="Months"
-          dataTest="undefined-relative-period-filter"
+          currentFilter="MONTHLY"
+          dataTest="period-dimension-relative-period-filter"
+          excludedPeriodTypes={Array []}
           onSelectFilter={[Function]}
         />
       </div>

--- a/src/components/PeriodDimension/__tests__/fixedPeriods.spec.js
+++ b/src/components/PeriodDimension/__tests__/fixedPeriods.spec.js
@@ -18,11 +18,11 @@ describe('fixedPeriods utils', () => {
             expect(periodIds).toEqual([
                 'DAILY',
                 'WEEKLY',
-                'BIWEEKLY',
                 'WEEKLYWED',
                 'WEEKLYTHU',
                 'WEEKLYSAT',
                 'WEEKLYSUN',
+                'BIWEEKLY',
                 'MONTHLY',
                 'BIMONTHLY',
                 'QUARTERLY',

--- a/src/components/PeriodDimension/__tests__/utils.spec.js
+++ b/src/components/PeriodDimension/__tests__/utils.spec.js
@@ -1,0 +1,54 @@
+import { filterPeriodTypesById } from '../utils'
+import { getFixedPeriodsOptions } from '../utils/fixedPeriods'
+import { getRelativePeriodsOptions } from '../utils/relativePeriods'
+
+describe('utils', () => {
+    describe('filterPeriodTypesById', () => {
+        it('should filter fixed periods', () => {
+            const excludedPeriodTypes = [
+                'DAILY',
+                'WEEKLY',
+                'WEEKLYSAT',
+                'MONTHLY',
+                'FYOCT',
+            ]
+            const periodIds = filterPeriodTypesById(
+                getFixedPeriodsOptions(),
+                excludedPeriodTypes
+            ).map(option => option.id)
+
+            expect(periodIds).toEqual([
+                'WEEKLYWED',
+                'WEEKLYTHU',
+                'WEEKLYSUN',
+                'BIWEEKLY',
+                'BIMONTHLY',
+                'QUARTERLY',
+                'SIXMONTHLY',
+                'SIXMONTHLYAPR',
+                'YEARLY',
+                'FYNOV',
+                'FYJUL',
+                'FYAPR',
+            ])
+        })
+
+        it('should filter relative periods', () => {
+            const excludedPeriodTypes = ['MONTHLY', 'BIMONTHLY']
+            const periodIds = filterPeriodTypesById(
+                getRelativePeriodsOptions(),
+                excludedPeriodTypes
+            ).map(option => option.id)
+
+            expect(periodIds).toEqual([
+                'DAILY',
+                'WEEKLY',
+                'BIWEEKLY',
+                'QUARTERLY',
+                'SIXMONTHLY',
+                'FINANCIAL',
+                'YEARLY',
+            ])
+        })
+    })
+})

--- a/src/components/PeriodDimension/utils/fixedPeriods.js
+++ b/src/components/PeriodDimension/utils/fixedPeriods.js
@@ -1,23 +1,23 @@
 import i18n from '../../../locales/index.js'
-// generate periods config object: { boolean offset, boolean filterFuturePeriods, boolean reversePeriods }
-
-export const DAILY = 'DAILY'
-export const WEEKLY = 'WEEKLY'
-export const BIWEEKLY = 'BIWEEKLY'
-export const WEEKLYWED = 'WEEKLYWED'
-export const WEEKLYTHU = 'WEEKLYTHU'
-export const WEEKLYSAT = 'WEEKLYSAT'
-export const WEEKLYSUN = 'WEEKLYSUN'
-export const MONTHLY = 'MONTHLY'
-export const BIMONTHLY = 'BIMONTHLY'
-export const QUARTERLY = 'QUARTERLY'
-export const SIXMONTHLY = 'SIXMONTHLY'
-export const SIXMONTHLYAPR = 'SIXMONTHLYAPR'
-export const YEARLY = 'YEARLY'
-export const FYNOV = 'FYNOV'
-export const FYOCT = 'FYOCT'
-export const FYJUL = 'FYJUL'
-export const FYAPR = 'FYAPR'
+import {
+    DAILY,
+    WEEKLY,
+    WEEKLYWED,
+    WEEKLYTHU,
+    WEEKLYSAT,
+    WEEKLYSUN,
+    BIWEEKLY,
+    MONTHLY,
+    BIMONTHLY,
+    QUARTERLY,
+    SIXMONTHLY,
+    SIXMONTHLYAPR,
+    YEARLY,
+    FYNOV,
+    FYOCT,
+    FYJUL,
+    FYAPR,
+} from './index.js'
 
 const PERIOD_TYPE_REGEX = {
     [DAILY]: /^([0-9]{4})([0-9]{2})([0-9]{2})$/, // YYYYMMDD
@@ -575,11 +575,6 @@ const getOptions = () => [
         name: i18n.t('Weekly'),
     },
     {
-        id: BIWEEKLY,
-        getPeriods: getBiWeeklyPeriodType(formatYyyyMmDd, filterFuturePeriods),
-        name: i18n.t('Bi-weekly'),
-    },
-    {
         id: WEEKLYWED,
         getPeriods: getWeeklyPeriodType(
             formatYyyyMmDd,
@@ -614,6 +609,11 @@ const getOptions = () => [
             filterFuturePeriods
         ),
         name: i18n.t('Weekly (Start Sunday)'),
+    },
+    {
+        id: BIWEEKLY,
+        getPeriods: getBiWeeklyPeriodType(formatYyyyMmDd, filterFuturePeriods),
+        name: i18n.t('Bi-weekly'),
     },
     {
         id: MONTHLY,

--- a/src/components/PeriodDimension/utils/index.js
+++ b/src/components/PeriodDimension/utils/index.js
@@ -1,0 +1,21 @@
+export const DAILY = 'DAILY'
+export const WEEKLY = 'WEEKLY'
+export const WEEKLYWED = 'WEEKLYWED'
+export const WEEKLYTHU = 'WEEKLYTHU'
+export const WEEKLYSAT = 'WEEKLYSAT'
+export const WEEKLYSUN = 'WEEKLYSUN'
+export const BIWEEKLY = 'BIWEEKLY'
+export const MONTHLY = 'MONTHLY'
+export const BIMONTHLY = 'BIMONTHLY'
+export const QUARTERLY = 'QUARTERLY'
+export const SIXMONTHLY = 'SIXMONTHLY'
+export const SIXMONTHLYAPR = 'SIXMONTHLYAPR'
+export const YEARLY = 'YEARLY'
+export const FINANCIAL = 'FINANCIAL'
+export const FYNOV = 'FYNOV'
+export const FYOCT = 'FYOCT'
+export const FYJUL = 'FYJUL'
+export const FYAPR = 'FYAPR'
+
+export const filterPeriodTypesById = (allPeriodTypes, excludedPeriodTypes) =>
+    allPeriodTypes.filter(period => !excludedPeriodTypes.includes(period.id))

--- a/src/components/PeriodDimension/utils/relativePeriods.js
+++ b/src/components/PeriodDimension/utils/relativePeriods.js
@@ -1,14 +1,15 @@
 import i18n from '../../../locales/index.js'
-
-export const DAYS = 'Days'
-export const WEEKS = 'Weeks'
-export const BIWEEKS = 'BiWeeks'
-export const MONTHS = 'Months'
-export const BIMONTHS = 'BiMonths'
-export const QUARTERS = 'Quarters'
-export const SIXMONTHS = 'SixMonths'
-export const FINACIALYEARS = 'FinancialYears'
-export const YEARS = 'Years'
+import {
+    DAILY,
+    WEEKLY,
+    BIWEEKLY,
+    MONTHLY,
+    BIMONTHLY,
+    QUARTERLY,
+    SIXMONTHLY,
+    FINANCIAL,
+    YEARLY,
+} from './index.js'
 
 const getDaysPeriodType = () => [
     { id: 'TODAY', name: i18n.t('Today') },
@@ -103,44 +104,48 @@ const getYearsPeriodType = () => [
 ]
 
 const getOptions = () => [
-    { id: DAYS, getPeriods: () => getDaysPeriodType(), name: i18n.t('Days') },
     {
-        id: WEEKS,
+        id: DAILY,
+        getPeriods: () => getDaysPeriodType(),
+        name: i18n.t('Days'),
+    },
+    {
+        id: WEEKLY,
         getPeriods: () => getWeeksPeriodType(),
         name: i18n.t('Weeks'),
     },
     {
-        id: BIWEEKS,
+        id: BIWEEKLY,
         getPeriods: () => getBiWeeksPeriodType(),
         name: i18n.t('Bi-weeks'),
     },
     {
-        id: MONTHS,
+        id: MONTHLY,
         getPeriods: () => getMonthsPeriodType(),
         name: i18n.t('Months'),
     },
     {
-        id: BIMONTHS,
+        id: BIMONTHLY,
         getPeriods: () => getBiMonthsPeriodType(),
         name: i18n.t('Bi-months'),
     },
     {
-        id: QUARTERS,
+        id: QUARTERLY,
         getPeriods: () => getQuartersPeriodType(),
         name: i18n.t('Quarters'),
     },
     {
-        id: SIXMONTHS,
+        id: SIXMONTHLY,
         getPeriods: () => getSixMonthsPeriodType(),
         name: i18n.t('Six-months'),
     },
     {
-        id: FINACIALYEARS,
+        id: FINANCIAL,
         getPeriods: () => getFinancialYearsPeriodType(),
         name: i18n.t('Financial Years'),
     },
     {
-        id: YEARS,
+        id: YEARLY,
         getPeriods: () => getYearsPeriodType(),
         name: i18n.t('Years'),
     },

--- a/src/index.js
+++ b/src/index.js
@@ -229,9 +229,25 @@ export {
     colorSets,
 } from './visualizations/util/colors/colorSets'
 
-// Utils: relativePeriods
+// Utils: periods
 export {
-    DAYS,
-    WEEKS,
-    getRelativePeriodsOptionsById,
-} from './components/PeriodDimension/utils/relativePeriods'
+    DAILY,
+    WEEKLY,
+    WEEKLYWED,
+    WEEKLYTHU,
+    WEEKLYSAT,
+    WEEKLYSUN,
+    BIWEEKLY,
+    MONTHLY,
+    BIMONTHLY,
+    QUARTERLY,
+    SIXMONTHLY,
+    SIXMONTHLYAPR,
+    YEARLY,
+    FINANCIAL,
+    FYNOV,
+    FYOCT,
+    FYJUL,
+    FYAPR,
+} from './components/PeriodDimension/utils'
+export { getRelativePeriodsOptionsById } from './components/PeriodDimension/utils/relativePeriods'


### PR DESCRIPTION
Implements [DHIS2-11161](https://jira.dhis2.org/browse/DHIS2-11161)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/1721**

---

### Key features

1. Hide periods based on `excludedPeriodTypes` (daily, weekly, biweekly, monthly, bimonthly)
2. Refactor PeriodTransfer.js to a functional component (see first commit)
3. Refactor all relative periods to use the fixed period format instead (e.g. `DAYS` becomes `DAILY`)
3. Export all the period types
4. Stories and unit tests for the new prop
5. Add missing`dataTest` props for `PeriodDimension` and `DynamicDimension`
6. Bonus: Moves `Bi-weekly` to the correct spot in the period type selector

---

### Description

Receives `excludedPeriodTypes` to hide certain periods in the period selector. Both relative and fixed periods are affected, which is why they needed to use the same format (`DAILY` in both instead of `DAILY` and `DAYS`).

There's a default selected period type, which is usually `Months`, this falls back to `Quarters` if `Months` is excluded, since `Quarters` can never be hidden in the settings app / backend, so it's the first "reliable" period type moving up from `Months`.

---

### BREAKING CHANGE

- `DAYS` and `WEEKS` is not exported anymore (use `DAILY` and `WEEKLY` instead)

### TODO

-   [x] Unit tests for the filter logic

---

### Screenshots

_`Quarters` is the default selected period type when `Months` is excluded_

![image](https://user-images.githubusercontent.com/12590483/119630489-48cb4500-be0f-11eb-966f-3c4947e9bcf6.png)

_`Months` is excluded from the type selector_

![image](https://user-images.githubusercontent.com/12590483/119630545-57196100-be0f-11eb-828b-01ada5f4a383.png)
