### PR TITLE
fix: force the modal flex item to shrink past its content's width

### DIFF
--- a/src/components/Interpretations/InterpretationModal/InterpretationModal.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationModal.js
@@ -219,6 +219,7 @@ const InterpretationModal = ({
 
                     .visualisation-wrap {
                         flex-grow: 1;
+                        min-width: 0;
                     }
 
                     .thread-wrap {


### PR DESCRIPTION

**Relates to https://github.com/dhis2/line-listing-app/pull/121**

---

### Key features

1. allow the visualization wrap container to shrink past its content's width

---

### Description

This avoids the right sidebar with the interpretation comments to be pushed to the right and be partially hidden when the width of the Modal/viewport is not enough to accommodate all the content without scrolling.

---

### Screenshots

Before:
<img width="1017" alt="Screenshot 2022-06-24 at 13 50 40" src="https://user-images.githubusercontent.com/150978/175528729-a907e5e3-7950-41ce-9bcd-84a69df19c1e.png">

After:
<img width="1015" alt="Screenshot 2022-06-24 at 13 50 18" src="https://user-images.githubusercontent.com/150978/175528721-8112f308-6383-40b1-8e1b-c46e86e00bcd.png">

