### PR TITLE
feat: show indicator type in SV visualization (DHIS2-7420)

### DIFF
--- a/src/visualizations/config/adapters/dhis_dhis/index.js
+++ b/src/visualizations/config/adapters/dhis_dhis/index.js
@@ -2,6 +2,8 @@ import getSubtitle from './subtitle'
 import getTitle from './title'
 import getValue from './value'
 
+export const INDICATOR_FACTOR_100 = 100
+
 export default function ({ store, layout, extraOptions }) {
     const data = store.generateData({
         type: layout.type,
@@ -12,21 +14,24 @@ export default function ({ store, layout, extraOptions }) {
         categoryId:
             layout.rows && layout.rows.length ? layout.rows[0].dimension : null,
     })
+    const metaData = store.data[0].metaData
 
     const config = {
         value: data[0] === undefined ? extraOptions.noData.text : data[0],
-        formattedValue: getValue(
-            data[0],
-            layout,
-            store.data[0].metaData,
-            extraOptions
-        ),
-        title: getTitle(layout, store.data[0].metaData, extraOptions.dashboard),
-        subtitle: getSubtitle(
-            layout,
-            store.data[0].metaData,
-            extraOptions.dashboard
-        ),
+        formattedValue: getValue(data[0], layout, metaData, extraOptions),
+        title: getTitle(layout, metaData, extraOptions.dashboard),
+        subtitle: getSubtitle(layout, metaData, extraOptions.dashboard),
+    }
+
+    // TODO find a better name and way of accessing this extra object
+    // also, is not necessarily present at all times
+    // should we look at the indicatorType too?
+    const indicatorInfo =
+        metaData.items[metaData.dimensions.dx[0]].indicatorInfo
+
+    // Use % symbol for factor 100 and the full string for others
+    if (indicatorInfo?.factor !== INDICATOR_FACTOR_100) {
+        config.subText = indicatorInfo?.displayName
     }
 
     return config

--- a/src/visualizations/config/adapters/dhis_dhis/index.js
+++ b/src/visualizations/config/adapters/dhis_dhis/index.js
@@ -23,15 +23,12 @@ export default function ({ store, layout, extraOptions }) {
         subtitle: getSubtitle(layout, metaData, extraOptions.dashboard),
     }
 
-    // TODO find a better name and way of accessing this extra object
-    // also, is not necessarily present at all times
-    // should we look at the indicatorType too?
-    const indicatorInfo =
-        metaData.items[metaData.dimensions.dx[0]].indicatorInfo
+    const indicatorType =
+        metaData.items[metaData.dimensions.dx[0]].indicatorType
 
     // Use % symbol for factor 100 and the full string for others
-    if (indicatorInfo?.factor !== INDICATOR_FACTOR_100) {
-        config.subText = indicatorInfo?.displayName
+    if (indicatorType?.factor !== INDICATOR_FACTOR_100) {
+        config.subText = indicatorType?.displayName
     }
 
     return config

--- a/src/visualizations/config/adapters/dhis_dhis/value/index.js
+++ b/src/visualizations/config/adapters/dhis_dhis/value/index.js
@@ -1,12 +1,25 @@
+import { INDICATOR_FACTOR_100 } from '../'
 import { VALUE_TYPE_TEXT } from '../../../../../modules/pivotTable/pivotTableConstants'
 import { renderValue } from '../../../../../modules/pivotTable/renderValue'
 
 export default function (value, layout, metaData, extraOptions) {
     const valueType = metaData.items[metaData.dimensions.dx[0]].valueType
-    return (
+    const indicatorInfo =
+        metaData.items[metaData.dimensions.dx[0]].indicatorInfo
+
+    console.log('indicator info', indicatorInfo)
+
+    let formattedValue =
         renderValue(value, valueType || VALUE_TYPE_TEXT, {
             digitGroupSeparator: layout.digitGroupSeparator,
             skipRounding: layout.skipRounding,
         }) || extraOptions.noData.text
-    )
+
+    // only show the percentage symbol for per cent
+    // for other factors, show the full text under the value
+    if (indicatorInfo?.factor === INDICATOR_FACTOR_100) {
+        formattedValue += ' %'
+    }
+
+    return formattedValue
 }

--- a/src/visualizations/config/adapters/dhis_dhis/value/index.js
+++ b/src/visualizations/config/adapters/dhis_dhis/value/index.js
@@ -4,10 +4,8 @@ import { renderValue } from '../../../../../modules/pivotTable/renderValue'
 
 export default function (value, layout, metaData, extraOptions) {
     const valueType = metaData.items[metaData.dimensions.dx[0]].valueType
-    const indicatorInfo =
-        metaData.items[metaData.dimensions.dx[0]].indicatorInfo
-
-    console.log('indicator info', indicatorInfo)
+    const indicatorType =
+        metaData.items[metaData.dimensions.dx[0]].indicatorType
 
     let formattedValue =
         renderValue(value, valueType || VALUE_TYPE_TEXT, {
@@ -17,8 +15,8 @@ export default function (value, layout, metaData, extraOptions) {
 
     // only show the percentage symbol for per cent
     // for other factors, show the full text under the value
-    if (indicatorInfo?.factor === INDICATOR_FACTOR_100) {
-        formattedValue += ' %'
+    if (indicatorType?.factor === INDICATOR_FACTOR_100) {
+        formattedValue += '%'
     }
 
     return formattedValue

--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -15,7 +15,6 @@ import {
 import { getColorByValueFromLegendSet } from '../../../../modules/legends'
 
 const svgNS = 'http://www.w3.org/2000/svg'
-const defaultFillColor = colors.grey900
 
 const generateValueSVG = (value, formattedValue, subText, legendSet, y) => {
     const textSize = 300
@@ -35,7 +34,7 @@ const generateValueSVG = (value, formattedValue, subText, legendSet, y) => {
 
     const fillColor = legendSet
         ? getColorByValueFromLegendSet(legendSet, value)
-        : defaultFillColor
+        : colors.grey900
 
     const textNode = document.createElementNS(svgNS, 'text')
     textNode.setAttribute('text-anchor', 'middle')
@@ -66,7 +65,7 @@ const generateValueSVG = (value, formattedValue, subText, legendSet, y) => {
         subTextNode.setAttribute('font-size', subTextSize)
         subTextNode.setAttribute('x', '50%')
         subTextNode.setAttribute('x', '50%')
-        subTextNode.setAttribute('fill', defaultFillColor)
+        subTextNode.setAttribute('fill', colors.grey600)
         subTextNode.appendChild(document.createTextNode(subText))
 
         svgSubText.appendChild(subTextNode)

--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -15,10 +15,10 @@ import {
 import { getColorByValueFromLegendSet } from '../../../../modules/legends'
 
 const svgNS = 'http://www.w3.org/2000/svg'
+const defaultFillColor = colors.grey900
 
-const generateValueSVG = (value, formattedValue, legendSet, y) => {
+const generateValueSVG = (value, formattedValue, subText, legendSet, y) => {
     const textSize = 300
-    const defaultFillColor = colors.grey900
 
     const svgValue = document.createElementNS(svgNS, 'svg')
     svgValue.setAttribute('xmlns', svgNS)
@@ -37,17 +37,42 @@ const generateValueSVG = (value, formattedValue, legendSet, y) => {
         ? getColorByValueFromLegendSet(legendSet, value)
         : defaultFillColor
 
-    const text = document.createElementNS(svgNS, 'text')
-    text.setAttribute('text-anchor', 'middle')
-    text.setAttribute('font-size', textSize)
-    text.setAttribute('font-weight', '300')
-    text.setAttribute('letter-spacing', '-5')
-    text.setAttribute('x', '50%')
-    text.setAttribute('fill', fillColor)
-    text.setAttribute('data-test', 'visualization-primary-value')
-    text.appendChild(document.createTextNode(formattedValue))
+    const textNode = document.createElementNS(svgNS, 'text')
+    textNode.setAttribute('text-anchor', 'middle')
+    textNode.setAttribute('font-size', textSize)
+    textNode.setAttribute('font-weight', '300')
+    textNode.setAttribute('letter-spacing', '-5')
+    textNode.setAttribute('x', '50%')
+    textNode.setAttribute('fill', fillColor)
+    textNode.setAttribute('data-test', 'visualization-primary-value')
+    textNode.appendChild(document.createTextNode(formattedValue))
 
-    svgValue.appendChild(text)
+    svgValue.appendChild(textNode)
+
+    if (subText) {
+        const svgSubText = document.createElementNS(svgNS, 'svg')
+        const subTextSize = 30
+        svgSubText.setAttribute(
+            'viewBox',
+            `0 -50 ${textSize * 0.75 * formattedValue.length} ${textSize + 200}`
+        )
+
+        if (y) {
+            svgSubText.setAttribute('y', y)
+        }
+
+        const subTextNode = document.createElementNS(svgNS, 'text')
+        subTextNode.setAttribute('text-anchor', 'middle')
+        subTextNode.setAttribute('font-size', subTextSize)
+        subTextNode.setAttribute('x', '50%')
+        subTextNode.setAttribute('x', '50%')
+        subTextNode.setAttribute('fill', defaultFillColor)
+        subTextNode.appendChild(document.createTextNode(subText))
+
+        svgSubText.appendChild(subTextNode)
+
+        svgValue.appendChild(svgSubText)
+    }
 
     return svgValue
 }
@@ -78,7 +103,12 @@ const generateDashboardItem = (config, legendSet) => {
     }
 
     container.appendChild(
-        generateValueSVG(config.value, config.formattedValue, legendSet)
+        generateValueSVG(
+            config.value,
+            config.formattedValue,
+            config.subText,
+            legendSet
+        )
     )
 
     return container
@@ -210,7 +240,13 @@ const generateDVItem = (config, legendSet, parentEl, fontStyle) => {
     }
 
     svg.appendChild(
-        generateValueSVG(config.value, config.formattedValue, legendSet, 20)
+        generateValueSVG(
+            config.value,
+            config.formattedValue,
+            config.subText,
+            legendSet,
+            20
+        )
     )
 
     return svg


### PR DESCRIPTION
**PUBLISHED v20.1.0-alpha.2 FOR TESTING**

Implements [DHIS2-7420](https://jira.dhis2.org/browse/DHIS2-7420)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/1830**

---

### Key features

1. Add indicator type info in SV visualizations

---

### Description

Show % symbol for indicators with factor 100 and a text for others (ie. "Per thousand")

---

### TODO

-   [ ] tests

---

### Known issues

-   [ ] in dashboard app when resizing the item, the text under the value can become too small. Agreed with @janhenrikoverland to merge what we have and see if it's a problem we need to address later.
-   [x] ~translations don't seem to work for the indicator type text returned in the analytics response~ (This was never an issue. DB language must be set in user settings for this to work.) <img width="725" alt="Screenshot 2021-08-17 at 08 57 12" src="https://user-images.githubusercontent.com/150978/129679335-244c8e70-8f9b-4a30-bafa-8972b7e77151.png">


---

### Screenshots

DV per cent:
<img width="1240" alt="Screenshot 2021-06-22 at 11 51 34" src="https://user-images.githubusercontent.com/150978/122904142-59a8a100-d350-11eb-9e98-2cc9b5dfc91e.png">

DV per thousand:
<img width="1250" alt="Screenshot 2021-06-22 at 11 51 56" src="https://user-images.githubusercontent.com/150978/122904162-5f9e8200-d350-11eb-9cfa-6666b2fbe5b8.png">

DV per hundred thousand:
<img width="1244" alt="Screenshot 2021-06-22 at 11 52 20" src="https://user-images.githubusercontent.com/150978/122904179-64fbcc80-d350-11eb-915c-d7167aaaea86.png">

Dashboard item:
<img width="504" alt="Screenshot 2021-06-17 at 12 00 29" src="https://user-images.githubusercontent.com/150978/122396720-93f0f780-cf78-11eb-92d9-5f199203097b.png">


