### PR TITLE
fix: dimension without items + filter (TECH-788)

### DIFF
--- a/src/api/analytics/AnalyticsRequest.js
+++ b/src/api/analytics/AnalyticsRequest.js
@@ -57,7 +57,7 @@ class AnalyticsRequest extends AnalyticsRequestDimensionsMixin(
 
             request = request.addDimension(
                 dimension,
-                d.items.map(item => item.id)
+                d.items?.map(item => item.id)
             )
         })
 
@@ -72,11 +72,11 @@ class AnalyticsRequest extends AnalyticsRequestDimensionsMixin(
                 passFilterAsDimension && fixedIds.includes(f.dimension)
                     ? request.addDimension(
                           f.dimension,
-                          f.items.map(item => item.id)
+                          f.items?.map(item => item.id)
                       )
                     : request.addFilter(
                           f.dimension,
-                          f.items.map(item => item.id)
+                          f.items?.map(item => item.id)
                       )
         })
 

--- a/src/api/analytics/AnalyticsRequestDimensionsMixin.js
+++ b/src/api/analytics/AnalyticsRequestDimensionsMixin.js
@@ -116,10 +116,13 @@ const AnalyticsRequestDimensionsMixin = base =>
             if (existingDimension) {
                 this.dimensions.splice(dimensionIndex, 1, {
                     dimension,
-                    items: updatedItems,
+                    ...(items && { items: updatedItems }),
                 })
             } else {
-                this.dimensions.push({ dimension, items: updatedItems })
+                this.dimensions.push({
+                    dimension,
+                    ...(items && { items: updatedItems }),
+                })
             }
 
             return new AnalyticsRequest(this)

--- a/src/api/analytics/__tests__/AnalyticsRequest.spec.js
+++ b/src/api/analytics/__tests__/AnalyticsRequest.spec.js
@@ -158,7 +158,7 @@ describe('AnalyticsRequest', () => {
                 request.addDimension('Jtf34kNZhzP')
 
                 expect(request.dimensions).toEqual([
-                    { dimension: 'Jtf34kNZhzP', items: [] },
+                    { dimension: 'Jtf34kNZhzP' },
                 ])
             })
 

--- a/src/modules/layout/dimension.js
+++ b/src/modules/layout/dimension.js
@@ -23,4 +23,15 @@ export const DIMENSION_PROP_ITEMS = {
     isValid: prop => Array.isArray(prop),
 }
 
-export const DIMENSION_PROPS = [DIMENSION_PROP_ID, DIMENSION_PROP_ITEMS]
+export const DIMENSION_PROP_FILTER = {
+    name: 'filter',
+    defaultValue: [],
+    required: false,
+    isValid: prop => isString(prop),
+}
+
+export const DIMENSION_PROPS = [
+    DIMENSION_PROP_ID,
+    DIMENSION_PROP_ITEMS,
+    DIMENSION_PROP_FILTER,
+]

--- a/src/modules/layout/dimensionCreate.js
+++ b/src/modules/layout/dimensionCreate.js
@@ -1,6 +1,16 @@
-import { DIMENSION_PROP_ID, DIMENSION_PROP_ITEMS } from './dimension'
+import {
+    DIMENSION_PROP_ID,
+    DIMENSION_PROP_ITEMS,
+    DIMENSION_PROP_FILTER,
+} from './dimension'
 
-export const dimensionCreate = (dimensionId, itemIds = []) => ({
-    [DIMENSION_PROP_ID.name]: dimensionId,
-    [DIMENSION_PROP_ITEMS.name]: itemIds.map(id => ({ id })),
-})
+export const dimensionCreate = (dimensionId, itemIds = [], args = {}) => {
+    const dimension = {
+        [DIMENSION_PROP_ID.name]: dimensionId,
+        ...(itemIds.length && {
+            [DIMENSION_PROP_ITEMS.name]: itemIds.map(id => ({ id })),
+        }),
+        ...(args.filter && { [DIMENSION_PROP_FILTER.name]: args.filter }),
+    }
+    return dimension
+}


### PR DESCRIPTION
Implements [TECH-788](https://jira.dhis2.org/browse/TECH-788)

**Relates to https://github.com/dhis2/event-reports-app/pull/875/**

---

### Key features

1. Allow `dimensions` without `items`
2. Support `filter` as arg for `dimensions`

_More info in the ER PR_

