### PR TITLE
fix: OpenFileDialog fixes

### DIFF
--- a/src/components/OpenFileDialog/FileList.js
+++ b/src/components/OpenFileDialog/FileList.js
@@ -38,7 +38,7 @@ FileList.propTypes = {
             displayName: PropTypes.string.isRequired,
             id: PropTypes.string.isRequired,
             lastUpdated: PropTypes.string.isRequired,
-            type: PropTypes.string.isRequired,
+            type: PropTypes.string,
         })
     ).isRequired,
     type: PropTypes.string.isRequired,

--- a/src/components/OpenFileDialog/FileList.js
+++ b/src/components/OpenFileDialog/FileList.js
@@ -12,7 +12,7 @@ export const FileList = ({ type, data, onSelect }) => (
                     {visualization.displayName}
                 </DataTableCell>
                 {type === 'visualization' && (
-                    <DataTableCell>
+                    <DataTableCell align="center">
                         <VisTypeIcon
                             type={visualization.type}
                             useSmall

--- a/src/components/OpenFileDialog/OpenFileDialog.js
+++ b/src/components/OpenFileDialog/OpenFileDialog.js
@@ -35,7 +35,7 @@ import { VisTypeFilter, VIS_TYPE_ALL, VIS_TYPE_CHARTS } from './VisTypeFilter'
 const getQuery = type => ({
     resource: AOTypeMap[type].apiEndpoint,
     params: ({
-        sortField = 'name',
+        sortField = 'displayName',
         sortDirection = 'asc',
         page = 1,
         filters,

--- a/src/components/OpenFileDialog/OpenFileDialog.js
+++ b/src/components/OpenFileDialog/OpenFileDialog.js
@@ -33,26 +33,28 @@ import { getTranslatedString, AO_TYPE_VISUALIZATION, AOTypeMap } from './utils'
 import { VisTypeFilter, VIS_TYPE_ALL, VIS_TYPE_CHARTS } from './VisTypeFilter'
 
 const getQuery = type => ({
-    resource: AOTypeMap[type].apiEndpoint,
-    params: ({
-        sortField = 'displayName',
-        sortDirection = 'asc',
-        page = 1,
-        filters,
-    }) => {
-        const queryParams = {
-            filter: filters,
-            fields: `id,type,displayName,title,displayDescription,created,lastUpdated,user,access,href`,
-            paging: true,
-            pageSize: 8,
-            page,
-        }
+    files: {
+        resource: AOTypeMap[type].apiEndpoint,
+        params: ({
+            sortField = 'displayName',
+            sortDirection = 'asc',
+            page = 1,
+            filters,
+        }) => {
+            const queryParams = {
+                filter: filters,
+                fields: `id,type,displayName,title,displayDescription,created,lastUpdated,user,access,href`,
+                paging: true,
+                pageSize: 8,
+                page,
+            }
 
-        if (sortDirection !== 'default') {
-            queryParams.order = `${sortField}:${sortDirection}`
-        }
+            if (sortDirection !== 'default') {
+                queryParams.order = `${sortField}:${sortDirection}`
+            }
 
-        return queryParams
+            return queryParams
+        },
     },
 })
 
@@ -115,10 +117,9 @@ export const OpenFileDialog = ({
         return queryFilters
     }
 
-    const { loading, error, data, refetch } = useDataQuery(
-        { files: filesQuery },
-        { lazy: true }
-    )
+    const { loading, error, data, refetch } = useDataQuery(filesQuery, {
+        lazy: true,
+    })
 
     const resetFilters = () => {
         setFilters(defaultFilters)

--- a/src/components/OpenFileDialog/OpenFileDialog.js
+++ b/src/components/OpenFileDialog/OpenFileDialog.js
@@ -152,14 +152,17 @@ export const OpenFileDialog = ({
         {
             field: 'displayName',
             label: i18n.t('Name'),
+            width: '470px',
         },
         {
             field: 'created',
             label: i18n.t('Created'),
+            width: '110px',
         },
         {
             field: 'lastUpdated',
             label: i18n.t('Last updated'),
+            width: '110px',
         },
     ]
 
@@ -167,6 +170,7 @@ export const OpenFileDialog = ({
         headers.splice(1, 0, {
             field: 'type',
             label: i18n.t('Type'),
+            width: '60px',
         })
     }
 
@@ -247,40 +251,38 @@ export const OpenFileDialog = ({
                         </NoticeBox>
                     ) : (
                         <>
-                            <DataTable>
+                            <DataTable layout="fixed">
                                 <DataTableHead>
                                     <DataTableRow>
                                         {data?.files[
                                             AOTypeMap[type].apiEndpoint
                                         ].length ? (
-                                            headers.map(({ field, label }) => (
-                                                <DataTableColumnHeader
-                                                    fixed
-                                                    top="0"
-                                                    key={field}
-                                                    name={field}
-                                                    onSortIconClick={({
-                                                        name,
-                                                        direction,
-                                                    }) =>
-                                                        setSorting({
-                                                            sortField: name,
-                                                            sortDirection:
-                                                                direction,
-                                                        })
-                                                    }
-                                                    sortDirection={getSortDirection(
-                                                        field
-                                                    )}
-                                                >
-                                                    {label}
-                                                </DataTableColumnHeader>
-                                            ))
+                                            headers.map(
+                                                ({ field, label, width }) => (
+                                                    <DataTableColumnHeader
+                                                        width={width}
+                                                        key={field}
+                                                        name={field}
+                                                        onSortIconClick={({
+                                                            name,
+                                                            direction,
+                                                        }) =>
+                                                            setSorting({
+                                                                sortField: name,
+                                                                sortDirection:
+                                                                    direction,
+                                                            })
+                                                        }
+                                                        sortDirection={getSortDirection(
+                                                            field
+                                                        )}
+                                                    >
+                                                        {label}
+                                                    </DataTableColumnHeader>
+                                                )
+                                            )
                                         ) : (
-                                            <DataTableColumnHeader
-                                                fixed
-                                                top="0"
-                                            />
+                                            <DataTableColumnHeader />
                                         )}
                                     </DataTableRow>
                                 </DataTableHead>

--- a/src/components/OpenFileDialog/VisTypeFilter.js
+++ b/src/components/OpenFileDialog/VisTypeFilter.js
@@ -15,6 +15,7 @@ export const VisTypeFilter = ({ selected, onChange }) => (
         onChange={({ selected }) => onChange(selected)}
         prefix={i18n.t('Type')}
         dense
+        maxHeight="400px"
     >
         {/* TODO figure out if this distinction still make sense since we have SV and potentially other new types in the future which might not fall into the chart/PT categories */}
         <SingleSelectOption label={i18n.t('All types')} value={VIS_TYPE_ALL} />


### PR DESCRIPTION
### Description

Various fixes after the analytics KFMT session.

---

### Known issues

-   [x] 1) "jumping columns" due to different widths when paginating/sorting or using filters
-   [x] 2) height of vis type dropdown should be bigger to use more vertical space and spare some scrolling
          ![Screenshot from 2021-06-29 15-42-17](https://user-images.githubusercontent.com/150978/124111751-e7c80a00-da69-11eb-8ff0-a3c51ddd49fa.png)
-   [x] 3) Loading message "flashing", it seems the message is always rendered even if the response comes back fast
-   [x] 4) all header items say "Sort items" when hovering, it would be better to be more specific
          ![image (4)](https://user-images.githubusercontent.com/150978/124112532-abe17480-da6a-11eb-986a-3053ba9565a2.png)
-   [ ] 5) the cursor on the rows in the table should be a pointer to indicate the row is clickable
-   [ ] 6) icons in vis type Select look too close to the prefix
          ![image (5)](https://user-images.githubusercontent.com/150978/124112648-cae00680-da6a-11eb-823e-bbeb45e0746e.png)
-   [x] 7) Translations not showing up for pagination buttons (interface lang is Spanish):
          ![image (6)](https://user-images.githubusercontent.com/150978/124112910-172b4680-da6b-11eb-9adc-5d3703b850c2.png)
-   [ ] 8) Problems with item count and pagination when adding/deleting visualizations:
          ![Screenshot from 2021-06-29 16-11-08](https://user-images.githubusercontent.com/150978/124121370-19929e00-da75-11eb-914b-9b01c4007c97.png)
          This can cause a crash:
          ![image (7)](https://user-images.githubusercontent.com/150978/124121589-5b234900-da75-11eb-91f2-97225188abc1.png)



### Notes on issues

1 ) Solved using a `fixed` layout on `DataTable` and specific widths on the cells.
This potentially might have some issues in some languages where the labels are much longer, but at least they can wrap on 2 lines without taking more space, see screenshot below.
3 ) Agreed with @janhenrikoverland this is not a problem.
4 ) Agreed with @janhenrikoverland this is not a problem. If `ui` will support a prop for this we can use different tooltips. Currently the label is hardcoded here:
https://github.com/dhis2/ui/blob/master/components/table/src/data-table/data-table-column-header/sorter.js#L31
To fix this we need a change in `ui` to support a new prop for setting a custom label.
Opened a Q/A: https://github.com/dhis2/notes/discussions/299
5 ) Currently it's not possible to pass an `onClick` callback on the table row, only on cells.
The click handler is only defined on the name cell at the moment.
Q/A for adding `onClick` on DataTable row: https://github.com/dhis2/notes/discussions/297
Regarding the cursor icon, I wasn't able to add a custom style for it with `styled-jsx`, I'm not sure why, so it might be possible.
In any case, it seems `ui` should set the cursor to a pointer if an `onClick` is defined: https://github.com/dhis2/notes/discussions/298
7 ) Tested again and it seems to work. ~Perhaps relevant discussion on `#ui`: https://dhis2.slack.com/archives/CBM8LNEQM/p1624494055176800~
8 ) Opened tickets for backend: https://jira.dhis2.org/browse/DHIS2-11504 and https://jira.dhis2.org/browse/DHIS2-11505.
It turned out this is due to caching, so not immediately solvable as that part on the backend is shared among different endpoints (@maikelarabori can explain better).

---

### Screenshots

Extended height for the vis type dropdown (2):
<img width="800" alt="Screenshot 2021-07-01 at 13 47 59" src="https://user-images.githubusercontent.com/150978/124119572-fb2ba300-da72-11eb-9e6d-d41eb857d79c.png">

Fixed layout and cell widths (1):
<img width="799" alt="Screenshot 2021-07-02 at 10 42 17" src="https://user-images.githubusercontent.com/150978/124247830-8dd74b00-db22-11eb-8bd3-40089b1b9124.png">

