### PR TITLE
fix: use stage id as prefix for dimensions

### DIFF
--- a/src/api/analytics/AnalyticsRequest.js
+++ b/src/api/analytics/AnalyticsRequest.js
@@ -55,6 +55,11 @@ class AnalyticsRequest extends AnalyticsRequestDimensionsMixin(
                 dimension += `-${d.legendSet.id}`
             }
 
+            // needed for ER ENROLLMENT
+            if (d.programStage?.id) {
+                dimension = `${d.programStage.id}.${dimension}`
+            }
+
             if (d.filter) {
                 dimension += `:${d.filter}`
             }

--- a/src/api/analytics/AnalyticsRequest.js
+++ b/src/api/analytics/AnalyticsRequest.js
@@ -55,7 +55,6 @@ class AnalyticsRequest extends AnalyticsRequestDimensionsMixin(
                 dimension += `-${d.legendSet.id}`
             }
 
-            // needed for ER ENROLLMENT
             if (d.programStage?.id) {
                 dimension = `${d.programStage.id}.${dimension}`
             }


### PR DESCRIPTION
### Key features

1. use stage id prefix in dimensions

---

### Description

For ER we need to prefix the dimension id with the stage id in the analytics request.