### PR TITLE
fix: legend options bleed (DHIS2-11239)

### DIFF
--- a/src/modules/visTypes.js
+++ b/src/modules/visTypes.js
@@ -167,7 +167,13 @@ const columnBasedTypes = [
 
 const verticalTypes = [VIS_TYPE_BAR, VIS_TYPE_STACKED_BAR, VIS_TYPE_GAUGE]
 
-const legendSetTypes = [VIS_TYPE_COLUMN, VIS_TYPE_BAR]
+const legendSetTypes = [
+    VIS_TYPE_COLUMN,
+    VIS_TYPE_BAR,
+    VIS_TYPE_GAUGE,
+    VIS_TYPE_SINGLE_VALUE,
+    VIS_TYPE_PIVOT_TABLE,
+]
 
 export const defaultVisType = VIS_TYPE_COLUMN
 export const isStacked = type => stackedTypes.includes(type)

--- a/src/visualizations/config/adapters/dhis_highcharts/legend.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/legend.js
@@ -11,7 +11,11 @@ import {
     LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM,
     LEGEND_DISPLAY_STRATEGY_FIXED,
 } from '../../../../modules/legends'
-import { isVerticalType, VIS_TYPE_SCATTER } from '../../../../modules/visTypes'
+import {
+    isLegendSetType,
+    isVerticalType,
+    VIS_TYPE_SCATTER,
+} from '../../../../modules/visTypes'
 import { getTextAlignOption } from './getTextAlignOption'
 
 const DASHBOARD_ITEM_STYLE = {
@@ -91,6 +95,7 @@ const formatLabel = ({
     fontStyle,
     seriesColor,
     seriesName,
+    visType,
 }) => {
     const legendSet = getLegendSetByDisplayStrategy({
         displayStrategy,
@@ -102,7 +107,7 @@ const formatLabel = ({
     result.push(
         '<div style="display: flex; align-items: center; margin-bottom: 4px;" class="data-test-series-key-item">'
     )
-    if (legendSet?.legends?.length) {
+    if (legendSet?.legends?.length && isLegendSetType(visType)) {
         legendSet.legends.forEach((legend, index) =>
             result.push(
                 `<span style="${getBulletStyleByFontStyle(
@@ -165,6 +170,7 @@ export default function ({
                           displayStrategy,
                           legendSets,
                           fontStyle: mergedFontStyle,
+                          visType,
                       })
                   },
               }


### PR DESCRIPTION
Implements [DHIS2-11239](https://jira.dhis2.org/browse/DHIS2-11239)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/1785**

---

### Key features

1. add all legend supporting types to `isLegendSetType`
2. check vis type before formatting the series key

---

### Description

Legend set options were bleeding in to non-supported vis types, as only the existence of a legend set in itself was the criteria to apply legend specific options. Since the user can apply the legend for a supported type and switch to a non-supported type, the current vistype needs to be verified before applying the options.
