### PR TITLE
fix: legend key bullet as svg (DHIS2-11725)

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/legend.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/legend.js
@@ -87,9 +87,6 @@ const getLegendSetByDisplayStrategy = ({
     }
 }
 
-const getBulletStyleByFontStyle = fontStyle =>
-    `display: inline-block; border-radius: 50%; width: ${fontStyle[FONT_STYLE_OPTION_FONT_SIZE]}px; height: ${fontStyle[FONT_STYLE_OPTION_FONT_SIZE]}px;`
-
 const formatLabel = ({
     seriesId,
     seriesColor,
@@ -136,13 +133,19 @@ const formatLabel = ({
             .sort((a, b) => a.startValue - b.startValue)
             .forEach((legend, index) =>
                 result.push(
-                    `<span style="${getBulletStyleByFontStyle(
-                        fontStyle
-                    )} background-color: ${
-                        legend.color
-                    }; margin-right:-5px; z-index: ${
+                    `<svg xmlns="http://www.w3.org/2000/svg" width="${
+                        fontStyle[FONT_STYLE_OPTION_FONT_SIZE]
+                    }" height="${
+                        fontStyle[FONT_STYLE_OPTION_FONT_SIZE]
+                    }" version="1.1"  style="margin-right:-5px; z-index: ${
                         legendSet.legends.length - index
-                    }" class="data-test-series-key-item-bullet"></span>`
+                    }" class="data-test-series-key-item-bullet">
+                    <circle cx="${
+                        fontStyle[FONT_STYLE_OPTION_FONT_SIZE] / 2
+                    }" cy="${fontStyle[FONT_STYLE_OPTION_FONT_SIZE] / 2}" r="${
+                        fontStyle[FONT_STYLE_OPTION_FONT_SIZE] / 2
+                    }" fill="${legend.color}"></circle>
+                    </svg>`
                 )
             )
         result.push(
@@ -177,9 +180,17 @@ const formatLabel = ({
             )
         } else {
             result.push(
-                `<span style="${getBulletStyleByFontStyle(
-                    fontStyle
-                )} background-color: ${seriesColor}; margin-right:5px" class="data-test-series-key-item-bullet"></span>`
+                `<svg xmlns="http://www.w3.org/2000/svg" width="${
+                    fontStyle[FONT_STYLE_OPTION_FONT_SIZE]
+                }" height="${
+                    fontStyle[FONT_STYLE_OPTION_FONT_SIZE]
+                }" version="1.1"  style="margin-right:5px" class="data-test-series-key-item-bullet">
+                    <circle cx="${
+                        fontStyle[FONT_STYLE_OPTION_FONT_SIZE] / 2
+                    }" cy="${fontStyle[FONT_STYLE_OPTION_FONT_SIZE] / 2}" r="${
+                    fontStyle[FONT_STYLE_OPTION_FONT_SIZE] / 2
+                }" fill="${seriesColor}"></circle>
+                    </svg>`
             )
         }
 


### PR DESCRIPTION
Fix for [DHIS2-11725](https://jira.dhis2.org/browse/DHIS2-11725)

Converts the series key bullets to use `svg` instead of `span`, as the `background-color` in the `span` isn't ideal for printing.

No visual changes, the output is identical to how it currently looks.

_master_
![image](https://user-images.githubusercontent.com/12590483/132230379-2685748b-77bb-41b0-a64b-2cc5a4244df2.png)

_this branch_
![image](https://user-images.githubusercontent.com/12590483/132230413-ea9094d6-4611-4c7c-967b-0e3a7bab6aad.png)
