### PR TITLE
feat: add support for ER (TECH-704)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-09-27T13:00:47.259Z\n"
-"PO-Revision-Date: 2021-09-27T13:00:47.259Z\n"
+"POT-Creation-Date: 2021-10-04T08:35:00.972Z\n"
+"PO-Revision-Date: 2021-10-04T08:35:00.972Z\n"
 
 msgid "Data Type"
 msgstr "Data Type"
@@ -311,6 +311,35 @@ msgstr ""
 
 msgid "New map"
 msgstr "New map"
+
+msgid "Open an event report"
+msgstr "Open an event report"
+
+msgid "Loading event reports"
+msgstr "Loading event reports"
+
+msgid "Couldn't load event reports"
+msgstr "Couldn't load event reports"
+
+msgid ""
+"There was a problem loading event reports. Try again or contact your system "
+"administrator."
+msgstr ""
+"There was a problem loading event reports. Try again or contact your system "
+"administrator."
+
+msgid "No event reports found. Click New event report to get started."
+msgstr "No event reports found. Click New event report to get started."
+
+msgid ""
+"No event reports found. Try adjusting your search or filter options to find "
+"what you're looking for."
+msgstr ""
+"No event reports found. Try adjusting your search or filter options to find "
+"what you're looking for."
+
+msgid "New event report"
+msgstr "New event report"
 
 msgid "Options"
 msgstr "Options"

--- a/src/__demo__/OpenFileDialog.stories.js
+++ b/src/__demo__/OpenFileDialog.stories.js
@@ -41,6 +41,21 @@ storiesOf('OpenFileDialog', module).add('List of maps', () => (
     </Provider>
 ))
 storiesOf('OpenFileDialog', module).add(
+    'List of event reports (Line list only)',
+    () => (
+        <Provider config={configMock}>
+            <OpenFileDialog
+                type="eventReport"
+                onClose={Function.prototype}
+                onFileSelect={onFileSelect}
+                onNew={Function.prototype}
+                open={true}
+                currentUser={user}
+            />
+        </Provider>
+    )
+)
+storiesOf('OpenFileDialog', module).add(
     'List of a supported type without custom titles/texts',
     () => (
         <Provider config={configMock}>

--- a/src/components/FileMenu/utils.js
+++ b/src/components/FileMenu/utils.js
@@ -1,4 +1,4 @@
-export const supportedFileTypes = ['visualization', 'map']
+export const supportedFileTypes = ['eventReport', 'visualization', 'map']
 
 export const endpointFromFileType = fileType => {
     switch (fileType) {

--- a/src/components/OpenFileDialog/OpenFileDialog.js
+++ b/src/components/OpenFileDialog/OpenFileDialog.js
@@ -29,7 +29,12 @@ import { FileList } from './FileList'
 import { NameFilter } from './NameFilter'
 import { styles } from './OpenFileDialog.styles'
 import { PaginationControls } from './PaginationControls'
-import { getTranslatedString, AO_TYPE_VISUALIZATION, AOTypeMap } from './utils'
+import {
+    getTranslatedString,
+    AO_TYPE_VISUALIZATION,
+    AO_TYPE_EVENT_REPORT,
+    AOTypeMap,
+} from './utils'
 import { VisTypeFilter, VIS_TYPE_ALL, VIS_TYPE_CHARTS } from './VisTypeFilter'
 
 const getQuery = type => ({
@@ -112,6 +117,11 @@ export const OpenFileDialog = ({
 
         if (filters.searchTerm) {
             queryFilters.push(`name:ilike:${filters.searchTerm}`)
+        }
+
+        // for ER 2.38 only show line list ER types
+        if (type === AO_TYPE_EVENT_REPORT) {
+            queryFilters.push('dataType:eq:EVENTS')
         }
 
         return queryFilters

--- a/src/components/OpenFileDialog/utils.js
+++ b/src/components/OpenFileDialog/utils.js
@@ -72,6 +72,24 @@ export const getTranslatedString = (type, key) => {
             }
             break
         }
+        case 'eventReport': {
+            texts = {
+                modalTitle: i18n.t('Open an event report'),
+                loadingText: i18n.t('Loading event reports'),
+                errorTitle: i18n.t("Couldn't load event reports"),
+                errorText: i18n.t(
+                    'There was a problem loading event reports. Try again or contact your system administrator.'
+                ),
+                noDataText: i18n.t(
+                    'No event reports found. Click New event report to get started.'
+                ),
+                noFilteredDataText: i18n.t(
+                    "No event reports found. Try adjusting your search or filter options to find what you're looking for."
+                ),
+                newButtonLabel: i18n.t('New event report'),
+            }
+            break
+        }
     }
 
     return texts[key]


### PR DESCRIPTION
Partially implements [TECH-704](https://jira.dhis2.org/browse/TECH-704)

---

### Key features

1. add support for ER in FileMenu
2. add support for ER in OpenFileDialog
3. filter only ER AO with `dataType` EVENT (Line list ERs)

---

### Description

The new ER app will use the same generic components from analytics as DV/Maps.
Specifically, the `FileMenu` and the `OpenFileDialog`.
These need to be updated in order to support ER AOs.
In particular, the `OpenFileDialog` for 2.38 need to filter only the Line list ERs (`dataType=EVENT`), and inform the user about the filtering.

---

### Screenshots
<img width="833" alt="Screenshot 2021-10-04 at 09 59 43" src="https://user-images.githubusercontent.com/150978/135814788-e969398e-b2a0-4b06-8de8-4ae631baafe0.png">


