### PR TITLE
feat: program stage prefix in layout

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-01-20T10:46:04.306Z\n"
-"PO-Revision-Date: 2022-01-20T10:46:04.306Z\n"
+"POT-Creation-Date: 2022-02-17T07:42:12.523Z\n"
+"PO-Revision-Date: 2022-02-17T07:42:12.523Z\n"
 
 msgid "view only"
 msgstr "view only"
@@ -367,35 +367,6 @@ msgstr ""
 
 msgid "New map"
 msgstr "New map"
-
-msgid "Open an event visualization"
-msgstr "Open an event visualization"
-
-msgid "Loading event visualizations"
-msgstr "Loading event visualizations"
-
-msgid "Couldn't load event visualizations"
-msgstr "Couldn't load event visualizations"
-
-msgid ""
-"There was a problem loading event visualizations. Try again or contact your "
-"system administrator."
-msgstr ""
-"There was a problem loading event visualizations. Try again or contact your "
-"system administrator."
-
-msgid "No event visualizations found. Click New event visualization to get started."
-msgstr "No event visualizations found. Click New event visualization to get started."
-
-msgid ""
-"No event visualizations found. Try adjusting your search or filter options "
-"to find what you're looking for."
-msgstr ""
-"No event visualizations found. Try adjusting your search or filter options "
-"to find what you're looking for."
-
-msgid "New event visualization"
-msgstr "New event visualization"
 
 msgid "Open an event visualization"
 msgstr "Open an event visualization"
@@ -963,11 +934,11 @@ msgstr "Assigned Categories"
 msgid "Pivot table"
 msgstr "Pivot table"
 
-msgid "Column"
-msgstr "Column"
+msgid "Area"
+msgstr "Area"
 
-msgid "Stacked column"
-msgstr "Stacked column"
+msgid "Stacked area"
+msgstr "Stacked area"
 
 msgid "Bar"
 msgstr "Bar"
@@ -975,14 +946,26 @@ msgstr "Bar"
 msgid "Stacked bar"
 msgstr "Stacked bar"
 
+msgid "Column"
+msgstr "Column"
+
+msgid "Year over year (column)"
+msgstr "Year over year (column)"
+
+msgid "Stacked column"
+msgstr "Stacked column"
+
+msgid "Gauge"
+msgstr "Gauge"
+
 msgid "Line"
 msgstr "Line"
 
-msgid "Area"
-msgstr "Area"
+msgid "Line list"
+msgstr "Line list"
 
-msgid "Stacked area"
-msgstr "Stacked area"
+msgid "Year over year (line)"
+msgstr "Year over year (line)"
 
 msgid "Pie"
 msgstr "Pie"
@@ -990,23 +973,11 @@ msgstr "Pie"
 msgid "Radar"
 msgstr "Radar"
 
-msgid "Gauge"
-msgstr "Gauge"
-
-msgid "Year over year (line)"
-msgstr "Year over year (line)"
-
-msgid "Year over year (column)"
-msgstr "Year over year (column)"
-
-msgid "Single value"
-msgstr "Single value"
-
 msgid "Scatter"
 msgstr "Scatter"
 
-msgid "Line list"
-msgstr "Line list"
+msgid "Single value"
+msgstr "Single value"
 
 msgid "All charts"
 msgstr "All charts"

--- a/src/modules/layout/dimensionGetId.js
+++ b/src/modules/layout/dimensionGetId.js
@@ -1,3 +1,8 @@
-import { DIMENSION_PROP_ID } from './dimension.js'
+import { DIMENSION_PROP_ID, DIMENSION_PROP_PROGRAM_STAGE } from './dimension.js'
 
-export const dimensionGetId = (dimension) => dimension[DIMENSION_PROP_ID.name]
+export const dimensionGetId = (dimension) =>
+    dimension[DIMENSION_PROP_PROGRAM_STAGE.name]?.id
+        ? `${dimension[DIMENSION_PROP_PROGRAM_STAGE.name].id}.${
+              dimension[DIMENSION_PROP_ID.name]
+          }`
+        : dimension[DIMENSION_PROP_ID.name]


### PR DESCRIPTION
### Key features

1. prefixes dimension id with program stage id when required

---

### Description

In the app's Redux store we use the prefixed dimension id for dimensions that have a `programStage` object set.
This PR is making sure that when the layout is generated from a AO, the program stage id is prefixed to the dimension id.

---

### Screenshots

Before:
<img width="491" alt="Screenshot 2022-02-17 at 11 09 59" src="https://user-images.githubusercontent.com/150978/154453992-52b9aa18-e7a0-4a99-a42f-94e82e8bf35d.png">

After:
<img width="482" alt="Screenshot 2022-02-17 at 10 59 39" src="https://user-images.githubusercontent.com/150978/154454022-8e03fef5-3078-46f7-9872-166417e5f46b.png">
