### PR TITLE
fix: disable org unit levels and groups with user org units

### DIFF
--- a/src/components/OrgUnitDimension/OrgUnitDimension.js
+++ b/src/components/OrgUnitDimension/OrgUnitDimension.js
@@ -41,12 +41,7 @@ const OrgUnitDimension = ({ roots, selected, onSelect }) => {
 
         if (checked && DYNAMIC_ORG_UNITS.includes(id)) {
             result = [
-                ...result.filter(
-                    item =>
-                        DYNAMIC_ORG_UNITS.includes(item.id) ||
-                        ouIdHelper.hasLevelPrefix(item.id) ||
-                        ouIdHelper.hasGroupPrefix(item.id)
-                ),
+                ...result.filter(item => DYNAMIC_ORG_UNITS.includes(item.id)),
                 { id, displayName },
             ]
         } else if (checked) {
@@ -261,7 +256,13 @@ const OrgUnitDimension = ({ roots, selected, onSelect }) => {
                     dataTest={'org-unit-tree'}
                 />
             </div>
-            <div className="selectsWrapper">
+            <div
+                className={cx('selectsWrapper', {
+                    disabled: selected.some(item =>
+                        DYNAMIC_ORG_UNITS.includes(item.id)
+                    ),
+                })}
+            >
                 <MultiSelect
                     selected={
                         ouLevels.length


### PR DESCRIPTION
### Key features

1. Disable org unit levels and groups with user org units

---

### Description

This used to be disabled (2.37 and down), but was enabled now that the new org unit tree is being used. However it turns out this feature has too many edge-cases that needs to be addressed (especially re the generated vis title), so we're disabling it again for now.

