### PR TITLE
fix: add support for Maps app (LIBS-339)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-08-10T13:11:21.079Z\n"
-"PO-Revision-Date: 2022-08-10T13:11:21.079Z\n"
+"POT-Creation-Date: 2022-08-22T09:12:05.760Z\n"
+"PO-Revision-Date: 2022-08-22T09:12:05.760Z\n"
 
 msgid "view only"
 msgstr "view only"
@@ -26,9 +26,6 @@ msgstr "Shared with {{commaSeparatedListOfUsersAndGroups}}"
 msgid "Not shared with any users or groups"
 msgstr "Not shared with any users or groups"
 
-msgid "About this visualization"
-msgstr "About this visualization"
-
 msgid "No description"
 msgstr "No description"
 
@@ -37,6 +34,9 @@ msgstr "Last updated {{time}}"
 
 msgid "Created {{time}} by {{author}}"
 msgstr "Created {{time}} by {{author}}"
+
+msgid "Created {{time}}"
+msgstr "Created {{time}}"
 
 msgid "Viewed {{count}} times"
 msgid_plural "Viewed {{count}} times"
@@ -57,6 +57,15 @@ msgstr "Subscribe to get updates about new interpretations."
 
 msgid "Subscribe"
 msgstr "Subscribe"
+
+msgid "About this map"
+msgstr "About this map"
+
+msgid "About this line list"
+msgstr "About this line list"
+
+msgid "About this visualization"
+msgstr "About this visualization"
 
 msgid "This app could not retrieve required data."
 msgstr "This app could not retrieve required data."

--- a/src/components/AboutAOUnit/AboutAOUnit.js
+++ b/src/components/AboutAOUnit/AboutAOUnit.js
@@ -202,7 +202,8 @@ const AboutAOUnit = ({ type, id }) => {
                                                   time: moment(
                                                       data.ao.created
                                                   ).fromNow(),
-                                                  author: data.ao.createdBy.displayName,
+                                                  author: data.ao.createdBy
+                                                      .displayName,
                                               }
                                           )
                                         : i18n.t('Created {{time}}', {

--- a/src/components/AboutAOUnit/utils.js
+++ b/src/components/AboutAOUnit/utils.js
@@ -1,0 +1,37 @@
+import i18n from '@dhis2/d2-i18n'
+
+export const AO_TYPE_VISUALIZATION = 'visualization'
+export const AO_TYPE_MAP = 'map'
+export const AO_TYPE_EVENT_VISUALIZATION = 'eventVisualization'
+
+export const AOTypeMap = {
+    [AO_TYPE_VISUALIZATION]: {
+        apiEndpoint: 'visualizations',
+    },
+    [AO_TYPE_MAP]: {
+        apiEndpoint: 'maps',
+    },
+    [AO_TYPE_EVENT_VISUALIZATION]: {
+        apiEndpoint: 'eventVisualizations',
+    },
+}
+
+const NO_TYPE = 'NO_TYPE'
+
+const texts = {
+    [AO_TYPE_MAP]: {
+        unitTitle: i18n.t('About this map'),
+    },
+    [AO_TYPE_EVENT_VISUALIZATION]: {
+        unitTitle: i18n.t('About this line list'),
+    },
+    [AO_TYPE_VISUALIZATION]: {
+        unitTitle: i18n.t('About this visualization'),
+    },
+    [NO_TYPE]: {
+        unitTitle: i18n.t('About this visualization'),
+    }
+}
+
+export const getTranslatedString = (type, key) =>
+    (texts[type] || texts[NO_TYPE])[key]

--- a/src/components/AboutAOUnit/utils.js
+++ b/src/components/AboutAOUnit/utils.js
@@ -30,7 +30,7 @@ const texts = {
     },
     [NO_TYPE]: {
         unitTitle: i18n.t('About this visualization'),
-    }
+    },
 }
 
 export const getTranslatedString = (type, key) =>


### PR DESCRIPTION
Implements [LIBS-339](https://dhis2.atlassian.net/browse/LIBS-339)

**Relates to https://github.com/dhis2/maps-app/pull/2228**

---

### Key features

1. use `map` in place of `maps` for the type prop to align with interpretations components
2. adjust the title of the unit based on the `type` passed
3. adjust the "Created" text to remove the author part if not available

---

### BREAKING CHANGE

The `type` prop changed from the plural version to the singular, this requires updating the apps that use the `AboutAOUnit` component.

---

### Screenshots

Custom title for Maps:
![Screenshot 2022-08-22 at 11 21 16](https://user-images.githubusercontent.com/150978/185890637-f44e12c1-3f1c-47bb-bee0-2fe3a74439b6.png)


Created string without the author:
![Screenshot 2022-08-22 at 11 21 23](https://user-images.githubusercontent.com/150978/185890604-1172dd5f-159a-48c7-bed0-bfd3fa966fa7.png)

