### PR TITLE
fix: filter on displayName to get objects in current language DHIS2-13015 20.x

### DIFF
--- a/src/components/OpenFileDialog/OpenFileDialog.js
+++ b/src/components/OpenFileDialog/OpenFileDialog.js
@@ -116,7 +116,7 @@ export const OpenFileDialog = ({
         }
 
         if (filters.searchTerm) {
-            queryFilters.push(`name:ilike:${filters.searchTerm}`)
+            queryFilters.push(`displayName:ilike:${filters.searchTerm}`)
         }
 
         // for ER 2.38 only show line list ER types


### PR DESCRIPTION
Backport of the fix that partially resolves [DHIS2-13015](https://dhis2.atlassian.net/browse/DHIS2-13015)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/**

---

### Key features

1. use `displayName` instead of `name` when searching visualizations

---

### Description

This gives results in the current user's language.

---

### Screenshots

Before:
<img width="635" alt="Screenshot 2022-04-04 at 16 10 50" src="https://user-images.githubusercontent.com/150978/161562425-c85e0cc1-6f30-48f5-9869-8c1ca8603d8b.png">
<img width="810" alt="Screenshot 2022-04-04 at 16 11 14" src="https://user-images.githubusercontent.com/150978/161562482-92a6fbef-da47-440b-908f-dc2c802903e8.png">


After:
<img width="628" alt="Screenshot 2022-04-04 at 16 09 37" src="https://user-images.githubusercontent.com/150978/161562208-30ed6287-6426-420e-a6eb-378f63d26a69.png">
<img width="800" alt="Screenshot 2022-04-04 at 16 11 33" src="https://user-images.githubusercontent.com/150978/161562543-5722eb03-72b0-4b70-98a1-1eac29bd8c3a.png">

