### PR TITLE
fix: show no data text instead of undefined

### DIFF
--- a/src/visualizations/config/adapters/dhis_dhis/index.js
+++ b/src/visualizations/config/adapters/dhis_dhis/index.js
@@ -17,8 +17,11 @@ export default function ({ store, layout, extraOptions }) {
     const metaData = store.data[0].metaData
 
     const config = {
-        value: data[0] === undefined ? extraOptions.noData.text : data[0],
-        formattedValue: getValue(data[0], layout, metaData, extraOptions),
+        value: data[0],
+        formattedValue:
+            data[0] === undefined
+                ? extraOptions.noData.text
+                : getValue(data[0], layout, metaData),
         title: getTitle(layout, metaData, extraOptions.dashboard),
         subtitle: getSubtitle(layout, metaData, extraOptions.dashboard),
     }

--- a/src/visualizations/config/adapters/dhis_dhis/value/index.js
+++ b/src/visualizations/config/adapters/dhis_dhis/value/index.js
@@ -2,16 +2,15 @@ import { INDICATOR_FACTOR_100 } from '../'
 import { VALUE_TYPE_TEXT } from '../../../../../modules/pivotTable/pivotTableConstants'
 import { renderValue } from '../../../../../modules/pivotTable/renderValue'
 
-export default function (value, layout, metaData, extraOptions) {
+export default function (value, layout, metaData) {
     const valueType = metaData.items[metaData.dimensions.dx[0]].valueType
     const indicatorType =
         metaData.items[metaData.dimensions.dx[0]].indicatorType
 
-    let formattedValue =
-        renderValue(value, valueType || VALUE_TYPE_TEXT, {
-            digitGroupSeparator: layout.digitGroupSeparator,
-            skipRounding: layout.skipRounding,
-        }) || extraOptions.noData.text
+    let formattedValue = renderValue(value, valueType || VALUE_TYPE_TEXT, {
+        digitGroupSeparator: layout.digitGroupSeparator,
+        skipRounding: layout.skipRounding,
+    })
 
     // only show the percentage symbol for per cent
     // for other factors, show the full text under the value


### PR DESCRIPTION
### Key features

1. Show the no data text instead of undefined in SV

### Screenshots

Before:
<img width="335" alt="Screenshot 2021-09-20 at 09 14 33" src="https://user-images.githubusercontent.com/150978/133968667-f559f098-b7e3-494f-9a47-7eb047da72e6.png">

After:
<img width="644" alt="Screenshot 2021-09-20 at 09 13 58" src="https://user-images.githubusercontent.com/150978/133968682-688a7738-089b-4a02-be2f-fb3d5fa29610.png">

