### PR TITLE
fix: do not fix headers if no dimension items are selected

### DIFF
--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -277,6 +277,13 @@ export class PivotTableEngine {
             return sets
         }, {})
         this.rawData = data
+
+        this.dimensionLookup = buildDimensionLookup(
+            this.visualization,
+            this.rawData.metaData,
+            this.rawData.headers
+        )
+
         this.options = {
             ...defaultOptions,
             showColumnTotals: visualization.colTotals,
@@ -289,15 +296,15 @@ export class PivotTableEngine {
             subtitle: visualization.hideSubtitle
                 ? undefined
                 : visualization.subtitle,
-            fixColumnHeaders: visualization.fixColumnHeaders,
-            fixRowHeaders: visualization.fixRowHeaders,
+            // turn on fixed headers only when there are dimensions
+            fixColumnHeaders: this.dimensionLookup.columns.length
+                ? visualization.fixColumnHeaders
+                : false,
+            fixRowHeaders: this.dimensionLookup.rows.length
+                ? visualization.fixRowHeaders
+                : false,
         }
 
-        this.dimensionLookup = buildDimensionLookup(
-            this.visualization,
-            this.rawData.metaData,
-            this.rawData.headers
-        )
         this.adaptiveClippingController = new AdaptiveClippingController(this)
 
         const doColumnSubtotals =


### PR DESCRIPTION
**Relates to https://github.com/dhis2/data-visualizer-app/pull/1918**

---

### Key features

1. Enable fix headers only when the corresponding axis (Rows, Columns) has dimension items selected and the DV option is enabled

---

### Description

This solves an issue with missing table borders when a fix header option
is enabled but nothing is selected in the corresponding axis (Columns,
Rows).

### Screenshots

Before:
![image (8)](https://user-images.githubusercontent.com/150978/135644283-ccae67f3-ba60-4773-bf74-5c19de9f9e0c.png)

After:
<img width="667" alt="Screenshot 2021-10-01 at 17 13 21" src="https://user-images.githubusercontent.com/150978/135644744-1bd10140-01b4-469c-b50d-362a44a85205.png">


