### PR TITLE
fix: highcharts legend when exporting (DHIS2-12719)

### DIFF
--- a/src/modules/legends.js
+++ b/src/modules/legends.js
@@ -13,3 +13,20 @@ export const getColorByValueFromLegendSet = (legendSet, value) => {
     const legend = getLegendByValueFromLegendSet(legendSet, value)
     return legend && legend.color
 }
+
+export const getLegendSetByDisplayStrategy = ({
+    displayStrategy,
+    legendSets,
+    legendSetId,
+}) => {
+    if (
+        displayStrategy === LEGEND_DISPLAY_STRATEGY_FIXED &&
+        legendSets.length
+    ) {
+        return legendSets[0]
+    } else if (displayStrategy === LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM) {
+        return legendSets.find((legendSet) => legendSet.id === legendSetId)
+    } else {
+        return null
+    }
+}

--- a/src/visualizations/config/adapters/dhis_highcharts/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/index.js
@@ -1,6 +1,10 @@
 import isString from 'd2-utilizr/lib/isString'
 import objectClean from 'd2-utilizr/lib/objectClean'
 import {
+    defaultFontStyle,
+    FONT_STYLE_OPTION_FONT_SIZE,
+} from '../../../../modules/fontStyle.js'
+import {
     LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM,
     LEGEND_DISPLAY_STRATEGY_FIXED,
 } from '../../../../modules/legends.js'
@@ -101,13 +105,19 @@ export default function ({ store, layout, el, extraConfig, extraOptions }) {
         yAxis: getYAxis(_layout, series, _extraOptions),
 
         // series
-        series: getSeries(
-            series.slice(),
-            store.data[0].metaData,
-            _layout,
-            stacked,
-            _extraOptions
-        ),
+        series: getSeries({
+            series: series.slice(),
+            metaData: store.data[0].metaData.items,
+            layout: _layout,
+            isStacked: stacked,
+            extraOptions: _extraOptions,
+            legendSets,
+            displayStrategy: _layout.legend?.strategy,
+            fontSize:
+                _layout.seriesKey?.label?.fontStyle?.[
+                    FONT_STYLE_OPTION_FONT_SIZE
+                ] || defaultFontStyle.legend[FONT_STYLE_OPTION_FONT_SIZE],
+        }),
 
         // legend
         legend: getLegend({
@@ -115,9 +125,9 @@ export default function ({ store, layout, el, extraConfig, extraOptions }) {
             fontStyle: _layout.seriesKey?.label?.fontStyle,
             visType: _layout.type,
             dashboard: _extraOptions.dashboard,
-            legendSets,
-            metaData: store.data[0].metaData.items,
-            displayStrategy: _layout.legend?.strategy,
+            // legendSets,
+            // metaData: store.data[0].metaData.items,
+            // displayStrategy: _layout.legend?.strategy,
         }),
 
         // pane

--- a/src/visualizations/config/adapters/dhis_highcharts/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/index.js
@@ -117,9 +117,6 @@ export default function ({ store, layout, el, extraConfig, extraOptions }) {
             fontStyle: _layout.seriesKey?.label?.fontStyle,
             visType: _layout.type,
             dashboard: _extraOptions.dashboard,
-            // legendSets,
-            // metaData: store.data[0].metaData.items,
-            // displayStrategy: _layout.legend?.strategy,
         }),
 
         // pane

--- a/src/visualizations/config/adapters/dhis_highcharts/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/index.js
@@ -1,10 +1,6 @@
 import isString from 'd2-utilizr/lib/isString'
 import objectClean from 'd2-utilizr/lib/objectClean'
 import {
-    defaultFontStyle,
-    FONT_STYLE_OPTION_FONT_SIZE,
-} from '../../../../modules/fontStyle.js'
-import {
     LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM,
     LEGEND_DISPLAY_STRATEGY_FIXED,
 } from '../../../../modules/legends.js'
@@ -113,10 +109,6 @@ export default function ({ store, layout, el, extraConfig, extraOptions }) {
             extraOptions: _extraOptions,
             legendSets,
             displayStrategy: _layout.legend?.strategy,
-            fontSize:
-                _layout.seriesKey?.label?.fontStyle?.[
-                    FONT_STYLE_OPTION_FONT_SIZE
-                ] || defaultFontStyle.legend[FONT_STYLE_OPTION_FONT_SIZE],
         }),
 
         // legend

--- a/src/visualizations/config/adapters/dhis_highcharts/legend.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/legend.js
@@ -230,19 +230,19 @@ export default function ({
                   useHTML: true,
                   symbolWidth: 0.001,
                   symbolHeight: 0.001,
-                  labelFormatter: function () {
-                      return formatLabel({
-                          seriesId: this.userOptions?.id,
-                          seriesColor: this.color,
-                          seriesName: this.name,
-                          seriesType: this.userOptions?.type,
-                          metaData,
-                          displayStrategy,
-                          legendSets,
-                          fontStyle: mergedFontStyle,
-                          visType,
-                      })
-                  },
+                  //   labelFormatter: function () {
+                  //       return formatLabel({
+                  //           seriesId: this.userOptions?.id,
+                  //           seriesColor: this.color,
+                  //           seriesName: this.name,
+                  //           seriesType: this.userOptions?.type,
+                  //           metaData,
+                  //           displayStrategy,
+                  //           legendSets,
+                  //           fontStyle: mergedFontStyle,
+                  //           visType,
+                  //       })
+                  //   },
               }
           )
 }

--- a/src/visualizations/config/adapters/dhis_highcharts/legend.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/legend.js
@@ -7,10 +7,7 @@ import {
     FONT_STYLE_LEGEND,
     mergeFontStyleWithDefault,
 } from '../../../../modules/fontStyle.js'
-import {
-    LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM,
-    LEGEND_DISPLAY_STRATEGY_FIXED,
-} from '../../../../modules/legends.js'
+import { getLegendSetByDisplayStrategy } from '../../../../modules/legends.js'
 import {
     isLegendSetType,
     isVerticalType,
@@ -71,23 +68,6 @@ function getLegend(fontStyle, dashboard, visType) {
                   ),
               }
     )
-}
-
-const getLegendSetByDisplayStrategy = ({
-    displayStrategy,
-    legendSets,
-    legendSetId,
-}) => {
-    if (
-        displayStrategy === LEGEND_DISPLAY_STRATEGY_FIXED &&
-        legendSets.length
-    ) {
-        return legendSets[0]
-    } else if (displayStrategy === LEGEND_DISPLAY_STRATEGY_BY_DATA_ITEM) {
-        return legendSets.find((legendSet) => legendSet.id === legendSetId)
-    } else {
-        return null
-    }
 }
 
 const formatLabel = ({
@@ -210,9 +190,9 @@ export default function ({
     fontStyle,
     visType,
     dashboard,
-    legendSets = [],
-    metaData,
-    displayStrategy,
+    // legendSets = [],
+    // metaData,
+    // displayStrategy,
 }) {
     const mergedFontStyle = mergeFontStyleWithDefault(
         fontStyle,

--- a/src/visualizations/config/adapters/dhis_highcharts/legend.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/legend.js
@@ -7,19 +7,11 @@ import {
     FONT_STYLE_LEGEND,
     mergeFontStyleWithDefault,
 } from '../../../../modules/fontStyle.js'
-import { getLegendSetByDisplayStrategy } from '../../../../modules/legends.js'
 import {
-    isLegendSetType,
     isVerticalType,
-    VIS_TYPE_LINE,
     VIS_TYPE_SCATTER,
 } from '../../../../modules/visTypes.js'
-import {
-    colorSets,
-    COLOR_SET_PATTERNS,
-} from '../../../util/colors/colorSets.js'
 import { getTextAlignOption } from './getTextAlignOption.js'
-import getType from './type.js'
 
 const DASHBOARD_ITEM_STYLE = {
     fontSize: '11px',
@@ -70,130 +62,7 @@ function getLegend(fontStyle, dashboard, visType) {
     )
 }
 
-const formatLabel = ({
-    seriesId,
-    seriesColor,
-    seriesName,
-    seriesType,
-    metaData,
-    displayStrategy,
-    legendSets,
-    fontStyle,
-    visType,
-}) => {
-    const legendSet = getLegendSetByDisplayStrategy({
-        displayStrategy,
-        legendSets,
-        legendSetId: metaData[seriesId]?.legendSet,
-    })
-    const result = []
-    // Note: Highcharts strips out 'data-test' and similar attributes, hence 'class="data-test-..." was used instead
-    result.push(
-        '<div style="display: flex; align-items: center; margin-bottom: 4px;" class="data-test-series-key-item">'
-    )
-    if (
-        (!seriesId || seriesId.startsWith('trendline')) &&
-        seriesType === getType(VIS_TYPE_LINE).type
-    ) {
-        // trendline
-        result.push(
-            `<span style="height: ${
-                fontStyle[FONT_STYLE_OPTION_FONT_SIZE] / 6.5
-            }px; width: ${
-                fontStyle[FONT_STYLE_OPTION_FONT_SIZE]
-            }px; background-color: ${seriesColor}; display: inline-block;"></span>`
-        )
-        result.push(
-            `<span style="margin-left: 8px" class="data-test-series-key-item-name">${seriesName}</span>`
-        )
-    } else if (
-        legendSet?.legends?.length &&
-        isLegendSetType(visType) &&
-        seriesType !== getType(VIS_TYPE_LINE).type
-    ) {
-        // item with legend set
-        legendSet.legends
-            .sort((a, b) => a.startValue - b.startValue)
-            .forEach((legend, index) =>
-                result.push(
-                    `<svg width="${
-                        fontStyle[FONT_STYLE_OPTION_FONT_SIZE]
-                    }" height="${
-                        fontStyle[FONT_STYLE_OPTION_FONT_SIZE]
-                    }" style="margin-right:-5px; z-index: ${
-                        legendSet.legends.length - index
-                    }" class="data-test-series-key-item-bullet">
-                    <circle cx="${
-                        fontStyle[FONT_STYLE_OPTION_FONT_SIZE] / 2
-                    }" cy="${fontStyle[FONT_STYLE_OPTION_FONT_SIZE] / 2}" r="${
-                        fontStyle[FONT_STYLE_OPTION_FONT_SIZE] / 2
-                    }" fill="${legend.color}"></circle>
-                    </svg>`
-                )
-            )
-        result.push(
-            `<span style="margin-left: 8px" class="data-test-series-key-item-name">${seriesName}</span>`
-        )
-    } else {
-        // regular item (not a trendline, no applied legend set)
-        if (seriesColor?.patternIndex !== undefined) {
-            const pattern =
-                colorSets[COLOR_SET_PATTERNS].patterns[seriesColor.patternIndex]
-            result.push(
-                `<svg style="height: ${
-                    fontStyle[FONT_STYLE_OPTION_FONT_SIZE]
-                }px; width: ${
-                    fontStyle[FONT_STYLE_OPTION_FONT_SIZE]
-                }px; display: inline-block; margin-right:5px" class="data-test-series-key-item-bullet">
-                <defs>
-                  <pattern id="pattern${
-                      seriesColor.patternIndex
-                  }" patternUnits="userSpaceOnUse" width="${
-                    pattern.width
-                }" height="${pattern.height}">
-                    <path stroke="${pattern.color}" d="${pattern.path}"/>
-                  </pattern>
-                </defs>
-                <circle cx="${
-                    fontStyle[FONT_STYLE_OPTION_FONT_SIZE] / 2
-                }" cy="${fontStyle[FONT_STYLE_OPTION_FONT_SIZE] / 2}" r="${
-                    fontStyle[FONT_STYLE_OPTION_FONT_SIZE] / 2
-                }" fill="url(#pattern${seriesColor.patternIndex})"/>
-              </svg>`
-            )
-        } else {
-            result.push(
-                `<svg width="${
-                    fontStyle[FONT_STYLE_OPTION_FONT_SIZE]
-                }" height="${
-                    fontStyle[FONT_STYLE_OPTION_FONT_SIZE]
-                }" style="margin-right:5px" class="data-test-series-key-item-bullet">
-                    <circle cx="${
-                        fontStyle[FONT_STYLE_OPTION_FONT_SIZE] / 2
-                    }" cy="${fontStyle[FONT_STYLE_OPTION_FONT_SIZE] / 2}" r="${
-                    fontStyle[FONT_STYLE_OPTION_FONT_SIZE] / 2
-                }" fill="${seriesColor}"></circle>
-                    </svg>`
-            )
-        }
-
-        result.push(
-            `<span class="data-test-series-key-item-name">${seriesName}</span>`
-        )
-    }
-    result.push('</div>')
-    return result.join('')
-}
-
-export default function ({
-    isHidden,
-    fontStyle,
-    visType,
-    dashboard,
-    // legendSets = [],
-    // metaData,
-    // displayStrategy,
-}) {
+export default function ({ isHidden, fontStyle, visType, dashboard }) {
     const mergedFontStyle = mergeFontStyleWithDefault(
         fontStyle,
         FONT_STYLE_LEGEND
@@ -205,24 +74,6 @@ export default function ({
         : Object.assign(
               {},
               getLegend(mergedFontStyle, dashboard, visType),
-              getItemStyle(mergedFontStyle, dashboard),
-              {
-                  //useHTML: true,
-                  //symbolWidth: 0.001,
-                  //symbolHeight: 0.001,
-                  //   labelFormatter: function () {
-                  //       return formatLabel({
-                  //           seriesId: this.userOptions?.id,
-                  //           seriesColor: this.color,
-                  //           seriesName: this.name,
-                  //           seriesType: this.userOptions?.type,
-                  //           metaData,
-                  //           displayStrategy,
-                  //           legendSets,
-                  //           fontStyle: mergedFontStyle,
-                  //           visType,
-                  //       })
-                  //   },
-              }
+              getItemStyle(mergedFontStyle, dashboard)
           )
 }

--- a/src/visualizations/config/adapters/dhis_highcharts/legend.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/legend.js
@@ -227,9 +227,9 @@ export default function ({
               getLegend(mergedFontStyle, dashboard, visType),
               getItemStyle(mergedFontStyle, dashboard),
               {
-                  useHTML: true,
-                  symbolWidth: 0.001,
-                  symbolHeight: 0.001,
+                  //useHTML: true,
+                  //symbolWidth: 0.001,
+                  //symbolHeight: 0.001,
                   //   labelFormatter: function () {
                   //       return formatLabel({
                   //           seriesId: this.userOptions?.id,

--- a/src/visualizations/config/adapters/dhis_highcharts/series/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/index.js
@@ -186,6 +186,14 @@ function getDefault(series, metaData, layout, isStacked, extraOptions) {
         if (extraOptions.yearlySeries) {
             seriesObj.name = extraOptions.yearlySeries[index]
         }
+
+        seriesObj.color = 'red'
+        seriesObj.circle1color = 'lightblue'
+        seriesObj.circle2color = 'red'
+        seriesObj.circle3color = 'pink'
+        seriesObj.marker = {
+            enabled: false,
+        }
     })
 
     // DHIS2-701: use cumulative values

--- a/src/visualizations/config/adapters/dhis_highcharts/series/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/index.js
@@ -1,6 +1,7 @@
 import { colors } from '@dhis2/ui'
 import { hasCustomAxes } from '../../../../../modules/axis.js'
 import { axisHasRelativeItems } from '../../../../../modules/layout/axisHasRelativeItems.js'
+import { getLegendSetByDisplayStrategy } from '../../../../../modules/legends.js'
 import {
     VIS_TYPE_PIE,
     VIS_TYPE_GAUGE,
@@ -109,7 +110,16 @@ function getIdColorMap(series, layout, extraOptions) {
     }
 }
 
-function getDefault(series, metaData, layout, isStacked, extraOptions) {
+function getDefault({
+    series,
+    metaData,
+    layout,
+    isStacked,
+    extraOptions,
+    legendSets,
+    displayStrategy,
+    fontSize,
+}) {
     const fullIdAxisMap = getFullIdAxisMap(layout.series, series)
     const idColorMap = getIdColorMap(series, layout, extraOptions)
     const indexColorPatternMap = getIndexColorPatternMap(
@@ -187,10 +197,14 @@ function getDefault(series, metaData, layout, isStacked, extraOptions) {
             seriesObj.name = extraOptions.yearlySeries[index]
         }
 
-        seriesObj.color = 'red'
-        seriesObj.circle1color = 'lightblue'
-        seriesObj.circle2color = 'red'
-        seriesObj.circle3color = 'pink'
+        seriesObj.legendSet = getLegendSetByDisplayStrategy({
+            displayStrategy,
+            legendSets,
+            legendSetId: metaData[seriesObj.id]?.legendSet,
+        })
+
+        seriesObj.fontSize = fontSize
+        // displayStrategy
         seriesObj.marker = {
             enabled: false,
         }
@@ -204,7 +218,16 @@ function getDefault(series, metaData, layout, isStacked, extraOptions) {
     return series
 }
 
-export default function (series, metaData, layout, isStacked, extraOptions) {
+export default function ({
+    series,
+    metaData,
+    layout,
+    isStacked,
+    extraOptions,
+    legendSets,
+    displayStrategy,
+    fontSize,
+}) {
     switch (layout.type) {
         case VIS_TYPE_PIE:
             series = getPie(
@@ -219,13 +242,16 @@ export default function (series, metaData, layout, isStacked, extraOptions) {
             series = getScatter(extraOptions)
             break
         default:
-            series = getDefault(
+            series = getDefault({
                 series,
                 metaData,
                 layout,
                 isStacked,
-                extraOptions
-            )
+                extraOptions,
+                legendSets,
+                displayStrategy,
+                fontSize,
+            })
     }
 
     series.forEach((seriesObj) => {

--- a/src/visualizations/config/adapters/dhis_highcharts/series/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/index.js
@@ -118,7 +118,6 @@ function getDefault({
     extraOptions,
     legendSets,
     displayStrategy,
-    fontSize,
 }) {
     const fullIdAxisMap = getFullIdAxisMap(layout.series, series)
     const idColorMap = getIdColorMap(series, layout, extraOptions)
@@ -203,7 +202,6 @@ function getDefault({
             legendSetId: metaData[seriesObj.id]?.legendSet,
         })
 
-        seriesObj.fontSize = fontSize
         // displayStrategy
         seriesObj.marker = {
             enabled: false,
@@ -226,7 +224,6 @@ export default function ({
     extraOptions,
     legendSets,
     displayStrategy,
-    fontSize,
 }) {
     switch (layout.type) {
         case VIS_TYPE_PIE:
@@ -250,7 +247,6 @@ export default function ({
                 extraOptions,
                 legendSets,
                 displayStrategy,
-                fontSize,
             })
     }
 

--- a/src/visualizations/config/adapters/dhis_highcharts/series/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/index.js
@@ -202,7 +202,6 @@ function getDefault({
             legendSetId: metaData[seriesObj.id]?.legendSet,
         })
 
-        // displayStrategy
         seriesObj.marker = {
             enabled: false,
         }

--- a/src/visualizations/config/generators/highcharts/index.js
+++ b/src/visualizations/config/generators/highcharts/index.js
@@ -15,37 +15,51 @@ HPF(H)
 HB(H)
 
 function drawLegendSymbolWrap() {
-    H.seriesTypes.column.prototype.drawLegendSymbol = function () {
-        if (this.options.legendSet?.legends?.length) {
-            this.options.legendSet.legends
-                .sort((a, b) => b.startValue - a.startValue)
-                .forEach((legend, index) => {
-                    this.chart.renderer
-                        .circle(
-                            10 + index * -(this.options.fontSize - 5),
-                            Math.round(this.options.fontSize * 0.615 * 10) /
-                                10 +
-                                3,
-                            this.options.fontSize / 2
-                        )
-                        .attr({
-                            fill: legend.color,
-                        })
-                        .add(this.legendGroup)
-                })
-        } else {
-            this.chart.renderer
-                .circle(
-                    10,
-                    Math.round(this.options.fontSize * 0.615 * 10) / 10 + 3,
-                    this.options.fontSize / 2
+    const pick = H.pick
+    H.wrap(
+        H.seriesTypes.column.prototype,
+        'drawLegendSymbol',
+        function (proceed, legend, item) {
+            if (this.options.legendSet?.legends?.length) {
+                const ys = legend.baseline - legend.symbolHeight + 1, // y start
+                    x = legend.symbolWidth / 2 > 8 ? legend.symbolWidth / 2 : 8, // x start
+                    ye = legend.symbolHeight + ys // y end
+                const legends = this.options.legendSet.legends.sort(
+                    (a, b) => a.startValue - b.startValue
                 )
-                .attr({
-                    fill: this.options.color,
-                })
-                .add(this.legendGroup)
+                this.chart.renderer
+                    .path(['M', x, ys, 'A', 1, 1, 0, 0, 0, x, ye, 'V', ys])
+                    .attr({
+                        fill: legends.at(legends.length >= 5 ? 1 : 0).color,
+                    })
+                    .add(this.legendGroup)
+                this.chart.renderer
+                    .path(['M', x, ye, 'A', 1, 1, 0, 0, 0, x, ys, 'V', ye])
+                    .attr({
+                        fill: legends.at(legends.length >= 5 ? -2 : -1).color,
+                    })
+                    .add(this.legendGroup)
+            } else {
+                var options = legend.options,
+                    symbolHeight = legend.symbolHeight,
+                    square = options.squareSymbol,
+                    symbolWidth = square ? symbolHeight : legend.symbolWidth
+                item.legendSymbol = this.chart.renderer
+                    .rect(
+                        square ? (legend.symbolWidth - symbolHeight) / 2 : 0,
+                        legend.baseline - symbolHeight + 1,
+                        symbolWidth,
+                        symbolHeight,
+                        pick(legend.options.symbolRadius, symbolHeight / 2)
+                    )
+                    .addClass('highcharts-point')
+                    .attr({
+                        zIndex: 3,
+                    })
+                    .add(item.legendGroup)
+            }
         }
-    }
+    )
 }
 
 export default function (config, el) {

--- a/src/visualizations/config/generators/highcharts/index.js
+++ b/src/visualizations/config/generators/highcharts/index.js
@@ -14,6 +14,36 @@ HE(H)
 HPF(H)
 HB(H)
 
+function drawLegendSymbolWrap() {
+    H.wrap(H.Series.prototype, 'drawLegendSymbol', function (proceed, legend) {
+        proceed.call(this, legend)
+
+        // First circle
+        this.customCircle1 = this.chart.renderer
+            .circle(-10, 10, 8)
+            .attr({
+                fill: this.options.circle1color,
+            })
+            .add(this.legendGroup)
+
+        // Second circle
+        this.customCircle2 = this.chart.renderer
+            .circle(0, 10, 8)
+            .attr({
+                fill: this.options.circle2color,
+            })
+            .add(this.legendGroup)
+
+        // Third circle
+        this.customCircle3 = this.chart.renderer
+            .circle(10, 10, 8)
+            .attr({
+                fill: this.options.circle3color,
+            })
+            .add(this.legendGroup)
+    })
+}
+
 export default function (config, el) {
     if (config) {
         config.chart.renderTo = el || config.chart.renderTo
@@ -26,6 +56,8 @@ export default function (config, el) {
                 lang: config.lang,
             })
         }
+
+        drawLegendSymbolWrap()
 
         return new H.Chart(config)
     }

--- a/src/visualizations/config/generators/highcharts/index.js
+++ b/src/visualizations/config/generators/highcharts/index.js
@@ -15,10 +15,7 @@ HPF(H)
 HB(H)
 
 function drawLegendSymbolWrap() {
-    H.wrap(H.Series.prototype, 'drawLegendSymbol', function (proceed, legend) {
-        proceed.call(this, legend)
-
-        // First circle
+    H.seriesTypes.column.prototype.drawLegendSymbol = function () {
         this.customCircle1 = this.chart.renderer
             .circle(-10, 10, 8)
             .attr({
@@ -41,7 +38,7 @@ function drawLegendSymbolWrap() {
                 fill: this.options.circle3color,
             })
             .add(this.legendGroup)
-    })
+    }
 }
 
 export default function (config, el) {

--- a/src/visualizations/config/generators/highcharts/index.js
+++ b/src/visualizations/config/generators/highcharts/index.js
@@ -35,9 +35,13 @@ function drawLegendSymbolWrap() {
                 })
         } else {
             this.chart.renderer
-                .circle(-10, 10, 8)
+                .circle(
+                    10,
+                    Math.round(this.options.fontSize * 0.615 * 10) / 10 + 3,
+                    this.options.fontSize / 2
+                )
                 .attr({
-                    fill: 'pink',
+                    fill: this.options.color,
                 })
                 .add(this.legendGroup)
         }

--- a/src/visualizations/config/generators/highcharts/index.js
+++ b/src/visualizations/config/generators/highcharts/index.js
@@ -16,28 +16,31 @@ HB(H)
 
 function drawLegendSymbolWrap() {
     H.seriesTypes.column.prototype.drawLegendSymbol = function () {
-        this.customCircle1 = this.chart.renderer
-            .circle(-10, 10, 8)
-            .attr({
-                fill: this.options.circle1color,
-            })
-            .add(this.legendGroup)
-
-        // Second circle
-        this.customCircle2 = this.chart.renderer
-            .circle(0, 10, 8)
-            .attr({
-                fill: this.options.circle2color,
-            })
-            .add(this.legendGroup)
-
-        // Third circle
-        this.customCircle3 = this.chart.renderer
-            .circle(10, 10, 8)
-            .attr({
-                fill: this.options.circle3color,
-            })
-            .add(this.legendGroup)
+        if (this.options.legendSet?.legends?.length) {
+            this.options.legendSet.legends
+                .sort((a, b) => b.startValue - a.startValue)
+                .forEach((legend, index) => {
+                    this.chart.renderer
+                        .circle(
+                            10 + index * -(this.options.fontSize - 5),
+                            Math.round(this.options.fontSize * 0.615 * 10) /
+                                10 +
+                                3,
+                            this.options.fontSize / 2
+                        )
+                        .attr({
+                            fill: legend.color,
+                        })
+                        .add(this.legendGroup)
+                })
+        } else {
+            this.chart.renderer
+                .circle(-10, 10, 8)
+                .attr({
+                    fill: 'pink',
+                })
+                .add(this.legendGroup)
+        }
     }
 }
 


### PR DESCRIPTION
Implements [DHIS2-12719](https://jira.dhis2.org/browse/DHIS2-12719)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/2126**

---

### Key features

1. Replaces the custom label formatter for legend with a custom `drawLegendSymbol` function

---

### Description

As the Batik export of charts doesn't support the use of the `<foreignObject>` tag (which is used when a custom legend uses html), the previously used label formatter was replaced by a custom `drawLegendSymbol` to handle the  custom rendering of series items that use legend sets.

Because of technical challenges the design using multiple overlapping circles was replaced by a single circle that is split in half. This makes sure that all items are of equal width for scaling, multi row wrapping and positioning purposes.

The new symbol is split vertically and uses the first and last color of the legendSet, but as it seems to be common practice to have the first and/or last legend act as an out-of-bounds range, if there are 5 or more legends in total the split circle symbol will use the colors of the second item and second last item instead. e.g. 4 items: use the colors from item1 and item4. 5 items: use the colors from item2 and item4.

---

### Screenshots

_overview of the new legend symbols in use_
<img width="771" alt="image" src="https://user-images.githubusercontent.com/12590483/174293822-f8620e47-52a1-49cf-a952-9a4f33d93a71.png">

_a detailed look at the new split circle symbol that represents the use of legendSets_
<img width="414" alt="image" src="https://user-images.githubusercontent.com/12590483/174293923-c5aadd79-d17d-48fe-9218-20811bf3d7c7.png">

