### PR TITLE
chore: add README info regarding new 16.x branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ To publish, simply mark the commit using [semantic release terminology](https://
 
 The master branch follows semantic versioning according to spec.
 
+### 16.x branch
+
+Commits to the 16.x branch cannot trigger a major version bump, even if it is technically a breaking change. This is because 17.0.0 has already been published. In the unlikely case that you need to commit a change that is considered breaking, you will have to mark it to only trigger a patch or minor bump, then make sure to update the apps that are locked to the 16.x version of analytics
+
 ### 11.0.x branch
 
 Commits to the 11.0.x branch cannot trigger a major or minor version bump, even if it is technically a breaking or feature change. This is because 11.1.0 and 12.0.0 have already been published. In the unlikely case that you need to commit a change that is considered breaking or feature, you will have to mark it to only trigger a patch bump, then make sure to update the apps that are locked to the 11.0.x version of analytics


### PR DESCRIPTION
A 16.x branch has been created to support backporting fixes to previous versions of apps (Including Dashboards v36 and DV v36).
