### PR TITLE
fix: fetch translations for field labels from api TECH-873

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2021-12-10T13:58:09.736Z\n"
-"PO-Revision-Date: 2021-12-10T13:58:09.736Z\n"
+"POT-Creation-Date: 2022-01-03T11:09:02.270Z\n"
+"PO-Revision-Date: 2022-01-03T11:09:02.270Z\n"
 
 msgid "view only"
 msgstr "view only"
@@ -726,6 +726,9 @@ msgstr "Translate: {{objectName}}"
 
 msgid "Save translations"
 msgstr "Save translations"
+
+msgid "Could not load translations"
+msgstr "Could not load translations"
 
 msgid "Retry"
 msgstr "Retry"

--- a/src/components/TranslationDialog/TranslationModal/TranslationForm.js
+++ b/src/components/TranslationDialog/TranslationModal/TranslationForm.js
@@ -29,18 +29,9 @@ export const TranslationForm = ({
 }) => {
     const [newTranslations, setNewTranslations] = useState()
     const [translationLocale, setTranslationLocale] = useState()
+    const [fieldsTranslations, setFieldsTranslations] = useState({})
 
     const { show: showError } = useAlert((error) => error, { critical: true })
-
-    const formatFieldLabel = (field) => {
-        field
-            .replace(/[a-z][A-Z]/g, (match) =>
-                [match.charAt(0), match.charAt(1)].join(' ')
-            )
-            .toLowerCase()
-
-        return field.charAt(0).toUpperCase() + field.slice(1)
-    }
 
     const camelCaseToUnderscores = (field) =>
         field
@@ -82,6 +73,18 @@ export const TranslationForm = ({
         )
     }
 
+    const [fetchFieldsTranslations] = useDataMutation(
+        {
+            resource: 'i18n',
+            type: 'create',
+            data: fieldsToTranslate.map(camelCaseToUnderscores),
+        },
+        {
+            onComplete: (res) => setFieldsTranslations(res),
+            onError: (error) => showError(error),
+        }
+    )
+
     const translationsMutationRef = useRef({
         resource: `${resource}/translations`,
         type: 'update',
@@ -95,9 +98,7 @@ export const TranslationForm = ({
                 onTranslationSaved()
                 onClose()
             },
-            onError: (error) => {
-                showError(error)
-            },
+            onError: (error) => showError(error),
         }
     )
 
@@ -122,6 +123,13 @@ export const TranslationForm = ({
         []
     )
 
+    useEffect(() => {
+        const fetchTranslations = () =>
+            fetchFieldsTranslations(fieldsToTranslate)
+
+        fetchTranslations()
+    }, [fieldsToTranslate])
+
     useEffect(() => setNewTranslations(translations), [translations])
 
     return (
@@ -145,30 +153,26 @@ export const TranslationForm = ({
                         {fieldsToTranslate.map((field, index) => (
                             <DataTableRow key={field}>
                                 <DataTableCell>
-                                    <div className="">
-                                        <InputField
-                                            label={formatFieldLabel(field)}
-                                            value={objectToTranslate[field]}
-                                            readOnly
-                                        />
-                                    </div>
+                                    <InputField
+                                        label={fieldsTranslations[field]}
+                                        value={objectToTranslate[field]}
+                                        readOnly
+                                    />
                                 </DataTableCell>
                                 {translationLocale && (
                                     <DataTableCell>
-                                        <div className="">
-                                            <InputField
-                                                label={formatFieldLabel(field)}
-                                                value={getTranslationForField(
-                                                    field
-                                                )}
-                                                onChange={({ value }) =>
-                                                    setTranslationForField(
-                                                        field,
-                                                        value
-                                                    )
-                                                }
-                                            />
-                                        </div>
+                                        <InputField
+                                            label={fieldsTranslations[field]}
+                                            value={getTranslationForField(
+                                                field
+                                            )}
+                                            onChange={({ value }) =>
+                                                setTranslationForField(
+                                                    field,
+                                                    value
+                                                )
+                                            }
+                                        />
                                     </DataTableCell>
                                 )}
                                 {!translationLocale && index === 0 && (


### PR DESCRIPTION
Fix for [TECH-873](https://jira.dhis2.org/browse/TECH-873)

See issue described in https://github.com/dhis2/analytics/pull/1105.

### Key features

1. Fetch translations for the labels of the input fields

---

### Description

Use the `api/i18n` endpoint to request the translations for the fields passed to `fieldsToTranslate` and used as labels of the input fields in the form.

The translation keys can be fetched from the schema, but it's not
possible to filter only the required properties, so instead, transform the
field name to the format used for the translation keys, see `fieldName` and `i18nTranslationKey` in the schemas.