### PR TITLE
fix: include legendset in the analytics request (TECH-788)

### DIFF
--- a/src/api/analytics/AnalyticsRequest.js
+++ b/src/api/analytics/AnalyticsRequest.js
@@ -51,6 +51,10 @@ class AnalyticsRequest extends AnalyticsRequestDimensionsMixin(
         columns.concat(rows).forEach(d => {
             let dimension = d.dimension
 
+            if (d.legendSet?.id) {
+                dimension += `-${d.legendSet.id}`
+            }
+
             if (d.filter) {
                 dimension += `:${d.filter}`
             }


### PR DESCRIPTION
Implements [TECH-788](https://jira.dhis2.org/browse/TECH-788)

---

### Key features

1. Append legendSet id to the dimension if present

---

### Description

The legendSet id required by the backend to be part of the request as `DIMENSION-LEGENDSETID`, when legendsets (rangesets) are being used.