### PR TITLE
fix: provide default props for maps being displayed as table [DHIS2-11304] [16.x]

### DIFF
--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -57,6 +57,11 @@ const defaultOptions = {
     showColumnSubtotals: false,
 }
 
+const defaultVisualizationProps = {
+    fontSize: FONT_SIZE_OPTION_NORMAL,
+    displayDensity: DISPLAY_DENSITY_OPTION_NORMAL,
+}
+
 const isDxDimension = dimensionItem =>
     [DIMENSION_TYPE_DATA, DIMENSION_TYPE_DATA_ELEMENT_GROUP_SET].includes(
         dimensionItem.dimensionType
@@ -263,7 +268,11 @@ export class PivotTableEngine {
     columnMap = []
 
     constructor(visualization, data, legendSets) {
-        this.visualization = visualization
+        this.visualization = Object.assign(
+            {},
+            defaultVisualizationProps,
+            visualization
+        )
         this.legendSets = (legendSets || []).reduce((sets, set) => {
             sets[set.id] = set
             return sets


### PR DESCRIPTION
Fixes DHIS2-11304

Backport of https://github.com/dhis2/analytics/pull/947

Key features
Provides default values for fontSize and displayDensity, which are missing from the visualization when it is originally a Map. For instance, in dashboard, a Map can be viewed as a Table. Since those properties were missing, the table had an unexpected font size and display density (see screenshots from https://github.com/dhis2/analytics/pull/947)