### PR TITLE
fix: typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ master: ![DHIS2: Test](https://github.com/dhis2/analytics/workflows/DHIS2:%20Tes
 
 ## Overview
 
-The analytics library contains components and modules that are used in DHIS 2 analytics apps, including:
+The analytics library contains components and modules that are used in DHIS2 analytics apps, including:
 
 -   [dhis2/dashboards-app](https://github.com/dhis2/dashboards-app)
 -   [dhis2/data-visualizer-app](https://github.com/dhis2/data-visualizer-app)


### PR DESCRIPTION
Because the previous [commit](https://github.com/dhis2/analytics/commit/96c4446fdb475b819d1a3d158aea110343fe47c4) was missing the `fix:` prefix