### PR TITLE
feat: fixed headers in PT (DHIS2-11057)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/analytics",
-    "version": "20.1.0-alpha.3",
+    "version": "20.1.0-alpha.4",
     "main": "./build/cjs/index.js",
     "module": "./build/es/index.js",
     "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/analytics",
-    "version": "20.1.0-alpha.1",
+    "version": "20.1.0-alpha.3",
     "main": "./build/cjs/index.js",
     "module": "./build/es/index.js",
     "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/analytics",
-    "version": "20.2.2",
+    "version": "20.1.0-alpha.1",
     "main": "./build/cjs/index.js",
     "module": "./build/es/index.js",
     "exports": {

--- a/src/__demo__/PivotTable.stories.js
+++ b/src/__demo__/PivotTable.stories.js
@@ -404,6 +404,25 @@ storiesOf('PivotTable', module).add('deep', (_, { pivotTableOptions }) => {
 })
 
 storiesOf('PivotTable', module).add(
+    'deep - title / subtitle / filter',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...deepVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            showDimensionLabels: false,
+            title: 'This is a Table',
+            subtitle: "It's a rather big table",
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable data={deepData} visualization={visualization} />
+            </div>
+        )
+    }
+)
+
+storiesOf('PivotTable', module).add(
     'deep - dimension labels',
     (_, { pivotTableOptions }) => {
         const visualization = {

--- a/src/__demo__/PivotTable.stories.js
+++ b/src/__demo__/PivotTable.stories.js
@@ -13,6 +13,8 @@ import avgMetadataResponse from './data/avgTotalAggregationType.metadata.json'
 import avgVisualization from './data/avgTotalAggregationType.visualization.json'
 import deepData from './data/deep.data.json'
 import deepVisualization from './data/deep.visualization.json'
+import deepWithFiltersData from './data/deepWithFilters.data.json'
+import deepWithFiltersVisualization from './data/deepWithFilters.visualization.json'
 import degsDataResponse from './data/degs.data.json'
 import degsMetadataResponse from './data/degs.metadata.json'
 import degsVisualization from './data/degs.visualization.json'
@@ -402,6 +404,26 @@ storiesOf('PivotTable', module).add('deep', (_, { pivotTableOptions }) => {
         </div>
     )
 })
+
+storiesOf('PivotTable', module).add(
+    'deep - filter',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...deepWithFiltersVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            showDimensionLabels: false,
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable
+                    data={deepWithFiltersData}
+                    visualization={visualization}
+                />
+            </div>
+        )
+    }
+)
 
 storiesOf('PivotTable', module).add(
     'deep - title / subtitle / filter',

--- a/src/__demo__/PivotTable.stories.js
+++ b/src/__demo__/PivotTable.stories.js
@@ -99,8 +99,8 @@ const weeklyColumnsData = combineDataWithMetadata(
 
 const PivotTableOptionsWrapper = story => {
     const [pivotTableOptions, setPivotTableOptions] = useState({
-        fixedColumnHeaders: false,
-        fixedRowHeaders: false,
+        fixColumnHeaders: false,
+        fixRowHeaders: false,
     })
 
     return (
@@ -108,22 +108,22 @@ const PivotTableOptionsWrapper = story => {
             <div>
                 <Checkbox
                     label="Use fixed column headers"
-                    checked={pivotTableOptions.fixedColumnHeaders}
+                    checked={pivotTableOptions.fixColumnHeaders}
                     onChange={({ checked }) =>
                         setPivotTableOptions({
                             ...pivotTableOptions,
-                            fixedColumnHeaders: checked,
+                            fixColumnHeaders: checked,
                         })
                     }
                     dense
                 />
                 <Checkbox
                     label="Use fixed row headers"
-                    checked={pivotTableOptions.fixedRowHeaders}
+                    checked={pivotTableOptions.fixRowHeaders}
                     onChange={({ checked }) =>
                         setPivotTableOptions({
                             ...pivotTableOptions,
-                            fixedRowHeaders: checked,
+                            fixRowHeaders: checked,
                         })
                     }
                     dense

--- a/src/__demo__/PivotTable.stories.js
+++ b/src/__demo__/PivotTable.stories.js
@@ -1,3 +1,4 @@
+import { Checkbox, Divider } from '@dhis2/ui'
 import { storiesOf } from '@storybook/react'
 import cloneDeep from 'lodash/cloneDeep'
 import PropTypes from 'prop-types'
@@ -94,37 +95,83 @@ const weeklyColumnsData = combineDataWithMetadata(
     weeklyColumnsMetadataResponse
 )
 
-storiesOf('PivotTable', module).add('simple', () => {
-    const visualization = {
-        ...simpleVisualization,
-        ...visualizationReset,
-    }
+const PivotTableOptionsWrapper = story => {
+    const [pivotTableOptions, setPivotTableOptions] = useState({
+        fixedColumnHeaders: false,
+        fixedRowHeaders: false,
+    })
+
     return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={simpleData} visualization={visualization} />
+        <div>
+            <div>
+                <Checkbox
+                    label="Use fixed column headers"
+                    checked={pivotTableOptions.fixedColumnHeaders}
+                    onChange={({ checked }) =>
+                        setPivotTableOptions({
+                            ...pivotTableOptions,
+                            fixedColumnHeaders: checked,
+                        })
+                    }
+                    dense
+                />
+                <Checkbox
+                    label="Use fixed row headers"
+                    checked={pivotTableOptions.fixedRowHeaders}
+                    onChange={({ checked }) =>
+                        setPivotTableOptions({
+                            ...pivotTableOptions,
+                            fixedRowHeaders: checked,
+                        })
+                    }
+                    dense
+                />
+                <Divider />
+            </div>
+            {story({ pivotTableOptions })}
         </div>
     )
-})
+}
 
-storiesOf('PivotTable', module).add('simple - comma DGS', () => {
-    const visualization = {
-        ...simpleVisualization,
-        ...visualizationReset,
-        digitGroupSeparator: 'COMMA',
-    }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={simpleData} visualization={visualization} />
-        </div>
-    )
-})
-
-storiesOf('PivotTable', module).add(
-    'simple - title / subtitle / filter',
-    () => {
+storiesOf('PivotTable', module)
+    .addDecorator(PivotTableOptionsWrapper)
+    .add('simple', (_, { pivotTableOptions }) => {
         const visualization = {
             ...simpleVisualization,
             ...visualizationReset,
+            ...pivotTableOptions,
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable data={simpleData} visualization={visualization} />
+            </div>
+        )
+    })
+
+storiesOf('PivotTable', module).add(
+    'simple - comma DGS',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...simpleVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            digitGroupSeparator: 'COMMA',
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable data={simpleData} visualization={visualization} />
+            </div>
+        )
+    }
+)
+
+storiesOf('PivotTable', module).add(
+    'simple - title / subtitle / filter',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...simpleVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
             title: 'This is a Table',
             subtitle: "It's not a very big table",
         }
@@ -136,148 +183,181 @@ storiesOf('PivotTable', module).add(
     }
 )
 
-storiesOf('PivotTable', module).add('simple - column %', () => {
-    const visualization = {
-        ...simpleVisualization,
-        ...visualizationReset,
-        colTotals: true,
-        numberType: NUMBER_TYPE_COLUMN_PERCENTAGE,
+storiesOf('PivotTable', module).add(
+    'simple - column %',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...simpleVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            colTotals: true,
+            numberType: NUMBER_TYPE_COLUMN_PERCENTAGE,
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable data={simpleData} visualization={visualization} />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={simpleData} visualization={visualization} />
-        </div>
-    )
-})
+)
 
-storiesOf('PivotTable', module).add('simple - data as filter', () => {
-    const visualization = {
-        ...simpleVisualization,
-        ...visualizationReset,
-        columns: simpleVisualization.filters,
-        filters: simpleVisualization.columns,
+storiesOf('PivotTable', module).add(
+    'simple - data as filter',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...simpleVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            columns: simpleVisualization.filters,
+            filters: simpleVisualization.columns,
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable data={simpleData} visualization={visualization} />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={simpleData} visualization={visualization} />
-        </div>
-    )
-})
+)
 
-storiesOf('PivotTable', module).add('simple - no columns', () => {
-    const visualization = {
-        ...simpleVisualization,
-        ...visualizationReset,
-        colTotals: true,
-        colSubTotals: true,
-        rowTotals: true,
-        rowSubTotals: true,
-        columns: [],
-        filters: simpleVisualization.columns,
+storiesOf('PivotTable', module).add(
+    'simple - no columns',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...simpleVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            colTotals: true,
+            colSubTotals: true,
+            rowTotals: true,
+            rowSubTotals: true,
+            columns: [],
+            filters: simpleVisualization.columns,
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable data={simpleData} visualization={visualization} />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={simpleData} visualization={visualization} />
-        </div>
-    )
-})
+)
 
-storiesOf('PivotTable', module).add('simple - no columns (single cell)', () => {
-    const visualization = {
-        ...simpleVisualization,
-        ...visualizationReset,
-        title: 'Singular cell',
-        columns: [],
-        rows: simpleVisualization.columns,
-        filters: [],
+storiesOf('PivotTable', module).add(
+    'simple - no columns (single cell)',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...simpleVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            title: 'Singular cell',
+            columns: [],
+            rows: simpleVisualization.columns,
+            filters: [],
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable data={simpleData} visualization={visualization} />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={simpleData} visualization={visualization} />
-        </div>
-    )
-})
+)
 
-storiesOf('PivotTable', module).add('simple - no columns (deep)', () => {
-    const visualization = {
-        ...simpleVisualization,
-        ...visualizationReset,
-        showDimensionLabels: true,
-        title: 'Deep row headers',
-        columns: [],
-        rows: [simpleVisualization.columns[0], simpleVisualization.rows[0]],
-        filters: [],
+storiesOf('PivotTable', module).add(
+    'simple - no columns (deep)',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...simpleVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            showDimensionLabels: true,
+            title: 'Deep row headers',
+            columns: [],
+            rows: [simpleVisualization.columns[0], simpleVisualization.rows[0]],
+            filters: [],
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable data={simpleData} visualization={visualization} />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={simpleData} visualization={visualization} />
-        </div>
-    )
-})
+)
 
-storiesOf('PivotTable', module).add('simple - no columns (label)', () => {
-    const visualization = {
-        ...simpleVisualization,
-        ...visualizationReset,
-        showDimensionLabels: true,
-        colTotals: true,
-        colSubTotals: true,
-        rowTotals: true,
-        rowSubTotals: true,
-        columns: [],
-        filters: simpleVisualization.columns,
+storiesOf('PivotTable', module).add(
+    'simple - no columns (label)',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...simpleVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            showDimensionLabels: true,
+            colTotals: true,
+            colSubTotals: true,
+            rowTotals: true,
+            rowSubTotals: true,
+            columns: [],
+            filters: simpleVisualization.columns,
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable data={simpleData} visualization={visualization} />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={simpleData} visualization={visualization} />
-        </div>
-    )
-})
+)
 
-storiesOf('PivotTable', module).add('simple - no rows (small)', () => {
-    const visualization = {
-        ...simpleVisualization,
-        ...visualizationReset,
-        showDimensionLabels: true,
-        colTotals: true,
-        colSubTotals: true,
-        rowTotals: true,
-        rowSubTotals: true,
-        rows: [],
-        filters: simpleVisualization.rows,
+storiesOf('PivotTable', module).add(
+    'simple - no rows (small)',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...simpleVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            showDimensionLabels: true,
+            colTotals: true,
+            colSubTotals: true,
+            rowTotals: true,
+            rowSubTotals: true,
+            rows: [],
+            filters: simpleVisualization.rows,
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable data={simpleData} visualization={visualization} />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={simpleData} visualization={visualization} />
-        </div>
-    )
-})
+)
 
-storiesOf('PivotTable', module).add('simple - no rows (large)', () => {
-    const visualization = {
-        ...simpleVisualization,
-        ...visualizationReset,
-        colTotals: true,
-        colSubTotals: true,
-        rowTotals: true,
-        rowSubTotals: true,
-        rows: [],
-        columns: simpleVisualization.rows,
-        filters: simpleVisualization.columns,
+storiesOf('PivotTable', module).add(
+    'simple - no rows (large)',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...simpleVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            colTotals: true,
+            colSubTotals: true,
+            rowTotals: true,
+            rowSubTotals: true,
+            rows: [],
+            columns: simpleVisualization.rows,
+            filters: simpleVisualization.columns,
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable data={simpleData} visualization={visualization} />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={simpleData} visualization={visualization} />
-        </div>
-    )
-})
+)
 
 storiesOf('PivotTable', module).add(
     'simple - avg totalAggregationType columns',
-    () => {
+    (_, { pivotTableOptions }) => {
         const visualization = {
             ...avgVisualization,
             ...visualizationReset,
+            ...pivotTableOptions,
             colTotals: true,
             hideEmptyRows: true,
         }
@@ -291,10 +371,11 @@ storiesOf('PivotTable', module).add(
 
 storiesOf('PivotTable', module).add(
     'simple - avg totalAggregationType rows',
-    () => {
+    (_, { pivotTableOptions }) => {
         const visualization = {
             ...avgVisualization,
             ...visualizationReset,
+            ...pivotTableOptions,
             columns: avgVisualization.rows,
             rows: avgVisualization.columns,
             rowTotals: true,
@@ -308,10 +389,11 @@ storiesOf('PivotTable', module).add(
     }
 )
 
-storiesOf('PivotTable', module).add('deep', () => {
+storiesOf('PivotTable', module).add('deep', (_, { pivotTableOptions }) => {
     const visualization = {
         ...deepVisualization,
         ...visualizationReset,
+        ...pivotTableOptions,
         showDimensionLabels: false,
     }
     return (
@@ -321,79 +403,99 @@ storiesOf('PivotTable', module).add('deep', () => {
     )
 })
 
-storiesOf('PivotTable', module).add('deep - dimension labels', () => {
-    const visualization = {
-        ...deepVisualization,
-        ...visualizationReset,
+storiesOf('PivotTable', module).add(
+    'deep - dimension labels',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...deepVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable data={deepData} visualization={visualization} />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={deepData} visualization={visualization} />
-        </div>
-    )
-})
+)
 
-storiesOf('PivotTable', module).add('deep - small / compact', () => {
-    const visualization = {
-        ...deepVisualization,
-        ...visualizationReset,
-        displayDensity: 'COMPACT',
-        fontSize: 'SMALL',
+storiesOf('PivotTable', module).add(
+    'deep - small / compact',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...deepVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            displayDensity: 'COMPACT',
+            fontSize: 'SMALL',
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable data={deepData} visualization={visualization} />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={deepData} visualization={visualization} />
-        </div>
-    )
-})
+)
 
-storiesOf('PivotTable', module).add('deep - large / comfortable', () => {
-    const visualization = {
-        ...deepVisualization,
-        ...visualizationReset,
-        displayDensity: 'COMFORTABLE',
-        fontSize: 'LARGE',
+storiesOf('PivotTable', module).add(
+    'deep - large / comfortable',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...deepVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            displayDensity: 'COMFORTABLE',
+            fontSize: 'LARGE',
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable data={deepData} visualization={visualization} />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={deepData} visualization={visualization} />
-        </div>
-    )
-})
+)
 
-storiesOf('PivotTable', module).add('deep - row %', () => {
-    const visualization = {
-        ...deepVisualization,
-        ...visualizationReset,
-        numberType: NUMBER_TYPE_ROW_PERCENTAGE,
-        colSubTotals: true,
-        rowSubTotals: true,
-        rowTotals: true,
-        colTotals: true,
+storiesOf('PivotTable', module).add(
+    'deep - row %',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...deepVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            numberType: NUMBER_TYPE_ROW_PERCENTAGE,
+            colSubTotals: true,
+            rowSubTotals: true,
+            rowTotals: true,
+            colTotals: true,
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable data={deepData} visualization={visualization} />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={deepData} visualization={visualization} />
-        </div>
-    )
-})
+)
 
-storiesOf('PivotTable', module).add('deep - column %', () => {
-    const visualization = {
-        ...deepVisualization,
-        ...visualizationReset,
-        numberType: NUMBER_TYPE_COLUMN_PERCENTAGE,
-        colSubTotals: true,
-        rowSubTotals: true,
-        rowTotals: true,
-        colTotals: true,
+storiesOf('PivotTable', module).add(
+    'deep - column %',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...deepVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            numberType: NUMBER_TYPE_COLUMN_PERCENTAGE,
+            colSubTotals: true,
+            rowSubTotals: true,
+            rowTotals: true,
+            colTotals: true,
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable data={deepData} visualization={visualization} />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={deepData} visualization={visualization} />
-        </div>
-    )
-})
+)
 
 const ResizingPivotTable = ({ visualization }) => {
     const [size, setSize] = useState(() => ({ width: 400, height: 300 }))
@@ -424,188 +526,249 @@ ResizingPivotTable.propTypes = {
     visualization: PropTypes.object.isRequired,
 }
 
-storiesOf('PivotTable', module).add('deep - resize', () => {
-    const visualization = {
-        ...deepVisualization,
-        ...visualizationReset,
+storiesOf('PivotTable', module).add(
+    'deep - resize',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...deepVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+        }
+        return <ResizingPivotTable visualization={visualization} />
     }
-    return <ResizingPivotTable visualization={visualization} />
-})
+)
 
-storiesOf('PivotTable', module).add('deep - totals', () => {
-    const visualization = {
-        ...deepVisualization,
-        ...visualizationReset,
-        rowTotals: true,
-        colTotals: true,
+storiesOf('PivotTable', module).add(
+    'deep - totals',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...deepVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            rowTotals: true,
+            colTotals: true,
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable data={deepData} visualization={visualization} />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={deepData} visualization={visualization} />
-        </div>
-    )
-})
+)
 
-storiesOf('PivotTable', module).add('deep - subtotals', () => {
-    const visualization = {
-        ...deepVisualization,
-        ...visualizationReset,
-        rowSubTotals: true,
-        colSubTotals: true,
+storiesOf('PivotTable', module).add(
+    'deep - subtotals',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...deepVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            rowSubTotals: true,
+            colSubTotals: true,
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable data={deepData} visualization={visualization} />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={deepData} visualization={visualization} />
-        </div>
-    )
-})
+)
 
-storiesOf('PivotTable', module).add('deep - all totals', () => {
-    const visualization = {
-        ...deepVisualization,
-        ...visualizationReset,
-        rowSubTotals: true,
-        colSubTotals: true,
-        rowTotals: true,
-        colTotals: true,
+storiesOf('PivotTable', module).add(
+    'deep - all totals',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...deepVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            rowSubTotals: true,
+            colSubTotals: true,
+            rowTotals: true,
+            colTotals: true,
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable data={deepData} visualization={visualization} />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={deepData} visualization={visualization} />
-        </div>
-    )
-})
+)
 
-storiesOf('PivotTable', module).add('small empty rows - shown', () => {
-    const visualization = {
-        ...diseaseWeeksVisualization,
-        ...visualizationReset,
-        colTotals: true,
-        rowTotals: true,
-        colSubTotals: true,
-        rowSubTotals: true,
+storiesOf('PivotTable', module).add(
+    'small empty rows - shown',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...diseaseWeeksVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            colTotals: true,
+            rowTotals: true,
+            colSubTotals: true,
+            rowSubTotals: true,
+        }
+
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable
+                    data={diseaseWeeksData}
+                    visualization={visualization}
+                />
+            </div>
+        )
     }
+)
 
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={diseaseWeeksData} visualization={visualization} />
-        </div>
-    )
-})
+storiesOf('PivotTable', module).add(
+    'small empty rows - hidden',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...diseaseWeeksVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            colTotals: true,
+            rowTotals: true,
+            colSubTotals: true,
+            rowSubTotals: true,
+            hideEmptyRows: true,
+        }
 
-storiesOf('PivotTable', module).add('small empty rows - hidden', () => {
-    const visualization = {
-        ...diseaseWeeksVisualization,
-        ...visualizationReset,
-        colTotals: true,
-        rowTotals: true,
-        colSubTotals: true,
-        rowSubTotals: true,
-        hideEmptyRows: true,
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable
+                    data={diseaseWeeksData}
+                    visualization={visualization}
+                />
+            </div>
+        )
     }
+)
 
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={diseaseWeeksData} visualization={visualization} />
-        </div>
-    )
-})
-
-storiesOf('PivotTable', module).add('empty rows - shown', () => {
-    const visualization = {
-        ...emptyRowsVisualization,
-        ...visualizationReset,
-        rowSubTotals: true,
-        colSubTotals: true,
-        rowTotals: true,
-        colTotals: true,
+storiesOf('PivotTable', module).add(
+    'empty rows - shown',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...emptyRowsVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            rowSubTotals: true,
+            colSubTotals: true,
+            rowTotals: true,
+            colTotals: true,
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable
+                    data={emptyRowsData}
+                    visualization={visualization}
+                />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={emptyRowsData} visualization={visualization} />
-        </div>
-    )
-})
+)
 
-storiesOf('PivotTable', module).add('empty rows - hidden', () => {
-    const visualization = {
-        ...emptyRowsVisualization,
-        ...visualizationReset,
-        hideEmptyRows: true,
+storiesOf('PivotTable', module).add(
+    'empty rows - hidden',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...emptyRowsVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            hideEmptyRows: true,
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable
+                    data={emptyRowsData}
+                    visualization={visualization}
+                />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={emptyRowsData} visualization={visualization} />
-        </div>
-    )
-})
+)
 
-storiesOf('PivotTable', module).add('empty columns - shown', () => {
-    const visualization = {
-        ...lastFiveYearsVisualization,
-        hideEmptyColumns: false,
+storiesOf('PivotTable', module).add(
+    'empty columns - shown',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...lastFiveYearsVisualization,
+            ...pivotTableOptions,
+            hideEmptyColumns: false,
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable
+                    data={lastFiveYearsData}
+                    visualization={visualization}
+                />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable
-                data={lastFiveYearsData}
-                visualization={visualization}
-            />
-        </div>
-    )
-})
+)
 
-storiesOf('PivotTable', module).add('empty columns - hidden', () => {
-    const visualization = {
-        ...lastFiveYearsVisualization,
-        hideEmptyColumns: true,
+storiesOf('PivotTable', module).add(
+    'empty columns - hidden',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...lastFiveYearsVisualization,
+            ...pivotTableOptions,
+            hideEmptyColumns: true,
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable
+                    data={lastFiveYearsData}
+                    visualization={visualization}
+                />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable
-                data={lastFiveYearsData}
-                visualization={visualization}
-            />
-        </div>
-    )
-})
+)
 
-storiesOf('PivotTable', module).add('empty columns (weekly) - shown', () => {
-    const visualization = {
-        ...weeklyColumnsVisualization,
-        hideEmptyColumns: false,
+storiesOf('PivotTable', module).add(
+    'empty columns (weekly) - shown',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...weeklyColumnsVisualization,
+            ...pivotTableOptions,
+            hideEmptyColumns: false,
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable
+                    data={weeklyColumnsData}
+                    visualization={visualization}
+                />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable
-                data={weeklyColumnsData}
-                visualization={visualization}
-            />
-        </div>
-    )
-})
+)
 
-storiesOf('PivotTable', module).add('empty columns (weekly) - hidden', () => {
-    const visualization = {
-        ...weeklyColumnsVisualization,
-        hideEmptyColumns: true,
+storiesOf('PivotTable', module).add(
+    'empty columns (weekly) - hidden',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...weeklyColumnsVisualization,
+            ...pivotTableOptions,
+            hideEmptyColumns: true,
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable
+                    data={weeklyColumnsData}
+                    visualization={visualization}
+                />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable
-                data={weeklyColumnsData}
-                visualization={visualization}
-            />
-        </div>
-    )
-})
+)
 
 storiesOf('PivotTable', module).add(
     'empty columns + assigned cats (shown)',
-    () => {
+    (_, { pivotTableOptions }) => {
         const visualization = {
             ...emptyColumnsVisualization,
             ...visualizationReset,
+            ...pivotTableOptions,
             hideEmptyColumns: false,
         }
         return (
@@ -621,10 +784,11 @@ storiesOf('PivotTable', module).add(
 
 storiesOf('PivotTable', module).add(
     'empty columns + assigned cats (hidden)',
-    () => {
+    (_, { pivotTableOptions }) => {
         const visualization = {
             ...emptyColumnsVisualization,
             ...visualizationReset,
+            ...pivotTableOptions,
             hideEmptyColumns: true,
         }
         return (
@@ -638,190 +802,232 @@ storiesOf('PivotTable', module).add(
     }
 )
 
-storiesOf('PivotTable', module).add('legend - fixed (light fill)', () => {
-    const visualization = {
-        ...targetVisualization,
-        ...visualizationReset,
-        rowSubTotals: true,
-        colSubTotals: true,
-        rowTotals: true,
-        colTotals: true,
-        legendDisplayStyle: 'FILL',
-        legendSet: {
-            id: underAbove100LegendSet.id,
-        },
+storiesOf('PivotTable', module).add(
+    'legend - fixed (light fill)',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...targetVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            rowSubTotals: true,
+            colSubTotals: true,
+            rowTotals: true,
+            colTotals: true,
+            legendDisplayStyle: 'FILL',
+            legendSet: {
+                id: underAbove100LegendSet.id,
+            },
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable
+                    data={targetData}
+                    visualization={visualization}
+                    legendSets={[underAbove100LegendSet]}
+                />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable
-                data={targetData}
-                visualization={visualization}
-                legendSets={[underAbove100LegendSet]}
-            />
-        </div>
-    )
-})
+)
 
-storiesOf('PivotTable', module).add('legend - fixed (dark fill)', () => {
-    const visualization = {
-        ...targetVisualization,
-        ...visualizationReset,
-        rowSubTotals: true,
-        colSubTotals: true,
-        legendDisplayStyle: 'FILL',
-        legendSet: {
-            id: underAbove100LegendSet.id,
-        },
+storiesOf('PivotTable', module).add(
+    'legend - fixed (dark fill)',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...targetVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            rowSubTotals: true,
+            colSubTotals: true,
+            legendDisplayStyle: 'FILL',
+            legendSet: {
+                id: underAbove100LegendSet.id,
+            },
+        }
+
+        const legendSet = cloneDeep(underAbove100LegendSet)
+        legendSet.legends[0].color = '#000000'
+        legendSet.legends[1].color = '#666666'
+
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable
+                    data={targetData}
+                    visualization={visualization}
+                    legendSets={[legendSet]}
+                />
+            </div>
+        )
     }
+)
 
-    const legendSet = cloneDeep(underAbove100LegendSet)
-    legendSet.legends[0].color = '#000000'
-    legendSet.legends[1].color = '#666666'
-
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable
-                data={targetData}
-                visualization={visualization}
-                legendSets={[legendSet]}
-            />
-        </div>
-    )
-})
-
-storiesOf('PivotTable', module).add('legend - fixed (text)', () => {
-    const visualization = {
-        ...targetVisualization,
-        ...visualizationReset,
-        legendDisplayStyle: 'TEXT',
-        legendSet: {
-            id: underAbove100LegendSet.id,
-        },
+storiesOf('PivotTable', module).add(
+    'legend - fixed (text)',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...targetVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            legendDisplayStyle: 'TEXT',
+            legendSet: {
+                id: underAbove100LegendSet.id,
+            },
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable
+                    data={targetData}
+                    visualization={visualization}
+                    legendSets={[underAbove100LegendSet]}
+                />
+            </div>
+        )
     }
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable
-                data={targetData}
-                visualization={visualization}
-                legendSets={[underAbove100LegendSet]}
-            />
-        </div>
-    )
-})
+)
 
-storiesOf('PivotTable', module).add('legend - fixed (% row)', () => {
-    const visualization = {
-        ...targetVisualization,
-        ...visualizationReset,
-        rowSubTotals: true,
-        colSubTotals: true,
-        numberType: NUMBER_TYPE_ROW_PERCENTAGE,
-        legendDisplayStyle: 'FILL',
-        legendSet: {
-            id: underAbove100LegendSet.id,
-        },
+storiesOf('PivotTable', module).add(
+    'legend - fixed (% row)',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...targetVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            rowSubTotals: true,
+            colSubTotals: true,
+            numberType: NUMBER_TYPE_ROW_PERCENTAGE,
+            legendDisplayStyle: 'FILL',
+            legendSet: {
+                id: underAbove100LegendSet.id,
+            },
+        }
+
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable
+                    data={targetData}
+                    visualization={visualization}
+                    legendSets={[underAbove100LegendSet]}
+                />
+            </div>
+        )
     }
+)
 
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable
-                data={targetData}
-                visualization={visualization}
-                legendSets={[underAbove100LegendSet]}
-            />
-        </div>
-    )
-})
+storiesOf('PivotTable', module).add(
+    'legend - by data item',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...targetVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            rowSubTotals: true,
+            colSubTotals: true,
+            legendDisplayStrategy: 'BY_DATA_ITEM',
+            legendSet: undefined,
+        }
+        const data = cloneDeep(targetData)
 
-storiesOf('PivotTable', module).add('legend - by data item', () => {
-    const visualization = {
-        ...targetVisualization,
-        ...visualizationReset,
-        rowSubTotals: true,
-        colSubTotals: true,
-        legendDisplayStrategy: 'BY_DATA_ITEM',
-        legendSet: undefined,
+        const customLegendSet = cloneDeep(underAbove100LegendSet)
+        customLegendSet.id = 'TESTID'
+        customLegendSet.legends[0].color = '#000000'
+        customLegendSet.legends[1].color = '#666666'
+
+        data.metaData.items[visualization.columns[0].items[1].id].legendSet =
+            underAbove100LegendSet.id
+        data.metaData.items[visualization.columns[0].items[3].id].legendSet =
+            customLegendSet.id
+
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable
+                    data={data}
+                    visualization={visualization}
+                    legendSets={[underAbove100LegendSet, customLegendSet]}
+                />
+            </div>
+        )
     }
-    const data = cloneDeep(targetData)
+)
 
-    const customLegendSet = cloneDeep(underAbove100LegendSet)
-    customLegendSet.id = 'TESTID'
-    customLegendSet.legends[0].color = '#000000'
-    customLegendSet.legends[1].color = '#666666'
+storiesOf('PivotTable', module).add(
+    'hierarchy - none',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...hierarchyVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            showHierarchy: false,
+            colTotals: true,
+            rowTotals: true,
+            colSubTotals: true,
+            rowSubTotals: true,
+        }
 
-    data.metaData.items[visualization.columns[0].items[1].id].legendSet =
-        underAbove100LegendSet.id
-    data.metaData.items[visualization.columns[0].items[3].id].legendSet =
-        customLegendSet.id
-
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable
-                data={data}
-                visualization={visualization}
-                legendSets={[underAbove100LegendSet, customLegendSet]}
-            />
-        </div>
-    )
-})
-
-storiesOf('PivotTable', module).add('hierarchy - none', () => {
-    const visualization = {
-        ...hierarchyVisualization,
-        ...visualizationReset,
-        showHierarchy: false,
-        colTotals: true,
-        rowTotals: true,
-        colSubTotals: true,
-        rowSubTotals: true,
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable
+                    data={hierarchyData}
+                    visualization={visualization}
+                />
+            </div>
+        )
     }
+)
+storiesOf('PivotTable', module).add(
+    'hierarchy - rows',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...hierarchyVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            colTotals: true,
+            rowTotals: true,
+            colSubTotals: true,
+            rowSubTotals: true,
+        }
 
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={hierarchyData} visualization={visualization} />
-        </div>
-    )
-})
-storiesOf('PivotTable', module).add('hierarchy - rows', () => {
-    const visualization = {
-        ...hierarchyVisualization,
-        ...visualizationReset,
-        colTotals: true,
-        rowTotals: true,
-        colSubTotals: true,
-        rowSubTotals: true,
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable
+                    data={hierarchyData}
+                    visualization={visualization}
+                />
+            </div>
+        )
     }
+)
 
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={hierarchyData} visualization={visualization} />
-        </div>
-    )
-})
+storiesOf('PivotTable', module).add(
+    'hierarchy - columns',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...hierarchyVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            columns: hierarchyVisualization.rows,
+            rows: hierarchyVisualization.columns,
+            colTotals: true,
+            rowTotals: true,
+            colSubTotals: true,
+            rowSubTotals: true,
+        }
 
-storiesOf('PivotTable', module).add('hierarchy - columns', () => {
-    const visualization = {
-        ...hierarchyVisualization,
-        ...visualizationReset,
-        columns: hierarchyVisualization.rows,
-        rows: hierarchyVisualization.columns,
-        colTotals: true,
-        rowTotals: true,
-        colSubTotals: true,
-        rowSubTotals: true,
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable
+                    data={hierarchyData}
+                    visualization={visualization}
+                />
+            </div>
+        )
     }
+)
 
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={hierarchyData} visualization={visualization} />
-        </div>
-    )
-})
-
-storiesOf('PivotTable', module).add('narrative', () => {
+storiesOf('PivotTable', module).add('narrative', (_, { pivotTableOptions }) => {
     const visualization = {
         ...narrativeVisualization,
         ...visualizationReset,
+        ...pivotTableOptions,
         rowTotals: true,
         colTotals: true,
     }
@@ -833,32 +1039,37 @@ storiesOf('PivotTable', module).add('narrative', () => {
     )
 })
 
-storiesOf('PivotTable', module).add('narrative - data as filter', () => {
-    const visualization = {
-        ...narrativeVisualization,
-        ...visualizationReset,
-        columns: narrativeVisualization.filters,
-        filters: narrativeVisualization.columns,
-        rowTotals: true,
-        colTotals: true,
+storiesOf('PivotTable', module).add(
+    'narrative - data as filter',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...narrativeVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            columns: narrativeVisualization.filters,
+            filters: narrativeVisualization.columns,
+            rowTotals: true,
+            colTotals: true,
+        }
+
+        const data = {
+            ...narrativeData,
+            rows: [narrativeData.rows[0]],
+        }
+
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable data={data} visualization={visualization} />
+            </div>
+        )
     }
+)
 
-    const data = {
-        ...narrativeData,
-        rows: [narrativeData.rows[0]],
-    }
-
-    return (
-        <div style={{ width: 800, height: 600 }}>
-            <PivotTable data={data} visualization={visualization} />
-        </div>
-    )
-})
-
-storiesOf('PivotTable', module).add('DEGS', () => {
+storiesOf('PivotTable', module).add('DEGS', (_, { pivotTableOptions }) => {
     const visualization = {
         ...degsVisualization,
         ...visualizationReset,
+        ...pivotTableOptions,
     }
 
     return (

--- a/src/__demo__/data/deepWithFilters.data.json
+++ b/src/__demo__/data/deepWithFilters.data.json
@@ -1,0 +1,488 @@
+{
+    "headers": [
+        {
+            "name": "dx",
+            "column": "Data",
+            "valueType": "TEXT",
+            "type": "java.lang.String",
+            "hidden": false,
+            "meta": true
+        },
+        {
+            "name": "pe",
+            "column": "Period",
+            "valueType": "TEXT",
+            "type": "java.lang.String",
+            "hidden": false,
+            "meta": true
+        },
+        {
+            "name": "ou",
+            "column": "Organisation unit",
+            "valueType": "TEXT",
+            "type": "java.lang.String",
+            "hidden": false,
+            "meta": true
+        },
+        {
+            "name": "value",
+            "column": "Value",
+            "valueType": "NUMBER",
+            "type": "java.lang.Double",
+            "hidden": false,
+            "meta": false
+        },
+        {
+            "name": "numerator",
+            "column": "Numerator",
+            "valueType": "NUMBER",
+            "type": "java.lang.Double",
+            "hidden": false,
+            "meta": false
+        },
+        {
+            "name": "denominator",
+            "column": "Denominator",
+            "valueType": "NUMBER",
+            "type": "java.lang.Double",
+            "hidden": false,
+            "meta": false
+        },
+        {
+            "name": "factor",
+            "column": "Factor",
+            "valueType": "NUMBER",
+            "type": "java.lang.Double",
+            "hidden": false,
+            "meta": false
+        },
+        {
+            "name": "multiplier",
+            "column": "Multiplier",
+            "valueType": "NUMBER",
+            "type": "java.lang.Double",
+            "hidden": false,
+            "meta": false
+        },
+        {
+            "name": "divisor",
+            "column": "Divisor",
+            "valueType": "NUMBER",
+            "type": "java.lang.Double",
+            "hidden": false,
+            "meta": false
+        }
+    ],
+    "metaData": {
+        "items": {
+            "202008": {
+                "name": "August 2020"
+            },
+            "202009": {
+                "name": "September 2020"
+            },
+            "202010": {
+                "name": "October 2020"
+            },
+            "202011": {
+                "name": "November 2020"
+            },
+            "202012": {
+                "name": "December 2020"
+            },
+            "202101": {
+                "name": "January 2021"
+            },
+            "202102": {
+                "name": "February 2021"
+            },
+            "202103": {
+                "name": "March 2021"
+            },
+            "202104": {
+                "name": "April 2021"
+            },
+            "202105": {
+                "name": "May 2021"
+            },
+            "202106": {
+                "name": "June 2021"
+            },
+            "202107": {
+                "name": "July 2021"
+            },
+            "nlX2VoouN63": {
+                "name": "Eastern Area"
+            },
+            "jUb8gELQApl": {
+                "name": "Kailahun"
+            },
+            "eIQbndfxQMb": {
+                "name": "Tonkolili"
+            },
+            "Vth0fbpFcsO": {
+                "name": "Kono"
+            },
+            "O6uvpzGd5pu": {
+                "name": "Bo"
+            },
+            "bL4ooGhyHRQ": {
+                "name": "Pujehun"
+            },
+            "kJq2mPyFEHo": {
+                "name": "Kenema"
+            },
+            "wjP19dkFeIk": {
+                "uid": "wjP19dkFeIk",
+                "name": "District"
+            },
+            "LAST_12_MONTHS": {
+                "name": "Last 12 months"
+            },
+            "ImspTQPwCqd": {
+                "uid": "ImspTQPwCqd",
+                "code": "OU_525",
+                "name": "Sierra Leone"
+            },
+            "at6UHUQatSo": {
+                "name": "Western Area"
+            },
+            "dx": {
+                "name": "Data"
+            },
+            "TEQlaapDQoK": {
+                "name": "Port Loko"
+            },
+            "PMa2VCrupOd": {
+                "name": "Kambia"
+            },
+            "ou": {
+                "name": "Organisation unit"
+            },
+            "uIuxlbV1vRT": {
+                "name": "Area"
+            },
+            "fdc6uOvgoji": {
+                "name": "Bombali"
+            },
+            "pe": {
+                "name": "Period"
+            },
+            "dwEq7wi6nXV": {
+                "name": "ANC IPT 1 Coverage"
+            },
+            "lc3eMKXaEfw": {
+                "name": "Bonthe"
+            },
+            "qhqAxPSTUXp": {
+                "name": "Koinadugu"
+            },
+            "jmIPBj66vD6": {
+                "name": "Moyamba"
+            }
+        },
+        "dimensions": {
+            "dx": ["dwEq7wi6nXV"],
+            "pe": [
+                "202008",
+                "202009",
+                "202010",
+                "202011",
+                "202012",
+                "202101",
+                "202102",
+                "202103",
+                "202104",
+                "202105",
+                "202106",
+                "202107"
+            ],
+            "ou": [
+                "O6uvpzGd5pu",
+                "fdc6uOvgoji",
+                "lc3eMKXaEfw",
+                "jUb8gELQApl",
+                "PMa2VCrupOd",
+                "kJq2mPyFEHo",
+                "qhqAxPSTUXp",
+                "Vth0fbpFcsO",
+                "jmIPBj66vD6",
+                "TEQlaapDQoK",
+                "bL4ooGhyHRQ",
+                "eIQbndfxQMb",
+                "at6UHUQatSo"
+            ],
+            "uIuxlbV1vRT": ["nlX2VoouN63"],
+            "co": []
+        }
+    },
+    "width": 9,
+    "rows": [
+        [
+            "dwEq7wi6nXV",
+            "202008",
+            "jUb8gELQApl",
+            "84.9",
+            "1131.0",
+            "1332.0",
+            "100.0",
+            "100",
+            "1"
+        ],
+        [
+            "dwEq7wi6nXV",
+            "202008",
+            "bL4ooGhyHRQ",
+            "157.2",
+            "1674.0",
+            "1065.0",
+            "100.0",
+            "100",
+            "1"
+        ],
+        [
+            "dwEq7wi6nXV",
+            "202009",
+            "jUb8gELQApl",
+            "75.8",
+            "903.0",
+            "1192.0",
+            "100.0",
+            "100",
+            "1"
+        ],
+        [
+            "dwEq7wi6nXV",
+            "202009",
+            "bL4ooGhyHRQ",
+            "152.2",
+            "1577.0",
+            "1036.0",
+            "100.0",
+            "100",
+            "1"
+        ],
+        [
+            "dwEq7wi6nXV",
+            "202010",
+            "jUb8gELQApl",
+            "156.0",
+            "1764.0",
+            "1131.0",
+            "100.0",
+            "100",
+            "1"
+        ],
+        [
+            "dwEq7wi6nXV",
+            "202010",
+            "bL4ooGhyHRQ",
+            "100.0",
+            "7.0",
+            "7.0",
+            "100.0",
+            "100",
+            "1"
+        ],
+        [
+            "dwEq7wi6nXV",
+            "202011",
+            "jUb8gELQApl",
+            "118.2",
+            "1497.0",
+            "1266.0",
+            "100.0",
+            "100",
+            "1"
+        ],
+        [
+            "dwEq7wi6nXV",
+            "202011",
+            "bL4ooGhyHRQ",
+            "225.0",
+            "18.0",
+            "8.0",
+            "100.0",
+            "100",
+            "1"
+        ],
+        [
+            "dwEq7wi6nXV",
+            "202012",
+            "jUb8gELQApl",
+            "117.6",
+            "1355.0",
+            "1152.0",
+            "100.0",
+            "100",
+            "1"
+        ],
+        [
+            "dwEq7wi6nXV",
+            "202012",
+            "bL4ooGhyHRQ",
+            "366.7",
+            "22.0",
+            "6.0",
+            "100.0",
+            "100",
+            "1"
+        ],
+        [
+            "dwEq7wi6nXV",
+            "202101",
+            "jUb8gELQApl",
+            "97.1",
+            "1184.0",
+            "1219.0",
+            "100.0",
+            "100",
+            "1"
+        ],
+        [
+            "dwEq7wi6nXV",
+            "202101",
+            "bL4ooGhyHRQ",
+            "101.5",
+            "1263.0",
+            "1244.0",
+            "100.0",
+            "100",
+            "1"
+        ],
+        [
+            "dwEq7wi6nXV",
+            "202102",
+            "jUb8gELQApl",
+            "91.1",
+            "1044.0",
+            "1146.0",
+            "100.0",
+            "100",
+            "1"
+        ],
+        [
+            "dwEq7wi6nXV",
+            "202102",
+            "bL4ooGhyHRQ",
+            "111.1",
+            "1123.0",
+            "1011.0",
+            "100.0",
+            "100",
+            "1"
+        ],
+        [
+            "dwEq7wi6nXV",
+            "202103",
+            "jUb8gELQApl",
+            "91.6",
+            "1115.0",
+            "1217.0",
+            "100.0",
+            "100",
+            "1"
+        ],
+        [
+            "dwEq7wi6nXV",
+            "202103",
+            "bL4ooGhyHRQ",
+            "95.4",
+            "959.0",
+            "1005.0",
+            "100.0",
+            "100",
+            "1"
+        ],
+        [
+            "dwEq7wi6nXV",
+            "202104",
+            "jUb8gELQApl",
+            "100.3",
+            "1268.0",
+            "1264.0",
+            "100.0",
+            "100",
+            "1"
+        ],
+        [
+            "dwEq7wi6nXV",
+            "202104",
+            "bL4ooGhyHRQ",
+            "101.1",
+            "1320.0",
+            "1306.0",
+            "100.0",
+            "100",
+            "1"
+        ],
+        [
+            "dwEq7wi6nXV",
+            "202105",
+            "jUb8gELQApl",
+            "102.5",
+            "1539.0",
+            "1501.0",
+            "100.0",
+            "100",
+            "1"
+        ],
+        [
+            "dwEq7wi6nXV",
+            "202105",
+            "bL4ooGhyHRQ",
+            "132.9",
+            "1811.0",
+            "1363.0",
+            "100.0",
+            "100",
+            "1"
+        ],
+        [
+            "dwEq7wi6nXV",
+            "202106",
+            "jUb8gELQApl",
+            "109.0",
+            "1488.0",
+            "1365.0",
+            "100.0",
+            "100",
+            "1"
+        ],
+        [
+            "dwEq7wi6nXV",
+            "202106",
+            "bL4ooGhyHRQ",
+            "107.0",
+            "1443.0",
+            "1348.0",
+            "100.0",
+            "100",
+            "1"
+        ],
+        [
+            "dwEq7wi6nXV",
+            "202107",
+            "jUb8gELQApl",
+            "87.5",
+            "1190.0",
+            "1360.0",
+            "100.0",
+            "100",
+            "1"
+        ],
+        [
+            "dwEq7wi6nXV",
+            "202107",
+            "bL4ooGhyHRQ",
+            "125.0",
+            "1579.0",
+            "1263.0",
+            "100.0",
+            "100",
+            "1"
+        ]
+    ],
+    "height": 24,
+    "headerWidth": 9
+}

--- a/src/__demo__/data/deepWithFilters.visualization.json
+++ b/src/__demo__/data/deepWithFilters.visualization.json
@@ -1,0 +1,147 @@
+{
+    "lastUpdated": "2021-08-13T12:37:08.665",
+    "href": "https://debug.dhis2.org/dev/api/37/visualizations/puDQiGqmvuU",
+    "id": "puDQiGqmvuU",
+    "created": "2021-08-13T12:37:08.665",
+    "name": "For edoardo",
+    "showData": true,
+    "numberType": "VALUE",
+    "legend": {
+        "showKey": false
+    },
+    "publicAccess": "--------",
+    "type": "PIVOT_TABLE",
+    "hideEmptyColumns": false,
+    "hideEmptyRows": false,
+    "subscribed": false,
+    "parentGraphMap": {
+        "ImspTQPwCqd": ""
+    },
+    "rowSubTotals": false,
+    "displayDensity": "NORMAL",
+    "regressionType": "NONE",
+    "completedOnly": false,
+    "cumulativeValues": false,
+    "colTotals": false,
+    "showDimensionLabels": false,
+    "sortOrder": 0,
+    "fontSize": "NORMAL",
+    "favorite": false,
+    "topLimit": 0,
+    "hideEmptyRowItems": "NONE",
+    "aggregationType": "DEFAULT",
+    "displayName": "For edoardo",
+    "hideSubtitle": false,
+    "title": "Hello",
+    "percentStackedValues": false,
+    "colSubTotals": false,
+    "noSpaceBetweenColumns": false,
+    "showHierarchy": false,
+    "rowTotals": false,
+    "seriesKey": {
+        "hidden": false
+    },
+    "digitGroupSeparator": "SPACE",
+    "hideTitle": false,
+    "regression": false,
+    "colorSet": "DEFAULT",
+    "skipRounding": false,
+    "lastUpdatedBy": {
+        "displayName": "Thor Odinsson",
+        "name": "Thor Odinsson",
+        "id": "Z7mGnIfGgqL",
+        "username": "analytics"
+    },
+    "fontStyle": {},
+    "access": {
+        "read": false,
+        "update": false,
+        "externalize": true,
+        "delete": false,
+        "write": false,
+        "manage": false
+    },
+    "reportingParams": {
+        "parentOrganisationUnit": false,
+        "reportingPeriod": false,
+        "organisationUnit": false,
+        "grandParentOrganisationUnit": false
+    },
+    "user": {
+        "displayName": "Thor Odinsson",
+        "name": "Thor Odinsson"
+    },
+    "axes": [],
+    "translations": [],
+    "yearlySeries": [],
+    "interpretations": [],
+    "userGroupAccesses": [],
+    "subscribers": [],
+    "userAccesses": [],
+    "favorites": [],
+    "columns": [
+        {
+            "dimension": "dx",
+            "items": [
+                {
+                    "name": "ANC IPT 1 Coverage",
+                    "id": "dwEq7wi6nXV",
+                    "displayName": "ANC IPT 1 Coverage",
+                    "displayShortName": "ANC IPT 1 Coverage",
+                    "dimensionItemType": "INDICATOR"
+                }
+            ]
+        }
+    ],
+    "filters": [
+        {
+            "dimension": "uIuxlbV1vRT",
+            "items": [
+                {
+                    "name": "Eastern Area",
+                    "id": "nlX2VoouN63",
+                    "displayName": "Eastern Area",
+                    "displayShortName": "Eastern Area",
+                    "dimensionItemType": "ORGANISATION_UNIT_GROUP"
+                }
+            ]
+        }
+    ],
+    "rows": [
+        {
+            "dimension": "pe",
+            "items": [
+                {
+                    "name": "LAST_12_MONTHS",
+                    "id": "LAST_12_MONTHS",
+                    "displayName": "LAST_12_MONTHS",
+                    "displayShortName": "LAST_12_MONTHS",
+                    "dimensionItemType": "PERIOD"
+                }
+            ]
+        },
+        {
+            "dimension": "ou",
+            "items": [
+                {
+                    "name": "Sierra Leone",
+                    "id": "ImspTQPwCqd",
+                    "displayName": "Sierra Leone",
+                    "displayShortName": "Sierra Leone",
+                    "dimensionItemType": "ORGANISATION_UNIT"
+                },
+                {
+                    "name": "LEVEL-2",
+                    "id": "LEVEL-2",
+                    "displayName": "LEVEL-2"
+                }
+            ]
+        }
+    ],
+    "series": [
+        {
+            "dimensionItem": "dwEq7wi6nXV",
+            "axis": 0
+        }
+    ]
+}

--- a/src/components/PivotTable/PivotTableCell.js
+++ b/src/components/PivotTable/PivotTableCell.js
@@ -5,10 +5,7 @@ import { usePivotTableEngine } from './PivotTableEngineContext'
 import { cell as cellStyle } from './styles/PivotTable.style'
 
 export const PivotTableCell = React.forwardRef(
-    (
-        { classes, isColumnHeader, children, dataTest, style = {}, ...props },
-        ref
-    ) => {
+    ({ classes, isHeader, children, dataTest, style = {}, ...props }, ref) => {
         const engine = usePivotTableEngine()
         style.height =
             style.minHeight =
@@ -21,7 +18,7 @@ export const PivotTableCell = React.forwardRef(
             `displaydensity-${engine.visualization.displayDensity}`
         )
 
-        return isColumnHeader ? (
+        return isHeader ? (
             <th
                 className={className}
                 style={style}
@@ -49,7 +46,7 @@ export const PivotTableCell = React.forwardRef(
 PivotTableCell.displayName = 'PivotTableCell'
 
 PivotTableCell.defaultProps = {
-    isColumnHeader: false,
+    isHeader: false,
 }
 PivotTableCell.propTypes = {
     children: PropTypes.node,
@@ -59,6 +56,6 @@ PivotTableCell.propTypes = {
         PropTypes.string,
     ]),
     dataTest: PropTypes.string,
-    isColumnHeader: PropTypes.bool,
+    isHeader: PropTypes.bool,
     style: PropTypes.object,
 }

--- a/src/components/PivotTable/PivotTableColumnHeaderCell.js
+++ b/src/components/PivotTable/PivotTableColumnHeaderCell.js
@@ -37,10 +37,7 @@ export const PivotTableColumnHeaderCell = ({
                     minWidth: width,
                 }
 
-                if (
-                    engine.options.fixedColumnHeaders ||
-                    engine.options.fixedRowHeaders
-                ) {
+                if (engine.options.fixedColumnHeaders) {
                     style.top =
                         level * (engine.fontSize + engine.cellPadding * 2 + 2)
                     // left value for the column header cells should be sum of row headers' width when engine.options.fixedRowHeaders is true

--- a/src/components/PivotTable/PivotTableColumnHeaderCell.js
+++ b/src/components/PivotTable/PivotTableColumnHeaderCell.js
@@ -30,24 +30,41 @@ export const PivotTableColumnHeaderCell = ({
                     header.span === 1 &&
                     engine.isSortable(index)
 
+                const style = {
+                    cursor: isSortable ? 'pointer' : 'default',
+                    width,
+                    maxWidth: width,
+                    minWidth: width,
+                }
+
+                if (
+                    engine.options.fixedColumnHeaders ||
+                    engine.options.fixedRowHeaders
+                ) {
+                    style.top =
+                        level * (engine.fontSize + engine.cellPadding * 2 + 2)
+                    // left value for the column header cells should be sum of row headers' width when engine.options.fixedRowHeaders is true
+                    style.left = engine.options.fixedRowHeaders
+                        ? engine.rowHeaderPixelWidth
+                        : 0
+                }
+
                 return (
                     <PivotTableCell
-                        isColumnHeader
-                        classes={
+                        isHeader
+                        classes={[
                             header.label &&
                             header.label !== 'Total' &&
                             header.label !== 'Subtotal' // TODO: Actually look up the column type!
                                 ? 'column-header'
-                                : 'empty-header'
-                        }
+                                : 'empty-header',
+                            {
+                                fixedHeader: engine.options.fixedColumnHeaders,
+                            },
+                        ]}
                         colSpan={header.span}
                         title={header.label}
-                        style={{
-                            cursor: isSortable ? 'pointer' : 'default',
-                            width,
-                            maxWidth: width,
-                            minWidth: width,
-                        }}
+                        style={style}
                         onClick={
                             isSortable ? () => onSortByColumn(index) : undefined
                         }
@@ -75,8 +92,9 @@ export const PivotTableColumnHeaderCell = ({
 }
 
 PivotTableColumnHeaderCell.propTypes = {
-    clippingResult: PropTypes.shape({ columns: PropTypes.object.isRequired })
-        .isRequired,
+    clippingResult: PropTypes.shape({
+        columns: PropTypes.object.isRequired,
+    }).isRequired,
     index: PropTypes.number.isRequired,
     level: PropTypes.number.isRequired,
     onSortByColumn: PropTypes.func.isRequired,

--- a/src/components/PivotTable/PivotTableColumnHeaderCell.js
+++ b/src/components/PivotTable/PivotTableColumnHeaderCell.js
@@ -37,11 +37,11 @@ export const PivotTableColumnHeaderCell = ({
                     minWidth: width,
                 }
 
-                if (engine.options.fixedColumnHeaders) {
+                if (engine.options.fixColumnHeaders) {
                     style.top =
                         level * (engine.fontSize + engine.cellPadding * 2 + 2)
-                    // left value for the column header cells should be sum of row headers' width when engine.options.fixedRowHeaders is true
-                    style.left = engine.options.fixedRowHeaders
+                    // left value for the column header cells should be sum of row headers' width when engine.options.fixRowHeaders is true
+                    style.left = engine.options.fixRowHeaders
                         ? engine.rowHeaderPixelWidth
                         : 0
                 }
@@ -56,7 +56,7 @@ export const PivotTableColumnHeaderCell = ({
                                 ? 'column-header'
                                 : 'empty-header',
                             {
-                                fixedHeader: engine.options.fixedColumnHeaders,
+                                fixedHeader: engine.options.fixColumnHeaders,
                             },
                         ]}
                         colSpan={header.span}

--- a/src/components/PivotTable/PivotTableDimensionLabelCell.js
+++ b/src/components/PivotTable/PivotTableDimensionLabelCell.js
@@ -37,13 +37,44 @@ export const PivotTableDimensionLabelCell = ({ rowLevel, columnLevel }) => {
     }
 
     const width = engine.rowHeaderWidths[rowLevel]
+    const style = {
+        width,
+        maxWidth: width,
+        minWidth: width,
+    }
+
+    if (engine.options.fixedColumnHeaders || engine.options.fixedRowHeaders) {
+        style.zIndex =
+            engine.options.fixedColumnHeaders && engine.options.fixedRowHeaders
+                ? 2
+                : 1
+        style.top = engine.options.fixedColumnHeaders
+            ? columnLevel * (engine.fontSize + engine.cellPadding * 2 + 2)
+            : 0
+        style.left = engine.options.fixedRowHeaders
+            ? // calculate the width of all row header cells on the left of current cell
+              engine.rowHeaderWidths
+                  .slice(0, rowLevel)
+                  .reduce((width, acc) => (acc += width), 0)
+            : 0
+    }
+
     return (
         <PivotTableCell
-            classes={['empty-header', 'column-header']}
+            isHeader={true}
+            classes={[
+                'empty-header',
+                'column-header',
+                {
+                    fixedHeader:
+                        engine.options.fixedColumnHeaders ||
+                        engine.options.fixedRowHeaders,
+                },
+            ]}
             colSpan={colSpan}
             rowSpan={rowSpan}
             title={label}
-            style={{ width, maxWidth: width, minWidth: width }}
+            style={style}
         >
             {label}
         </PivotTableCell>

--- a/src/components/PivotTable/PivotTableDimensionLabelCell.js
+++ b/src/components/PivotTable/PivotTableDimensionLabelCell.js
@@ -43,15 +43,15 @@ export const PivotTableDimensionLabelCell = ({ rowLevel, columnLevel }) => {
         minWidth: width,
     }
 
-    if (engine.options.fixedColumnHeaders || engine.options.fixedRowHeaders) {
+    if (engine.options.fixColumnHeaders || engine.options.fixRowHeaders) {
         style.zIndex =
-            engine.options.fixedColumnHeaders && engine.options.fixedRowHeaders
+            engine.options.fixColumnHeaders && engine.options.fixRowHeaders
                 ? 2
                 : 1
-        style.top = engine.options.fixedColumnHeaders
+        style.top = engine.options.fixColumnHeaders
             ? columnLevel * (engine.fontSize + engine.cellPadding * 2 + 2)
             : 0
-        style.left = engine.options.fixedRowHeaders
+        style.left = engine.options.fixRowHeaders
             ? // calculate the width of all row header cells on the left of current cell
               engine.rowHeaderWidths
                   .slice(0, rowLevel)
@@ -67,8 +67,8 @@ export const PivotTableDimensionLabelCell = ({ rowLevel, columnLevel }) => {
                 'column-header',
                 {
                     fixedHeader:
-                        engine.options.fixedColumnHeaders ||
-                        engine.options.fixedRowHeaders,
+                        engine.options.fixColumnHeaders ||
+                        engine.options.fixRowHeaders,
                 },
             ]}
             colSpan={colSpan}

--- a/src/components/PivotTable/PivotTableEmptyRow.js
+++ b/src/components/PivotTable/PivotTableEmptyRow.js
@@ -15,7 +15,7 @@ export const PivotTableEmptyRow = ({ height, columns }) => {
                 classes={[
                     'row-header',
                     {
-                        fixedHeader: engine.options.fixedRowHeaders,
+                        fixedHeader: engine.options.fixRowHeaders,
                     },
                 ]}
             />

--- a/src/components/PivotTable/PivotTableEmptyRow.js
+++ b/src/components/PivotTable/PivotTableEmptyRow.js
@@ -9,9 +9,15 @@ export const PivotTableEmptyRow = ({ height, columns }) => {
     return (
         <tr>
             <PivotTableCell
+                isHeader={true}
                 colSpan={engine.rowDepth}
                 style={{ height }}
-                classes="row-header"
+                classes={[
+                    'row-header',
+                    {
+                        fixedHeader: engine.options.fixedRowHeaders,
+                    },
+                ]}
             />
             {columns.map(i => (
                 <PivotTableCell key={i} />

--- a/src/components/PivotTable/PivotTableRowHeaderCell.js
+++ b/src/components/PivotTable/PivotTableRowHeaderCell.js
@@ -21,6 +21,7 @@ export const PivotTableRowHeaderCell = ({
             showHierarchy={engine.visualization.showHierarchy}
             render={header => (
                 <PivotTableCell
+                    isHeader
                     classes={[
                         header.label &&
                         header.label !== 'Total' &&
@@ -28,10 +29,19 @@ export const PivotTableRowHeaderCell = ({
                             ? 'row-header'
                             : 'empty-header',
                         header.includesHierarchy && 'row-header-hierarchy',
+                        { fixedHeader: engine.options.fixedRowHeaders },
                     ]}
                     rowSpan={header.span}
                     title={header.label}
-                    style={{ width, maxWidth: width, minWidth: width }}
+                    style={{
+                        width,
+                        maxWidth: width,
+                        minWidth: width,
+                        left:
+                            rowLevel > 0
+                                ? engine.rowHeaderWidths[rowLevel - 1]
+                                : 0,
+                    }}
                     dataTest="visualization-row-header"
                 >
                     {header.label}

--- a/src/components/PivotTable/PivotTableRowHeaderCell.js
+++ b/src/components/PivotTable/PivotTableRowHeaderCell.js
@@ -29,7 +29,7 @@ export const PivotTableRowHeaderCell = ({
                             ? 'row-header'
                             : 'empty-header',
                         header.includesHierarchy && 'row-header-hierarchy',
-                        { fixedHeader: engine.options.fixedRowHeaders },
+                        { fixedHeader: engine.options.fixRowHeaders },
                     ]}
                     rowSpan={header.span}
                     title={header.label}

--- a/src/components/PivotTable/styles/PivotTable.style.js
+++ b/src/components/PivotTable/styles/PivotTable.style.js
@@ -17,9 +17,8 @@ export const table = css`
     }
     table {
         border-spacing: 0;
-        border-collapse: collapse;
+        border-collapse: separate;
         white-space: nowrap;
-        overflow: hidden;
         box-sizing: border-box;
         text-align: center;
     }
@@ -34,6 +33,13 @@ export const cell = css`
         text-overflow: ellipsis;
         border: 1px solid #b2b2b2;
         cursor: default;
+    }
+
+    .fixedHeader {
+        position: sticky;
+        z-index: 1;
+        top: 0;
+        left: 0;
     }
 
     .fontsize-SMALL {

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -52,6 +52,8 @@ const defaultOptions = {
     showColumnTotals: false,
     showRowSubtotals: false,
     showColumnSubtotals: false,
+    fixedColumnHeaders: false,
+    fixedRowHeaders: false,
 }
 
 const defaultVisualizationProps = {
@@ -287,6 +289,8 @@ export class PivotTableEngine {
             subtitle: visualization.hideSubtitle
                 ? undefined
                 : visualization.subtitle,
+            fixedColumnHeaders: visualization.fixedColumnHeaders,
+            fixedRowHeaders: visualization.fixedRowHeaders,
         }
 
         this.dimensionLookup = buildDimensionLookup(

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -52,8 +52,8 @@ const defaultOptions = {
     showColumnTotals: false,
     showRowSubtotals: false,
     showColumnSubtotals: false,
-    fixedColumnHeaders: false,
-    fixedRowHeaders: false,
+    fixColumnHeaders: false,
+    fixRowHeaders: false,
 }
 
 const defaultVisualizationProps = {
@@ -289,8 +289,8 @@ export class PivotTableEngine {
             subtitle: visualization.hideSubtitle
                 ? undefined
                 : visualization.subtitle,
-            fixedColumnHeaders: visualization.fixedColumnHeaders,
-            fixedRowHeaders: visualization.fixedRowHeaders,
+            fixColumnHeaders: visualization.fixColumnHeaders,
+            fixRowHeaders: visualization.fixRowHeaders,
         }
 
         this.dimensionLookup = buildDimensionLookup(

--- a/src/modules/pivotTable/clipAxis.js
+++ b/src/modules/pivotTable/clipAxis.js
@@ -1,29 +1,20 @@
 import times from 'lodash/times'
 
-export const clipAxis = ({
-    position,
-    size,
-    step,
-    totalCount,
-    headerCount,
-    fixedColumnHeaders,
-}) => {
+export const clipAxis = ({ position, size, step, totalCount, headerCount }) => {
     // position: scroll Y position
     // size: height of table container
     // step: height of cell in px
     // totalCount: number of rows
     // headerCount: number of header rows (plus 1 for title plus 1 for subtitle)
 
-    // height in px of all row headers section, including title and subtitle
+    // height in px of all row headers section, including title and subtitle when not using
+    // fixed column headers
     const floor = headerCount * step
     // offset in px for the clipping content
     const offset = position < floor ? floor - position : 0
 
-    const count = Math.min(
-        fixedColumnHeaders ? totalCount - headerCount : totalCount,
-        Math.ceil((size - offset) / step) + 1
-    )
-    position = Math.max(0, fixedColumnHeaders ? position : position - floor)
+    const count = Math.min(totalCount, Math.ceil((size - offset) / step) + 1)
+    position = Math.max(0, position - floor)
     const start = Math.min(totalCount - count, Math.floor(position / step))
     const pre = Math.max(start * step, 0)
     const post = (totalCount - (start + count)) * step

--- a/src/modules/pivotTable/clipAxis.js
+++ b/src/modules/pivotTable/clipAxis.js
@@ -1,11 +1,29 @@
 import times from 'lodash/times'
 
-export const clipAxis = ({ position, size, step, totalCount, headerCount }) => {
+export const clipAxis = ({
+    position,
+    size,
+    step,
+    totalCount,
+    headerCount,
+    fixedColumnHeaders,
+}) => {
+    // position: scroll Y position
+    // size: height of table container
+    // step: height of cell in px
+    // totalCount: number of rows
+    // headerCount: number of header rows (plus 1 for title plus 1 for subtitle)
+
+    // height in px of all row headers section, including title and subtitle
     const floor = headerCount * step
+    // offset in px for the clipping content
     const offset = position < floor ? floor - position : 0
 
-    const count = Math.min(totalCount, Math.ceil((size - offset) / step) + 1)
-    position = Math.max(0, position - floor) // TODO: Support sticky headers
+    const count = Math.min(
+        fixedColumnHeaders ? totalCount - headerCount : totalCount,
+        Math.ceil((size - offset) / step) + 1
+    )
+    position = Math.max(0, fixedColumnHeaders ? position : position - floor)
     const start = Math.min(totalCount - count, Math.floor(position / step))
     const pre = Math.max(start * step, 0)
     const post = (totalCount - (start + count)) * step

--- a/src/modules/pivotTable/useTableClipping.js
+++ b/src/modules/pivotTable/useTableClipping.js
@@ -34,16 +34,23 @@ export const useTableClipping = ({
             engine.height,
             engine.options.title,
             engine.options.subtitle,
+            engine.options.fixedColumnHeaders,
             visualization.columns.length,
         ]
     )
     const columns = useMemo(() => {
         const viewportPosition = Math.max(
             0,
-            scrollPosition.x - engine.rowHeaderPixelWidth
+            engine.options.fixedRowHeaders
+                ? scrollPosition.x
+                : scrollPosition.x - engine.rowHeaderPixelWidth
         )
         const viewportWidth =
-            width - Math.max(engine.rowHeaderPixelWidth - scrollPosition.x, 0)
+            width -
+            (engine.options.fixedRowHeaders
+                ? engine.rowHeaderPixelWidth
+                : Math.max(engine.rowHeaderPixelWidth - scrollPosition.x, 0))
+
         return clipPartitionedAxis({
             partitionSize: COLUMN_PARTITION_SIZE_PX,
             partitions: engine.columnPartitions,
@@ -60,6 +67,7 @@ export const useTableClipping = ({
         engine.columnMap,
         engine.columnWidths,
         engine.dataPixelWidth,
+        engine.options.fixedRowHeaders,
         width,
     ])
 

--- a/src/modules/pivotTable/useTableClipping.js
+++ b/src/modules/pivotTable/useTableClipping.js
@@ -24,6 +24,7 @@ export const useTableClipping = ({
                     visualization.columns.length +
                     (engine.options.title ? 1 : 0) +
                     (engine.options.subtitle ? 1 : 0),
+                fixedColumnHeaders: engine.options.fixedColumnHeaders,
             }),
         [
             scrollPosition.y,

--- a/src/modules/pivotTable/useTableClipping.js
+++ b/src/modules/pivotTable/useTableClipping.js
@@ -22,11 +22,10 @@ export const useTableClipping = ({
                 totalCount: engine.height,
                 headerCount:
                     visualization.columns.length +
-                    (engine.options.title && !engine.options.fixedColumnHeaders
+                    (engine.options.title && !engine.options.fixColumnHeaders
                         ? 1
                         : 0) +
-                    (engine.options.subtitle &&
-                    !engine.options.fixedColumnHeaders
+                    (engine.options.subtitle && !engine.options.fixColumnHeaders
                         ? 1
                         : 0),
             }),
@@ -38,20 +37,20 @@ export const useTableClipping = ({
             engine.height,
             engine.options.title,
             engine.options.subtitle,
-            engine.options.fixedColumnHeaders,
+            engine.options.fixColumnHeaders,
             visualization.columns.length,
         ]
     )
     const columns = useMemo(() => {
         const viewportPosition = Math.max(
             0,
-            engine.options.fixedRowHeaders
+            engine.options.fixRowHeaders
                 ? scrollPosition.x
                 : scrollPosition.x - engine.rowHeaderPixelWidth
         )
         const viewportWidth =
             width -
-            (engine.options.fixedRowHeaders
+            (engine.options.fixRowHeaders
                 ? engine.rowHeaderPixelWidth
                 : Math.max(engine.rowHeaderPixelWidth - scrollPosition.x, 0))
 
@@ -71,7 +70,7 @@ export const useTableClipping = ({
         engine.columnMap,
         engine.columnWidths,
         engine.dataPixelWidth,
-        engine.options.fixedRowHeaders,
+        engine.options.fixRowHeaders,
         width,
     ])
 

--- a/src/modules/pivotTable/useTableClipping.js
+++ b/src/modules/pivotTable/useTableClipping.js
@@ -22,9 +22,13 @@ export const useTableClipping = ({
                 totalCount: engine.height,
                 headerCount:
                     visualization.columns.length +
-                    (engine.options.title ? 1 : 0) +
-                    (engine.options.subtitle ? 1 : 0),
-                fixedColumnHeaders: engine.options.fixedColumnHeaders,
+                    (engine.options.title && !engine.options.fixedColumnHeaders
+                        ? 1
+                        : 0) +
+                    (engine.options.subtitle &&
+                    !engine.options.fixedColumnHeaders
+                        ? 1
+                        : 0),
             }),
         [
             scrollPosition.y,


### PR DESCRIPTION
**PUBLISHED v20.1.0-alpha.4 FOR TESTING**

Implements [DHIS2-11057](https://jira.dhis2.org/browse/DHIS2-11057)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/1797**

---

### Key features

1. implement fixed column headers and fixed row headers in pivot table
2. update storybook with a decorator that allows to set some options to all stories, so it's possible to test them without replicating the same stories

---

### Description

The fixed headers feature in PT is controlled by 2 options in DV (under the Style tab, see related PR).
The options can be used separately or combined together.
The storybook provide an easy way to simulate toggling of these options so all stories can be tested out with all possible combinations of the options.

The technical solution is to use `position: sticky` on the `th` cells that need to be fixed, together with specific values for `top` and `left` positioning of the cells.

There is some refactoring around the `isColumnHeader` prop, which is now renamed to the more generic `isHeader` as the same prop is used also on row headers, also now "converted" to `th` instead of `td`.


---

### TODO

-   [ ] _task_

---

### Known issues
-   [ ] Border-collapse: separate is needed to avoid seeing white borders when scrolling, but the border is double the thickness, couldn’t find another way…
-   [x] FIXED Label on column header is not centered when scrolling horizontally
-   [ ] Column headers sliding under when fixed but no vertical scrolling
-   [ ] Dimension header cells labels not centered when scrolling (because the cell width does not change)

---

### Screenshots

Quick video demo:

https://user-images.githubusercontent.com/150978/124780392-d76ccf00-df42-11eb-8e80-2b7d17ca53b6.mov


