### PR TITLE
fix: drill down popup not working when data labels are hidden (DHIS2-11061)

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/plotOptions.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/plotOptions.js
@@ -69,7 +69,7 @@ export default ({
                           point: {
                               events: {
                                   click: function () {
-                                      onClick(this.dataLabel?.element, {
+                                      onClick(this.graphic?.element, {
                                           category: this.category,
                                           series: this.series.name,
                                       })


### PR DESCRIPTION
Implements a fix for [DHIS2-11061](https://jira.dhis2.org/browse/DHIS2-11061)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/1735**

---

### Key features

1. Bind the popup to the `graphic` element in highcharts instead of the `dataLabel` element

---

### Screenshots

_See the DV PR_