### PR TITLE
fix: always display legend set name in legend key (DHIS2-75)

### DIFF
--- a/src/components/LegendKey/LegendKey.js
+++ b/src/components/LegendKey/LegendKey.js
@@ -14,9 +14,7 @@ const LegendKey = ({ legendSets }) => {
                     })}
                     data-test={`legend-key-item-${legendSet.id}`}
                 >
-                    {legendSets.length > 1 && (
-                        <span className="legendSetName">{legendSet.name}</span>
-                    )}
+                    <span className="legendSetName">{legendSet.name}</span>
                     {legendSet.legends
                         .sort((a, b) => a.startValue - b.startValue)
                         .map((legend) => (


### PR DESCRIPTION
Implements [DHIS2-75](https://dhis2.atlassian.net/browse/DHIS2-75)

**Relates to https://github.com/dhis2/line-listing-app/pull/187**

---

Previously legend set names were only displayed for 2+ legends in the legend key, however the name should be displayed even when there's only a single legend, so this has now been changed.