### PR TITLE
fix: set repetition in filter

### DIFF
--- a/src/api/analytics/AnalyticsRequest.js
+++ b/src/api/analytics/AnalyticsRequest.js
@@ -98,10 +98,18 @@ class AnalyticsRequest extends AnalyticsRequestDimensionsMixin(
                     filterString += `:${f.filter}`
                 }
 
-                request = request.addFilter(
-                    filterString,
-                    f.items?.map((item) => item.id)
-                )
+                if (f.repetition?.indexes?.length) {
+                    f.repetition.indexes.forEach((index) => {
+                        request = request.addFilter(
+                            filterString.replace(/\./, `[${index}].`)
+                        )
+                    })
+                } else {
+                    request = request.addFilter(
+                        filterString,
+                        f.items?.map((item) => item.id)
+                    )
+                }
             }
         })
 


### PR DESCRIPTION
Implements [TECH-1131](https://dhis2.atlassian.net/browse/TECH-1131)

1. Sets `repetition` for filters (based on the implementation for `dimensions`)

---

### Known issues
- [ ] using both `recent` and `old` in `Filters` with a `filter` (e.g. https://debug.dhis2.org/tracker_dev/api/apps/line-listing/index.html#/RDg1nZ9uz67) makes the filters act as `AND` instead of `OR`. Backend bug [DHIS2-13160](https://jira.dhis2.org/browse/DHIS2-13160)