### PR TITLE
feat: disable Save button when onSave not passed (TECH-1013)

### DIFF
--- a/src/components/FileMenu/FileMenu.js
+++ b/src/components/FileMenu/FileMenu.js
@@ -193,14 +193,18 @@ export const FileMenu = ({
                                 icon={
                                     <IconSave24
                                         color={
-                                            !fileObject?.id ||
-                                            fileObject?.access?.update
-                                                ? iconActiveColor
-                                                : iconInactiveColor
+                                            !onSave ||
+                                            !(
+                                                !fileObject?.id ||
+                                                fileObject?.access?.update
+                                            )
+                                                ? iconInactiveColor
+                                                : iconActiveColor
                                         }
                                     />
                                 }
                                 disabled={
+                                    !onSave ||
                                     !(
                                         !fileObject?.id ||
                                         fileObject?.access?.update
@@ -348,7 +352,6 @@ FileMenu.defaultProps = {
     onNew: Function.prototype,
     onOpen: Function.prototype,
     onRename: Function.prototype,
-    onSave: Function.prototype,
     onSaveAs: Function.prototype,
     onTranslate: Function.prototype,
 }


### PR DESCRIPTION
Required for  [TECH-1013](https://jira.dhis2.org/browse/TECH-1013)

**Relates to https://github.com/dhis2/event-reports-app/pull/XXX**

---

### Key features

1. disable `Save` button when `onSave` prop is not passed

---

### Description

We need a way of disabling the `Save` button in certain situations, for example for legacy AO loaded in the new ER app.
The logic should be in the consumer app.
The idea is to leverage the `onSave` prop and use it to enable/disable the
`Save` button, if the callback is not passed disable the `Save` button.

---

### Screenshots

<img width="987" alt="Screenshot 2022-03-02 at 12 41 25" src="https://user-images.githubusercontent.com/150978/156355273-5fcf5861-f2af-419f-ac13-9322bac0e83b.png">

