### PR TITLE
feat: legend key (DHIS2-11239) (#951)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-06-10T07:19:35.004Z\n"
-"PO-Revision-Date: 2021-06-10T07:19:35.004Z\n"
+"POT-Creation-Date: 2021-06-16T13:08:18.884Z\n"
+"PO-Revision-Date: 2021-06-16T13:08:18.884Z\n"
 
 msgid "Data Type"
 msgstr "Data Type"
@@ -178,15 +178,6 @@ msgstr "Rename"
 
 msgid "Save {{fileType}} as"
 msgstr "Save {{fileType}} as"
-
-msgid "Selected Data"
-msgstr "Selected Data"
-
-msgid "Deselect All"
-msgstr "Deselect All"
-
-msgid "Select all"
-msgstr "Select all"
 
 msgid "Created by"
 msgstr "Created by"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "devDependencies": {
         "@dhis2/app-runtime": "^2.8.0",
         "@dhis2/cli-app-scripts": "^6.2.0",
-        "@dhis2/cli-style": "^8.4.1",
+        "@dhis2/cli-style": "^9.0.1",
         "@dhis2/d2-i18n": "^1.1.0",
         "@dhis2/ui": "^6.9.0",
         "@sambego/storybook-state": "^2.0.1",

--- a/src/components/LegendKey/LegendKey.js
+++ b/src/components/LegendKey/LegendKey.js
@@ -1,0 +1,56 @@
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import React from 'react'
+import styles from './styles/LegendKey.style'
+
+const LegendKey = ({ legendSets }) => {
+    return legendSets.length ? (
+        <div className="container">
+            {legendSets.map((legendSet, index) => (
+                <div
+                    key={legendSet.id}
+                    className={cx('legendSet', {
+                        divider: index > 0,
+                    })}
+                >
+                    {legendSets.length > 1 && (
+                        <span className="legendSetName">{legendSet.name}</span>
+                    )}
+                    {legendSet.legends
+                        .sort((a, b) => a.startValue - b.startValue)
+                        .map(legend => (
+                            <div
+                                key={legend.startValue}
+                                className="legend"
+                                style={{
+                                    borderLeft: `6px ${legend.color} solid`,
+                                }}
+                            >
+                                <span>{legend.name}</span>
+                                <span className="values">{`${legend.startValue}-<${legend.endValue}`}</span>
+                            </div>
+                        ))}
+                </div>
+            ))}
+            <style jsx>{styles}</style>
+        </div>
+    ) : null
+}
+
+LegendKey.propTypes = {
+    legendSets: PropTypes.arrayOf(
+        PropTypes.shape({
+            id: PropTypes.string.isRequired,
+            legends: PropTypes.arrayOf(
+                PropTypes.shape({
+                    color: PropTypes.string.isRequired,
+                    endValue: PropTypes.number.isRequired,
+                    name: PropTypes.string.isRequired,
+                    startValue: PropTypes.number.isRequired,
+                })
+            ).isRequired,
+        })
+    ).isRequired,
+}
+
+export default LegendKey

--- a/src/components/LegendKey/styles/LegendKey.style.js
+++ b/src/components/LegendKey/styles/LegendKey.style.js
@@ -1,0 +1,41 @@
+import { spacers, colors } from '@dhis2/ui'
+import css from 'styled-jsx/css'
+
+export default css`
+    .container {
+        width: 180px;
+        background: ${colors.white};
+        padding: ${spacers.dp8};
+        border: 1px solid ${colors.grey400};
+    }
+    .legendSet {
+        display: flex;
+        flex-direction: column;
+        margin-left: ${spacers.dp4};
+    }
+    .legendSetName {
+        display: inline-block;
+        font-size: 13px;
+        color: ${colors.grey700};
+        margin-bottom: 2px;
+    }
+    .legend {
+        display: flex;
+        flex-direction: column;
+        flex-wrap: wrap;
+        padding: ${spacers.dp4} 0 ${spacers.dp4} 6px;
+        white-space: break-spaces;
+        text-align: left;
+        font-size: 13px;
+    }
+    .values {
+        color: ${colors.grey600};
+        font-size: 12px;
+        padding-top: 2px;
+    }
+    .divider {
+        border-top: 1px solid ${colors.grey400};
+        padding-top: ${spacers.dp8};
+        margin-top: ${spacers.dp8};
+    }
+`

--- a/src/components/PivotTable/PivotTableValueCell.js
+++ b/src/components/PivotTable/PivotTableValueCell.js
@@ -72,6 +72,7 @@ export const PivotTableValueCell = ({
             style={style}
             onClick={isClickable ? onClick : undefined}
             ref={cellRef}
+            dataTest={'visualization-value-cell'}
         >
             {cellContent.renderedValue ?? null}
         </PivotTableCell>

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,8 @@ export { default as FileMenu } from './components/FileMenu/FileMenu'
 
 export { default as VisTypeIcon } from './components/VisTypeIcon'
 
+export { default as LegendKey } from './components/LegendKey/LegendKey'
+
 // Api
 
 export { default as Analytics } from './api/analytics/Analytics'
@@ -217,6 +219,15 @@ export {
     getTextAlignOptions,
     deleteFontStyleOption,
 } from './modules/fontStyle'
+
+// Modules: legend
+
+export {
+    LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM,
+    LEGEND_DISPLAY_STRATEGY_FIXED,
+    LEGEND_DISPLAY_STYLE_FILL,
+    LEGEND_DISPLAY_STYLE_TEXT,
+} from './modules/legends'
 
 // Utils: colorSets
 export {

--- a/src/modules/pivotTable/applyLegendSet.js
+++ b/src/modules/pivotTable/applyLegendSet.js
@@ -10,7 +10,7 @@ import { isColorBright } from './isColorBright'
 
 const getLegendSet = (engine, dxDimension) => {
     let legendSetId
-    switch (engine.visualization.legendDisplayStrategy) {
+    switch (engine.visualization.legend?.strategy) {
         case LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM:
             if (dxDimension && dxDimension.legendSet) {
                 legendSetId = dxDimension.legendSet
@@ -18,9 +18,7 @@ const getLegendSet = (engine, dxDimension) => {
             break
         case LEGEND_DISPLAY_STRATEGY_FIXED:
         default:
-            legendSetId = engine.visualization.legendSet
-                ? engine.visualization.legendSet.id
-                : undefined
+            legendSetId = engine.visualization.legend?.set?.id
             break
     }
 
@@ -29,7 +27,7 @@ const getLegendSet = (engine, dxDimension) => {
 
 const buildStyleObject = (legendColor, engine) => {
     const style = {}
-    switch (engine.visualization.legendDisplayStyle) {
+    switch (engine.visualization.legend?.style) {
         case LEGEND_DISPLAY_STYLE_TEXT:
             style.color = legendColor
             break

--- a/src/visualizations/config/adapters/dhis_highcharts/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/index.js
@@ -43,6 +43,7 @@ export default function ({ store, layout, el, extraConfig, extraOptions }) {
     const _layout = getTransformedLayout(layout)
     const _extraOptions = getTransformedExtraOptions(extraOptions)
     const stacked = isStacked(_layout.type)
+    const legendSets = extraOptions.legendSets
 
     const series = store.generateData({
         type: _layout.type,
@@ -107,12 +108,15 @@ export default function ({ store, layout, el, extraConfig, extraOptions }) {
         ),
 
         // legend
-        legend: getLegend(
-            _layout.legend?.hidden,
-            _layout.legend?.label?.fontStyle,
-            _layout.type,
-            _extraOptions.dashboard
-        ),
+        legend: getLegend({
+            isHidden: _layout.seriesKey?.hidden,
+            fontStyle: _layout.seriesKey?.label?.fontStyle,
+            visType: _layout.type,
+            dashboard: _extraOptions.dashboard,
+            legendSets,
+            metaData: store.data[0].metaData.items,
+            displayStrategy: _layout.legend?.strategy,
+        }),
 
         // pane
         pane: getPane(_layout.type),
@@ -184,13 +188,9 @@ export default function ({ store, layout, el, extraConfig, extraOptions }) {
      ** Note: This needs to go last, after all other data manipulation is done, as it changes
      ** the format of the data prop from an array of values to an array of objects with y and color props.
      */
-    const legendSets = extraOptions.legendSets
 
     if (legendSets?.length && isLegendSetType(layout.type)) {
-        if (
-            _layout.legendDisplayStrategy ===
-            LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM
-        ) {
+        if (_layout.legend?.strategy === LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM) {
             config.series = config.series.map(seriesObj => {
                 const legendSet = legendSets.find(
                     legendSet =>
@@ -201,9 +201,7 @@ export default function ({ store, layout, el, extraConfig, extraOptions }) {
                     ? applyLegendSet(seriesObj, legendSet)
                     : seriesObj
             })
-        } else if (
-            _layout.legendDisplayStrategy === LEGEND_DISPLAY_STRATEGY_FIXED
-        ) {
+        } else if (_layout.legend?.strategy === LEGEND_DISPLAY_STRATEGY_FIXED) {
             config.series = config.series.map(seriesObj =>
                 applyLegendSet(seriesObj, legendSets[0])
             )

--- a/src/visualizations/config/adapters/dhis_highcharts/series/gauge.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/gauge.js
@@ -19,8 +19,8 @@ export default function (series, layout, legendSet) {
                 style: {
                     fontSize: DEFAULT_FONT_SIZE,
                     color:
-                        layout.legendDisplayStyle ===
-                            LEGEND_DISPLAY_STYLE_TEXT && legendSet
+                        layout.legend?.style === LEGEND_DISPLAY_STYLE_TEXT &&
+                        legendSet
                             ? getColorByValueFromLegendSet(
                                   legendSet,
                                   series[0].data

--- a/src/visualizations/config/adapters/dhis_highcharts/series/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/index.js
@@ -176,15 +176,14 @@ function getDefault(series, metaData, layout, isStacked, extraOptions) {
         if (isLegendSetType(layout.type)) {
             const legendSets = extraOptions?.legendSets || []
             if (
-                layout.legendDisplayStrategy ===
-                LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM
+                layout.legend?.strategy === LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM
             ) {
                 legendSet = legendSets.find(
                     legendSet =>
                         legendSet.id === metaData.items[seriesObj.id]?.legendSet
                 )
             } else if (
-                layout.legendDisplayStrategy === LEGEND_DISPLAY_STRATEGY_FIXED
+                layout.legend?.strategy === LEGEND_DISPLAY_STRATEGY_FIXED
             ) {
                 legendSet = legendSets[0]
             }

--- a/src/visualizations/config/adapters/dhis_highcharts/yAxis/gauge.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/yAxis/gauge.js
@@ -114,7 +114,7 @@ export default function (layout, series, legendSet) {
         getPlotLine(axis.targetLine, DEFAULT_TARGET_LINE_LABEL),
     ])
     const fillColor =
-        layout.legendDisplayStyle === LEGEND_DISPLAY_STYLE_FILL && legendSet
+        layout.legend?.style === LEGEND_DISPLAY_STYLE_FILL && legendSet
             ? getColorByValueFromLegendSet(legendSet, series[0].data)
             : undefined
     return objectClean({

--- a/yarn.lock
+++ b/yarn.lock
@@ -1448,7 +1448,7 @@
     parse-gitignore "^1.0.1"
     styled-jsx "<3.3.3"
 
-"@dhis2/cli-helpers-engine@^2.1.1", "@dhis2/cli-helpers-engine@^2.4.0":
+"@dhis2/cli-helpers-engine@^2.1.1":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@dhis2/cli-helpers-engine/-/cli-helpers-engine-2.4.0.tgz#1609d358088f0616fb400aa9f90fc8bb57d4b196"
   integrity sha512-SRcN3s/sQTkd5VUbWAs2+UeYtJ0zLdj4F/RkrL8x2/RX/79vIxvryqBom4FFw/meY0c2GDpXgrpKNQcST/OHBQ==
@@ -1463,14 +1463,29 @@
     update-notifier "^3.0.0"
     yargs "^13.1.0"
 
-"@dhis2/cli-style@^8.4.1":
-  version "8.4.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/cli-style/-/cli-style-8.4.1.tgz#6246df4e2b5879af92239c3c15e9f54129799a84"
-  integrity sha512-4jNRCh/WO5jhzeGkDJ9+2Dx16muy67xTNuniQdJdb7eq7Dm9DN8X9h1QlKxEQuyc4O8jJ08Sk1j3YDL1ApS+ZA==
+"@dhis2/cli-helpers-engine@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/cli-helpers-engine/-/cli-helpers-engine-3.0.0.tgz#dacddea16de7e5e60280aefbee2e5661795b78b3"
+  integrity sha512-e8cZFFsunQp56iLx1FKBWGZ1tmWOjdbqJaBwOnzvsKPyYopV9RzNcPm+HIBwfnCjHBWoWTf6ijaf3xVnimZC2w==
+  dependencies:
+    chalk "^3.0.0"
+    cross-spawn "^7.0.3"
+    find-up "^5.0.0"
+    fs-extra "^8.0.1"
+    inquirer "^7.3.3"
+    request "^2.88.0"
+    tar "^4.4.8"
+    update-notifier "^3.0.0"
+    yargs "^13.1.0"
+
+"@dhis2/cli-style@^9.0.1":
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/@dhis2/cli-style/-/cli-style-9.0.1.tgz#919bb978362ed9aeb7a253a3b58d6f25e3c09bd9"
+  integrity sha512-CGZQebdhh3EtpjyQGeQEbwVE0vmSqzz8TWrVEkuo9bVxBu7Gjpok5mnsFE0wXLP0kqga9zBuwfeIbY8iAoO1kA==
   dependencies:
     "@commitlint/cli" "^11.0.0"
     "@commitlint/config-conventional" "^11.0.0"
-    "@dhis2/cli-helpers-engine" "^2.4.0"
+    "@dhis2/cli-helpers-engine" "^3.0.0"
     "@ls-lint/ls-lint" "^1.9.2"
     babel-eslint "^10.1.0"
     eslint "^7.18.0"


### PR DESCRIPTION
redeploys https://github.com/dhis2/analytics/pull/951 as a major bump instead of a minor as it was originally deployed as. see that PR for full info.

new LegendKey component
export LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM, LEGEND_DISPLAY_STRATEGY_FIXED, LEGEND_DISPLAY_STYLE_FILL, LEGEND_DISPLAY_STYLE_TEXT
adapt code to the new backend format for legend and series key

BREAKING CHANGE: layout.legend replaced by layout.seriesKey. legendSet, legendDisplayStyle, legendDisplayStrategy replaced by the consolidated legend prop
