### PR TITLE
fix: use lighter grey for No data text in SV

### DIFF
--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -39,11 +39,13 @@ const generateValueSVG = ({
         svgValue.setAttribute('y', y)
     }
 
-    const fillColor = legendSet
-        ? getColorByValueFromLegendSet(legendSet, value)
-        : formattedValue === noData.text
-        ? colors.grey600
-        : colors.grey900
+    let fillColor = colors.grey900
+
+    if (legendSet) {
+        fillColor = getColorByValueFromLegendSet(legendSet, value)
+    } else if (formattedValue === noData.text) {
+        fillColor = colors.grey600
+    }
 
     const textNode = document.createElementNS(svgNS, 'text')
     textNode.setAttribute('text-anchor', 'middle')

--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -16,7 +16,14 @@ import { getColorByValueFromLegendSet } from '../../../../modules/legends'
 
 const svgNS = 'http://www.w3.org/2000/svg'
 
-const generateValueSVG = (value, formattedValue, subText, legendSet, y) => {
+const generateValueSVG = ({
+    value,
+    formattedValue,
+    subText,
+    legendSet,
+    noData,
+    y,
+}) => {
     const textSize = 300
 
     const svgValue = document.createElementNS(svgNS, 'svg')
@@ -34,6 +41,8 @@ const generateValueSVG = (value, formattedValue, subText, legendSet, y) => {
 
     const fillColor = legendSet
         ? getColorByValueFromLegendSet(legendSet, value)
+        : formattedValue === noData.text
+        ? colors.grey600
         : colors.grey900
 
     const textNode = document.createElementNS(svgNS, 'text')
@@ -76,7 +85,7 @@ const generateValueSVG = (value, formattedValue, subText, legendSet, y) => {
     return svgValue
 }
 
-const generateDashboardItem = (config, legendSet) => {
+const generateDashboardItem = (config, { legendSet, noData }) => {
     const container = document.createElement('div')
     container.setAttribute(
         'style',
@@ -102,13 +111,14 @@ const generateDashboardItem = (config, legendSet) => {
     }
 
     container.appendChild(
-        generateValueSVG(
-            config.value,
-            config.formattedValue,
-            config.subText,
+        generateValueSVG({
+            value: config.value,
+            formattedValue: config.formattedValue,
+            subText: config.subText,
             legendSet,
-            40
-        )
+            noData,
+            y: 40,
+        })
     )
 
     return container
@@ -138,7 +148,7 @@ const getXFromTextAlign = textAlign => {
     }
 }
 
-const generateDVItem = (config, legendSet, parentEl, fontStyle) => {
+const generateDVItem = (config, { legendSet, parentEl, fontStyle, noData }) => {
     const parentElBBox = parentEl.getBoundingClientRect()
 
     const width = parentElBBox.width
@@ -240,13 +250,14 @@ const generateDVItem = (config, legendSet, parentEl, fontStyle) => {
     }
 
     svg.appendChild(
-        generateValueSVG(
-            config.value,
-            config.formattedValue,
-            config.subText,
+        generateValueSVG({
+            value: config.value,
+            formattedValue: config.formattedValue,
+            subText: config.subText,
             legendSet,
-            20
-        )
+            noData,
+            y: 20,
+        })
     )
 
     return svg
@@ -255,7 +266,7 @@ const generateDVItem = (config, legendSet, parentEl, fontStyle) => {
 export default function (
     config,
     parentEl,
-    { dashboard, legendSets, fontStyle }
+    { dashboard, legendSets, fontStyle, noData }
 ) {
     const legendSet = legendSets[0]
     parentEl.style.overflow = 'hidden'
@@ -263,6 +274,6 @@ export default function (
     parentEl.style.justifyContent = 'center'
 
     return dashboard
-        ? generateDashboardItem(config, legendSet)
-        : generateDVItem(config, legendSet, parentEl, fontStyle)
+        ? generateDashboardItem(config, { legendSet, noData })
+        : generateDVItem(config, { legendSet, parentEl, fontStyle, noData })
 }

--- a/src/visualizations/config/index.js
+++ b/src/visualizations/config/index.js
@@ -34,17 +34,18 @@ export default function ({
     if (!_generator) {
         onError(`No visualization implementation for format ${outputFormat}`)
     }
-    this.getConfig = () => {
-        const DEFAULT_EXTRA_OPTIONS = {
-            colors: theme1,
-            noData: {
-                text: i18n.t('No data'),
-            },
-            resetZoom: {
-                text: i18n.t('Reset zoom'),
-            },
-        }
 
+    const DEFAULT_EXTRA_OPTIONS = {
+        colors: theme1,
+        noData: {
+            text: i18n.t('No data'),
+        },
+        resetZoom: {
+            text: i18n.t('Reset zoom'),
+        },
+    }
+
+    this.getConfig = () => {
         const config = _adapter({
             layout: _validator({ layout, onError, onWarning }),
             extraOptions: Object.assign(
@@ -66,6 +67,7 @@ export default function ({
     this.createVisualization = () =>
         _generator(this.getConfig(), el, {
             ...extraOptions,
+            noData: DEFAULT_EXTRA_OPTIONS.noData,
             fontStyle: layout.fontStyle,
         })
 }


### PR DESCRIPTION
Part of the fix for [DHIS2-11810](https://jira.dhis2.org/browse/DHIS2-11810)

---

### Key features

1. Use lighter grey for the No data text
2. Refactored the params passed around functions, use an object instead of passing all in a list

---

### Screenshots
<img width="920" alt="Screenshot 2021-09-20 at 16 27 05" src="https://user-images.githubusercontent.com/150978/134020693-958dd7af-9a56-4c1c-95a7-874d2309d820.png">


