### PR TITLE
fix: hide empty categories with non-available data DHIS2-8174 v35

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/getTrimmedConfig.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/getTrimmedConfig.js
@@ -18,8 +18,10 @@ function getEmptySeriesIndexes(series) {
     series[0].data.forEach((value, index) => {
         seriesValues = []
 
-        series.forEach(seriesObj => {
-            seriesValues.push(seriesObj.data[index])
+        series.forEach(({ data }) => {
+            // handle undefined values due to empty (or shorter) serie data
+            // preserve 0 as valid value
+            seriesValues.push(data[index] === undefined ? null : data[index])
         })
 
         if (arrayNullsOnly(seriesValues)) {


### PR DESCRIPTION
Fixes [DHIS2-8174](https://jira.dhis2.org/browse/DHIS2-8174)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/XXX**

---

### Key features

1. backport for v35

---

### Description

The bug caused the hide empty categories option in DV to not work when
one or more of the dx dimensions had no data (ie. empty array in the
response from analytics).

Empty data caused undefined values to be added to the list checked for
all null values; with this check failing, the index in the category list
was never added to the list of empty category indexes, thus the chart
was not "filtered".

(cherry picked from commit 5703a570ecbf31c27cbe0a2b327723fcb4d3e231)
