### PR TITLE
fix: provide default props for maps being displayed as table [DHIS2-11304] [16.x]

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ To publish, simply mark the commit using [semantic release terminology](https://
 
 The master branch follows semantic versioning according to spec.
 
+### 16.x branch
+
+Commits to the 16.x branch cannot trigger a major version bump, even if it is technically a breaking change. This is because 17.0.0 has already been published. In the unlikely case that you need to commit a change that is considered breaking, you will have to mark it to only trigger a patch or minor bump, then make sure to update the apps that are locked to the 16.x version of analytics
+
 ### 11.0.x branch
 
 Commits to the 11.0.x branch cannot trigger a major or minor version bump, even if it is technically a breaking or feature change. This is because 11.1.0 and 12.0.0 have already been published. In the unlikely case that you need to commit a change that is considered breaking or feature, you will have to mark it to only trigger a patch bump, then make sure to update the apps that are locked to the 11.0.x version of analytics

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -57,6 +57,11 @@ const defaultOptions = {
     showColumnSubtotals: false,
 }
 
+const defaultVisualizationProps = {
+    fontSize: FONT_SIZE_OPTION_NORMAL,
+    displayDensity: DISPLAY_DENSITY_OPTION_NORMAL,
+}
+
 const isDxDimension = dimensionItem =>
     [DIMENSION_TYPE_DATA, DIMENSION_TYPE_DATA_ELEMENT_GROUP_SET].includes(
         dimensionItem.dimensionType
@@ -263,7 +268,11 @@ export class PivotTableEngine {
     columnMap = []
 
     constructor(visualization, data, legendSets) {
-        this.visualization = visualization
+        this.visualization = Object.assign(
+            {},
+            defaultVisualizationProps,
+            visualization
+        )
         this.legendSets = (legendSets || []).reduce((sets, set) => {
             sets[set.id] = set
             return sets


### PR DESCRIPTION
Fixes DHIS2-11304

Backport of #947

Key features
Provides default values for fontSize and displayDensity, which are missing from the visualization when it is originally a Map. For instance, in dashboard, a Map can be viewed as a Table. Since those properties were missing, the table had an unexpected font size and display density (see screenshots from #947)