### PR TITLE
fix: get stage id and filter string for filters just like for columns and rows

### DIFF
--- a/src/api/analytics/AnalyticsRequest.js
+++ b/src/api/analytics/AnalyticsRequest.js
@@ -84,16 +84,25 @@ class AnalyticsRequest extends AnalyticsRequestDimensionsMixin(
         const fixedIds = Object.keys(getFixedDimensions())
 
         filters.forEach((f) => {
-            request =
-                passFilterAsDimension && fixedIds.includes(f.dimension)
-                    ? request.addDimension(
-                          f.dimension,
-                          f.items?.map((item) => item.id)
-                      )
-                    : request.addFilter(
-                          f.dimension,
-                          f.items?.map((item) => item.id)
-                      )
+            if (passFilterAsDimension && fixedIds.includes(f.dimension)) {
+                request = request.addDimension(
+                    f.dimension,
+                    f.items?.map((item) => item.id)
+                )
+            } else {
+                let filterString = f.programStage?.id
+                    ? `${f.programStage.id}.${f.dimension}`
+                    : f.dimension
+
+                if (f.filter) {
+                    filterString += `:${f.filter}`
+                }
+
+                request = request.addFilter(
+                    filterString,
+                    f.items?.map((item) => item.id)
+                )
+            }
         })
 
         return request


### PR DESCRIPTION
Implements [TECH-1063](https://dhis2.atlassian.net/browse/TECH-1063)


### Key features

1. The filter values and stage id were missing from the filters property of the visualization analytics request

### Screenshots

![image](https://user-images.githubusercontent.com/6113918/160862778-6559848a-e8b7-4bf2-99c0-3c06f7815326.png)


https://user-images.githubusercontent.com/6113918/160862729-4033cae7-3566-45e1-b8a3-0be5a927f74b.mov


