### PR TITLE
fix: avoid dialog jumping when searching/paging TECH-1064

### DIFF
--- a/src/components/OpenFileDialog/OpenFileDialog.js
+++ b/src/components/OpenFileDialog/OpenFileDialog.js
@@ -11,7 +11,6 @@ import {
     DataTableRow,
     DataTableCell,
     DataTableColumnHeader,
-    DataTableToolbar,
     NoticeBox,
     CircularLoader,
     Button,

--- a/src/components/OpenFileDialog/OpenFileDialog.js
+++ b/src/components/OpenFileDialog/OpenFileDialog.js
@@ -194,7 +194,7 @@ export const OpenFileDialog = ({
     return (
         <Modal
             large
-            position="middle"
+            position="top"
             hide={!open}
             onClose={onClose}
             dataTest={cypressSelector}
@@ -264,134 +264,143 @@ export const OpenFileDialog = ({
                         </NoticeBox>
                     ) : (
                         <>
-                            <DataTable layout="fixed">
-                                <DataTableHead>
-                                    <DataTableRow>
-                                        {data?.files[
-                                            AOTypeMap[type].apiEndpoint
-                                        ].length ? (
-                                            headers.map(
-                                                ({ field, label, width }) => (
-                                                    <DataTableColumnHeader
-                                                        width={width}
-                                                        key={field}
-                                                        name={field}
-                                                        onSortIconClick={({
-                                                            name,
-                                                            direction,
-                                                        }) =>
-                                                            setSorting({
-                                                                sortField: name,
-                                                                sortDirection:
-                                                                    direction,
-                                                            })
-                                                        }
-                                                        sortDirection={getSortDirection(
-                                                            field
-                                                        )}
-                                                    >
-                                                        {label}
-                                                    </DataTableColumnHeader>
-                                                )
-                                            )
-                                        ) : (
-                                            <DataTableColumnHeader />
-                                        )}
-                                    </DataTableRow>
-                                </DataTableHead>
-                                <DataTableBody className="data-table-body">
-                                    {loading && (
+                            <div className="data-table-wrapper">
+                                <DataTable layout="fixed">
+                                    <DataTableHead>
                                         <DataTableRow>
-                                            <DataTableCell large>
-                                                <Box height="384px">
-                                                    <div className="info-cell">
-                                                        <CircularLoader small />
-                                                        <span className="info-text">
-                                                            {getTranslatedString(
-                                                                type,
-                                                                'loadingText'
+                                            {data?.files[
+                                                AOTypeMap[type].apiEndpoint
+                                            ].length ? (
+                                                headers.map(
+                                                    ({
+                                                        field,
+                                                        label,
+                                                        width,
+                                                    }) => (
+                                                        <DataTableColumnHeader
+                                                            width={width}
+                                                            key={field}
+                                                            name={field}
+                                                            onSortIconClick={({
+                                                                name,
+                                                                direction,
+                                                            }) =>
+                                                                setSorting({
+                                                                    sortField:
+                                                                        name,
+                                                                    sortDirection:
+                                                                        direction,
+                                                                })
+                                                            }
+                                                            sortDirection={getSortDirection(
+                                                                field
                                                             )}
-                                                        </span>
-                                                    </div>
-                                                </Box>
-                                            </DataTableCell>
+                                                        >
+                                                            {label}
+                                                        </DataTableColumnHeader>
+                                                    )
+                                                )
+                                            ) : (
+                                                <DataTableColumnHeader />
+                                            )}
                                         </DataTableRow>
-                                    )}
-                                    {!loading &&
-                                        !data?.files[
-                                            AOTypeMap[type].apiEndpoint
-                                        ].length > 0 && (
+                                    </DataTableHead>
+                                    <DataTableBody className="data-table-body">
+                                        {loading && (
                                             <DataTableRow>
                                                 <DataTableCell large>
-                                                    <Box minHeight="384px">
+                                                    <Box height="342px">
                                                         <div className="info-cell">
-                                                            <div className="info-container">
-                                                                {!isEqual(
-                                                                    filters,
-                                                                    defaultFilters
-                                                                ) ? (
-                                                                    <span className="info-text">
-                                                                        {getTranslatedString(
-                                                                            type,
-                                                                            'noFilteredDataText'
-                                                                        )}
-                                                                    </span>
-                                                                ) : (
-                                                                    <>
-                                                                        <div className="info-text">
-                                                                            {getTranslatedString(
-                                                                                type,
-                                                                                'noDataText'
-                                                                            )}
-                                                                        </div>
-                                                                        <div className="info-button">
-                                                                            <Button
-                                                                                onClick={() => {
-                                                                                    onNew()
-                                                                                    onClose()
-                                                                                }}
-                                                                            >
-                                                                                {getTranslatedString(
-                                                                                    type,
-                                                                                    'newButtonLabel'
-                                                                                )}
-                                                                            </Button>
-                                                                        </div>
-                                                                    </>
+                                                            <CircularLoader
+                                                                small
+                                                            />
+                                                            <span className="info-text">
+                                                                {getTranslatedString(
+                                                                    type,
+                                                                    'loadingText'
                                                                 )}
-                                                            </div>
+                                                            </span>
                                                         </div>
                                                     </Box>
                                                 </DataTableCell>
                                             </DataTableRow>
                                         )}
-                                    {data?.files[AOTypeMap[type].apiEndpoint]
-                                        .length > 0 && (
-                                        <FileList
-                                            data={
-                                                data.files[
-                                                    AOTypeMap[type].apiEndpoint
-                                                ]
-                                            }
-                                            onSelect={onFileSelect}
-                                            showVisTypeColumn={Boolean(
-                                                filterVisTypes?.length
+                                        {!loading &&
+                                            !data?.files[
+                                                AOTypeMap[type].apiEndpoint
+                                            ].length > 0 && (
+                                                <DataTableRow>
+                                                    <DataTableCell large>
+                                                        <Box minHeight="342px">
+                                                            <div className="info-cell">
+                                                                <div className="info-container">
+                                                                    {!isEqual(
+                                                                        filters,
+                                                                        defaultFilters
+                                                                    ) ? (
+                                                                        <span className="info-text">
+                                                                            {getTranslatedString(
+                                                                                type,
+                                                                                'noFilteredDataText'
+                                                                            )}
+                                                                        </span>
+                                                                    ) : (
+                                                                        <>
+                                                                            <div className="info-text">
+                                                                                {getTranslatedString(
+                                                                                    type,
+                                                                                    'noDataText'
+                                                                                )}
+                                                                            </div>
+                                                                            <div className="info-button">
+                                                                                <Button
+                                                                                    onClick={() => {
+                                                                                        onNew()
+                                                                                        onClose()
+                                                                                    }}
+                                                                                >
+                                                                                    {getTranslatedString(
+                                                                                        type,
+                                                                                        'newButtonLabel'
+                                                                                    )}
+                                                                                </Button>
+                                                                            </div>
+                                                                        </>
+                                                                    )}
+                                                                </div>
+                                                            </div>
+                                                        </Box>
+                                                    </DataTableCell>
+                                                </DataTableRow>
                                             )}
-                                        />
-                                    )}
-                                </DataTableBody>
-                            </DataTable>
+                                        {data?.files[
+                                            AOTypeMap[type].apiEndpoint
+                                        ].length > 0 && (
+                                            <FileList
+                                                data={
+                                                    data.files[
+                                                        AOTypeMap[type]
+                                                            .apiEndpoint
+                                                    ]
+                                                }
+                                                onSelect={onFileSelect}
+                                                showVisTypeColumn={Boolean(
+                                                    filterVisTypes?.length
+                                                )}
+                                            />
+                                        )}
+                                    </DataTableBody>
+                                </DataTable>
+                            </div>
                             {data?.files[AOTypeMap[type].apiEndpoint].length >
                                 0 && (
-                                <DataTableToolbar position="bottom">
-                                    <div className="pagination-controls">
-                                        <PaginationControls
-                                            page={page}
-                                            pager={data.files.pager}
-                                            onPageChange={setPage}
-                                        />
-                                    </div>
-                                </DataTableToolbar>
+                                <div className="pagination-controls">
+                                    <PaginationControls
+                                        page={page}
+                                        pager={data.files.pager}
+                                        onPageChange={setPage}
+                                    />
+                                </div>
                             )}
                         </>
                     )}

--- a/src/components/OpenFileDialog/OpenFileDialog.styles.js
+++ b/src/components/OpenFileDialog/OpenFileDialog.styles.js
@@ -2,12 +2,17 @@ import { colors, spacers } from '@dhis2/ui'
 import css from 'styled-jsx/css'
 
 export const styles = css`
+    .data-table-wrapper {
+        min-height: 405px;
+    }
+
     .data-table-body {
         min-height: 465px;
     }
 
     .pagination-controls {
         width: 100%;
+        margin-top: ${spacers.dp12};
         display: flex;
         justify-content: flex-end;
     }
@@ -32,6 +37,7 @@ export const styles = css`
         display: flex;
         align-items: center;
         justify-content: center;
+        gap: ${spacers.dp8};
         margin: ${spacers.dp32} 0;
     }
 


### PR DESCRIPTION
Implements [TECH-1064](https://dhis2.atlassian.net/browse/TECH-1064)

---

### Key features

1. Use fix height for the dialog to avoid jumping when searching or paging
2. open dialog at the top
3. add spacing between the loading spinner and the text

---

### Description

There can be some jumping when the text in some rows spans on multiple lines.
This is not possible to predict accurately.

The `DataTableToolbar` component has been removed to avoid a missing top border above the `Pagination` component.
The issue is visible if the number of rows is less than the maximum per page, since there is a space between the `DataTable` and the `Pagination` components.

---

### Screenshots
<img width="811" alt="Screenshot 2022-03-31 at 15 48 41" src="https://user-images.githubusercontent.com/150978/161071565-b8ccddad-efe9-4f6a-8675-a09b3acbb889.png">
<img width="813" alt="Screenshot 2022-03-31 at 15 48 21" src="https://user-images.githubusercontent.com/150978/161071580-2fdaea2e-2bd0-42a7-8bad-b420a477fad5.png">
<img width="806" alt="Screenshot 2022-03-31 at 15 55 10" src="https://user-images.githubusercontent.com/150978/161072153-fd99441f-00c6-4560-b67c-416e5f8a9119.png">


