### PR TITLE
fix: use loading state instead of disabling subscribe button

### DIFF
--- a/src/components/AboutAOUnit/AboutAOUnit.js
+++ b/src/components/AboutAOUnit/AboutAOUnit.js
@@ -221,7 +221,7 @@ const AboutAOUnit = ({ type, id }) => {
                                             }
                                             secondary
                                             small
-                                            disabled={unsubscribeIsLoading}
+                                            loading={unsubscribeIsLoading}
                                             onClick={unsubscribe}
                                         >
                                             {i18n.t('Unsubscribe')}
@@ -242,7 +242,7 @@ const AboutAOUnit = ({ type, id }) => {
                                             }
                                             secondary
                                             small
-                                            disabled={subscribeIsLoading}
+                                            loading={subscribeIsLoading}
                                             onClick={subscribe}
                                         >
                                             {i18n.t('Subscribe')}


### PR DESCRIPTION
### Key features

1. use the `ui` buttons `loading` prop while waiting for the subscribe/unsubscribe mutations to complete

### Known issues

-   [ ] on slow connections, after the mutation completes the button returns to its previous look, but its label changes after a while because it's controlled by a different query that is refetched after the mutation completes.
So for a moment, the button does not have the correct label: ie. the user is subscribed but the button still says "Subscribe" until the visualization query comes back with the updated value for `subscribed`.

---

### Screenshots
<img width="161" alt="Screenshot 2021-11-19 at 09 22 47" src="https://user-images.githubusercontent.com/150978/142589910-976263e1-af19-4921-bb44-6d6a3efc5c19.png">