### PR TITLE
fix: yoy x axis title and labels (DHIS2-11411) v34

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/xAxis/yearOnYear.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/xAxis/yearOnYear.js
@@ -1,17 +1,16 @@
 import objectClean from 'd2-utilizr/lib/objectClean'
 import {
-    FONT_STYLE_VERTICAL_AXIS_TITLE,
-    mergeFontStyleWithDefault,
+    FONT_STYLE_HORIZONTAL_AXIS_TITLE,
+    FONT_STYLE_CATEGORY_AXIS_LABELS,
+    FONT_STYLE_OPTION_TEXT_COLOR,
+    FONT_STYLE_OPTION_FONT_SIZE,
+    FONT_STYLE_OPTION_BOLD,
+    FONT_STYLE_OPTION_ITALIC
 } from '../../../../../modules/fontStyle'
-import { getAxis } from '../../../../util/axes'
 import getAxisTitle from '../getAxisTitle'
-import { getLabels } from '.'
 
 export default function (store, layout, extraOptions) {
     let categories
-    const AXIS_TYPE = 'DOMAIN'
-    const AXIS_INDEX = 0
-    const axis = getAxis(layout.axes, AXIS_TYPE, AXIS_INDEX)
 
     if (extraOptions.xAxisLabels) {
         categories = extraOptions.xAxisLabels
@@ -42,17 +41,18 @@ export default function (store, layout, extraOptions) {
         }, [])
     }
 
+    const labelFontStyle = layout.fontStyle[FONT_STYLE_CATEGORY_AXIS_LABELS]
+
     return objectClean({
         categories,
-        title: getAxisTitle(
-            axis.title?.text,
-            mergeFontStyleWithDefault(
-                axis.title?.fontStyle,
-                FONT_STYLE_VERTICAL_AXIS_TITLE
-            ),
-            FONT_STYLE_VERTICAL_AXIS_TITLE,
-            layout.type
-        ),
-        labels: getLabels(axis),
+        title: getAxisTitle(layout.domainAxisLabel, layout.fontStyle[FONT_STYLE_HORIZONTAL_AXIS_TITLE], FONT_STYLE_HORIZONTAL_AXIS_TITLE, layout.type),
+        labels: labelFontStyle ? {
+            style: {
+                color: labelFontStyle[FONT_STYLE_OPTION_TEXT_COLOR],
+                fontSize: `${labelFontStyle[FONT_STYLE_OPTION_FONT_SIZE]}px`,
+                fontWeight: labelFontStyle[FONT_STYLE_OPTION_BOLD] ? FONT_STYLE_OPTION_BOLD : 'normal',
+                fontStyle: labelFontStyle[FONT_STYLE_OPTION_ITALIC] ? FONT_STYLE_OPTION_ITALIC : 'normal'
+            },
+        } : {},
     })
 }

--- a/src/visualizations/config/adapters/dhis_highcharts/xAxis/yearOnYear.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/xAxis/yearOnYear.js
@@ -1,5 +1,17 @@
-export default function(store, layout, extraOptions) {
+import objectClean from 'd2-utilizr/lib/objectClean'
+import {
+    FONT_STYLE_VERTICAL_AXIS_TITLE,
+    mergeFontStyleWithDefault,
+} from '../../../../../modules/fontStyle'
+import { getAxis } from '../../../../util/axes'
+import getAxisTitle from '../getAxisTitle'
+import { getLabels } from '.'
+
+export default function (store, layout, extraOptions) {
     let categories
+    const AXIS_TYPE = 'DOMAIN'
+    const AXIS_INDEX = 0
+    const axis = getAxis(layout.axes, AXIS_TYPE, AXIS_INDEX)
 
     if (extraOptions.xAxisLabels) {
         categories = extraOptions.xAxisLabels
@@ -30,7 +42,17 @@ export default function(store, layout, extraOptions) {
         }, [])
     }
 
-    return {
+    return objectClean({
         categories,
-    }
+        title: getAxisTitle(
+            axis.title?.text,
+            mergeFontStyleWithDefault(
+                axis.title?.fontStyle,
+                FONT_STYLE_VERTICAL_AXIS_TITLE
+            ),
+            FONT_STYLE_VERTICAL_AXIS_TITLE,
+            layout.type
+        ),
+        labels: getLabels(axis),
+    })
 }

--- a/src/visualizations/config/adapters/dhis_highcharts/xAxis/yearOnYear.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/xAxis/yearOnYear.js
@@ -1,12 +1,4 @@
 import objectClean from 'd2-utilizr/lib/objectClean'
-import {
-    FONT_STYLE_HORIZONTAL_AXIS_TITLE,
-    FONT_STYLE_CATEGORY_AXIS_LABELS,
-    FONT_STYLE_OPTION_TEXT_COLOR,
-    FONT_STYLE_OPTION_FONT_SIZE,
-    FONT_STYLE_OPTION_BOLD,
-    FONT_STYLE_OPTION_ITALIC
-} from '../../../../../modules/fontStyle'
 import getAxisTitle from '../getAxisTitle'
 
 export default function (store, layout, extraOptions) {
@@ -41,18 +33,8 @@ export default function (store, layout, extraOptions) {
         }, [])
     }
 
-    const labelFontStyle = layout.fontStyle[FONT_STYLE_CATEGORY_AXIS_LABELS]
-
     return objectClean({
         categories,
-        title: getAxisTitle(layout.domainAxisLabel, layout.fontStyle[FONT_STYLE_HORIZONTAL_AXIS_TITLE], FONT_STYLE_HORIZONTAL_AXIS_TITLE, layout.type),
-        labels: labelFontStyle ? {
-            style: {
-                color: labelFontStyle[FONT_STYLE_OPTION_TEXT_COLOR],
-                fontSize: `${labelFontStyle[FONT_STYLE_OPTION_FONT_SIZE]}px`,
-                fontWeight: labelFontStyle[FONT_STYLE_OPTION_BOLD] ? FONT_STYLE_OPTION_BOLD : 'normal',
-                fontStyle: labelFontStyle[FONT_STYLE_OPTION_ITALIC] ? FONT_STYLE_OPTION_ITALIC : 'normal'
-            },
-        } : {},
+        title: getAxisTitle(layout.domainAxisLabel),
     })
 }


### PR DESCRIPTION
Implements [DHIS2-11411](https://jira.dhis2.org/browse/DHIS2-11411) for v34

Adapted cherry-pick of https://github.com/dhis2/analytics/pull/991 / https://github.com/dhis2/analytics/pull/991/commits/c0d5d3362f446abcd6325698388bffb4914a97a0 and https://github.com/dhis2/analytics/pull/991/commits/2a79f780e2b18942a59e6813e9a058199145d4e8

Adapted to v34 which doesn't have font styles, which made this change very small.

---

### Screenshots

_axis titles_
![image](https://user-images.githubusercontent.com/12590483/125446103-d034c5e9-cd25-4f2a-910a-ffe56a94c3db.png)

