### PR TITLE
fix: fix fixed row header with more than 2 cells DHIS2-11835

### DIFF
--- a/src/components/PivotTable/PivotTableRowHeaderCell.js
+++ b/src/components/PivotTable/PivotTableRowHeaderCell.js
@@ -44,8 +44,10 @@ export const PivotTableRowHeaderCell = ({
                         height,
                         left:
                             rowLevel > 0
-                                ? engine.adaptiveClippingController.columns
-                                      .headerSizes[rowLevel - 1]
+                                ? // calculate the width of all row header cells on the left of current cell
+                                  engine.adaptiveClippingController.columns.headerSizes
+                                      .slice(0, rowLevel)
+                                      .reduce((width, acc) => (acc += width), 0)
                                 : 0,
                     }}
                     dataTest="visualization-row-header"


### PR DESCRIPTION
Implements [DHIS2-11835](https://jira.dhis2.org/browse/DHIS2-11835)

---

### Key features

1. Fix a bug when number of row header cells > 2

---

### Description

The calculation of the `left` CSS property was wrong for the 3rd row header cell and up.

---

### Screenshots

Before:
<img width="299" alt="Screenshot 2021-09-22 at 16 29 00" src="https://user-images.githubusercontent.com/150978/134362969-bff5cf3b-639d-4da4-bd6e-9a47c9e34ff3.png">

After:
<img width="356" alt="Screenshot 2021-09-22 at 16 28 23" src="https://user-images.githubusercontent.com/150978/134363023-b5e99021-cf5c-4c01-adcb-1f1a1be7ac5b.png">

