### PR TITLE
fix: max size on name field TECH-1079

### DIFF
--- a/src/components/FileMenu/SaveAsDialog.js
+++ b/src/components/FileMenu/SaveAsDialog.js
@@ -41,6 +41,7 @@ export const SaveAsDialog = ({ type, object, onClose, onSaveAs }) => {
                     value={name}
                     onChange={({ value }) => setName(value)}
                     dataTest="file-menu-saveas-modal-name"
+                    max="230"
                 />
                 <TextAreaField
                     label={i18n.t('Description')}

--- a/src/components/FileMenu/SaveAsDialog.js
+++ b/src/components/FileMenu/SaveAsDialog.js
@@ -13,6 +13,8 @@ import React, { useState } from 'react'
 import i18n from '../../locales/index.js'
 import { supportedFileTypes, labelForFileType } from './utils.js'
 
+const NAME_MAXLENGTH = 230
+
 export const SaveAsDialog = ({ type, object, onClose, onSaveAs }) => {
     const [name, setName] = useState(object?.name)
     const [description, setDescription] = useState(object?.description)
@@ -39,9 +41,10 @@ export const SaveAsDialog = ({ type, object, onClose, onSaveAs }) => {
                     label={i18n.t('Name')}
                     required
                     value={name}
-                    onChange={({ value }) => setName(value)}
+                    onChange={({ value }) =>
+                        setName(value.substring(0, NAME_MAXLENGTH))
+                    }
                     dataTest="file-menu-saveas-modal-name"
-                    max="230"
                 />
                 <TextAreaField
                     label={i18n.t('Description')}

--- a/src/components/TranslationDialog/TranslationModal/TranslationForm.js
+++ b/src/components/TranslationDialog/TranslationModal/TranslationForm.js
@@ -8,8 +8,8 @@ import {
     DataTableColumnHeader,
     DataTableHead,
     DataTableRow,
-    InputField,
     ModalContent,
+    TextAreaField,
 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useEffect, useRef, useState } from 'react'
@@ -152,15 +152,16 @@ export const TranslationForm = ({
                         {fieldsToTranslate.map((field, index) => (
                             <DataTableRow key={field}>
                                 <DataTableCell>
-                                    <InputField
+                                    <TextAreaField
                                         label={fieldsTranslations[field]}
                                         value={objectToTranslate[field]}
                                         readOnly
+                                        rows={3}
                                     />
                                 </DataTableCell>
                                 {translationLocale && (
                                     <DataTableCell>
-                                        <InputField
+                                        <TextAreaField
                                             label={fieldsTranslations[field]}
                                             value={getTranslationForField(
                                                 field
@@ -171,6 +172,7 @@ export const TranslationForm = ({
                                                     value
                                                 )
                                             }
+                                            rows={3}
                                         />
                                     </DataTableCell>
                                 )}


### PR DESCRIPTION
Implements [TECH-1079](https://dhis2.atlassian.net/browse/TECH-1079)

---

### Key features

1. truncate at 230 character the value for `name`
2. use textarea in place of input in `TranslationDialog`

---

### Description

The backend has a limit of 230 characters for the `name` field in AO.
Set the same limit in the input field in the Save As dialog.

The translatable fields in the `TranslationDialog` can have various length limits.
Use textareas with 3 rows for better readability and to make it easier to write/edit the text.

---

### Screenshots

Textareas in `TranslationDialog`:

<img width="810" alt="Screenshot 2022-04-11 at 12 23 15" src="https://user-images.githubusercontent.com/150978/162722057-355fb1ae-44a3-4b25-9f4b-13061ec75c80.png">



