### PR TITLE
fix: avoid ES2022 functions

### DIFF
--- a/src/visualizations/config/generators/highcharts/index.js
+++ b/src/visualizations/config/generators/highcharts/index.js
@@ -30,13 +30,17 @@ function drawLegendSymbolWrap() {
                 this.chart.renderer
                     .path(['M', x, ys, 'A', 1, 1, 0, 0, 0, x, ye, 'V', ys])
                     .attr({
-                        fill: legends.at(legends.length >= 5 ? 1 : 0).color,
+                        fill: legends[legends.length >= 5 ? 1 : 0].color,
                     })
                     .add(this.legendGroup)
                 this.chart.renderer
                     .path(['M', x, ye, 'A', 1, 1, 0, 0, 0, x, ys, 'V', ye])
                     .attr({
-                        fill: legends.at(legends.length >= 5 ? -2 : -1).color,
+                        fill: legends[
+                            legends.length >= 5
+                                ? legends.length - 2
+                                : legends.length - 1
+                        ].color,
                     })
                     .add(this.legendGroup)
             } else {


### PR DESCRIPTION
The array function `.at` isn't supported by Cypress on CI, so this should be avoided. The previous use of this has been refactored to use the old-school bracket syntax instead.