### PR TITLE
fix(OpenFileDialog): rename event visualization to line list

### DIFF
--- a/src/components/OpenFileDialog/utils.js
+++ b/src/components/OpenFileDialog/utils.js
@@ -62,19 +62,19 @@ const texts = {
         newButtonLabel: i18n.t('New map'),
     },
     [AO_TYPE_EVENT_VISUALIZATION]: {
-        modalTitle: i18n.t('Open an event visualization'),
-        loadingText: i18n.t('Loading event visualizations'),
-        errorTitle: i18n.t("Couldn't load event visualizations"),
+        modalTitle: i18n.t('Open a line list'),
+        loadingText: i18n.t('Loading line lists'),
+        errorTitle: i18n.t("Couldn't load line lists"),
         errorText: i18n.t(
-            'There was a problem loading event visualizations. Try again or contact your system administrator.'
+            'There was a problem loading line lists. Try again or contact your system administrator.'
         ),
         noDataText: i18n.t(
-            'No event visualizations found. Click New event visualization to get started.'
+            'No line lists found. Click New line list to get started.'
         ),
         noFilteredDataText: i18n.t(
-            "No event visualizations found. Try adjusting your search or filter options to find what you're looking for."
+            "No line lists found. Try adjusting your search or filter options to find what you're looking for."
         ),
-        newButtonLabel: i18n.t('New event visualization'),
+        newButtonLabel: i18n.t('New line list'),
     },
 }
 


### PR DESCRIPTION
### Key features

1. Rename `event visualization` to `line list`

---

### Description

For the new Line Listing app we only filter Line List AO types and all the texts in the OpenFileDialog should use `line list` instead of `event visualization`.

---

### Screenshots

Before:
<img width="815" alt="Screenshot 2022-03-16 at 14 32 05" src="https://user-images.githubusercontent.com/150978/158601217-733c0574-b5fe-47e4-bb53-12207a674f79.png">


After:
<img width="813" alt="Screenshot 2022-03-16 at 14 20 21" src="https://user-images.githubusercontent.com/150978/158599018-7276810d-863a-44a3-b2c5-3cc29fae9934.png">

