### PR TITLE
fix: simplify code and fix double path issue DHIS2-12940

### DIFF
--- a/src/components/FileMenu/GetLinkDialog.js
+++ b/src/components/FileMenu/GetLinkDialog.js
@@ -1,4 +1,3 @@
-import { useConfig } from '@dhis2/app-runtime'
 import {
     Modal,
     ModalContent,
@@ -12,11 +11,9 @@ import i18n from '../../locales/index.js'
 import { supportedFileTypes, appPathFor } from './utils.js'
 
 export const GetLinkDialog = ({ type, id, onClose }) => {
-    const { baseUrl } = useConfig()
-
     // TODO simply use href from the visualization object?
     const appUrl = new URL(
-        `${baseUrl}/${appPathFor(type, id)}`,
+        appPathFor(type, id),
         `${window.location.origin}${window.location.pathname}`
     )
 

--- a/src/components/FileMenu/utils.js
+++ b/src/components/FileMenu/utils.js
@@ -36,6 +36,6 @@ export const appPathFor = (fileType, id) => {
         case FILE_TYPE_MAP:
             return `dhis-web-maps/index.html?id=${id}`
         default:
-            return window.location.href
+            return `${window.location.search}${window.location.hash}`
     }
 }

--- a/src/components/FileMenu/utils.js
+++ b/src/components/FileMenu/utils.js
@@ -36,9 +36,6 @@ export const appPathFor = (fileType, id) => {
         case FILE_TYPE_MAP:
             return `dhis-web-maps/index.html?id=${id}`
         default:
-            // strip origin and the first /
-            return `${window.location.pathname}${window.location.search}${window.location.hash}`.substring(
-                1
-            )
+            return window.location.href
     }
 }


### PR DESCRIPTION
Implements [DHIS2-12940](https://jira.dhis2.org/browse/DHIS2-12940)

---

### Key features

1. fix bug where part of the base URL is repeated twice (ie. https://play.dhis2.org/dev/dev/api/apps/line-listing/index.html#/TIuOzZ0ID0V)

---

### Description

The default returned by `appPathFor` is now the `search` and `hash` portion of `window.location`.
This applies for Line Listing app.