### PR TITLE
fix: use new sharing object in AboutUnit component

### DIFF
--- a/src/components/AboutAOUnit/AboutAOUnit.js
+++ b/src/components/AboutAOUnit/AboutAOUnit.js
@@ -123,14 +123,16 @@ const AboutAOUnit = ({ type, id }) => {
         const userAccesses = ao.sharing.users
         const groupAccesses = ao.sharing.userGroups
 
-        Object.values(userAccesses).concat(Object.values(groupAccesses)).forEach((accessRule) => {
-            sharingTextParts.push(
-                i18n.t('{{userOrGroup}} ({{accessLevel}})', {
-                    userOrGroup: accessRule.displayName,
-                    accessLevel: getAccessLevelString(accessRule.access),
-                })
-            )
-        })
+        Object.values(userAccesses)
+            .concat(Object.values(groupAccesses))
+            .forEach((accessRule) => {
+                sharingTextParts.push(
+                    i18n.t('{{userOrGroup}} ({{accessLevel}})', {
+                        userOrGroup: accessRule.displayName,
+                        accessLevel: getAccessLevelString(accessRule.access),
+                    })
+                )
+            })
 
         return sharingTextParts.length
             ? i18n.t('Shared with {{commaSeparatedListOfUsersAndGroups}}', {

--- a/src/components/AboutAOUnit/AboutAOUnit.js
+++ b/src/components/AboutAOUnit/AboutAOUnit.js
@@ -28,7 +28,7 @@ const getQueries = (type) => ({
         resource: type,
         id: ({ id }) => id,
         params: {
-            fields: 'id,displayDescription,created,createdBy[displayName],lastUpdated,subscribed,publicAccess,userAccesses[displayName,access],userGroupAccesses[displayName,access]',
+            fields: 'id,displayDescription,created,createdBy[displayName],lastUpdated,subscribed,sharing',
         },
     },
     dataStatistics: {
@@ -93,7 +93,7 @@ const AboutAOUnit = ({ type, id }) => {
         if (id) {
             refetch({ id })
         }
-    }, [type, id])
+    }, [type, id, refetch])
 
     const getAccessLevelString = (access) => {
         const re = new RegExp(`(?<accessLevel>${READ_AND_WRITE}?)`)
@@ -112,18 +112,18 @@ const AboutAOUnit = ({ type, id }) => {
 
         const re = new RegExp(`^${READ_AND_WRITE}?`)
 
-        if (re.test(ao.publicAccess)) {
+        if (re.test(ao.sharing.public)) {
             sharingTextParts.push(
                 i18n.t('all users ({{accessLevel}})', {
-                    accessLevel: getAccessLevelString(ao.publicAccess),
+                    accessLevel: getAccessLevelString(ao.sharing.public),
                 })
             )
         }
 
-        const userAccesses = ao.userAccesses
-        const groupAccesses = ao.userGroupAccesses
+        const userAccesses = ao.sharing.users
+        const groupAccesses = ao.sharing.userGroups
 
-        userAccesses.concat(groupAccesses).forEach((accessRule) => {
+        Object.values(userAccesses).concat(Object.values(groupAccesses)).forEach((accessRule) => {
             sharingTextParts.push(
                 i18n.t('{{userOrGroup}} ({{accessLevel}})', {
                     userOrGroup: accessRule.displayName,


### PR DESCRIPTION
### Key features

1. use the new `sharing` object returned from the visualizations/maps api

---

### Description

The old sharing properties at the root level of the returned object are deprecated and will be removed eventually.
More info here: https://docs.dhis2.org/en/develop/using-the-api/dhis-core-version-master/sharing.html#new-sharing-object

There was a bug in the backend that prevented the user/group displayName from being returned, causing a problem in the sharing summary (see screenshot below).
While investigating on that issue, it turned out there is a new sharing object that should be used instead, as explained in the documentation (see link above).

---

### Screenshots

Before:
<img width="379" alt="Screenshot 2022-08-01 at 12 36 50" src="https://user-images.githubusercontent.com/150978/182131923-79a259e0-ee37-4cdd-ab39-48daf28bd221.png">

After:
<img width="384" alt="Screenshot 2022-08-01 at 12 36 35" src="https://user-images.githubusercontent.com/150978/182131939-d3596230-63da-4803-90fb-bc3ecd0299ed.png">
