### PR TITLE
fix: various fixes in InterpretationModal for maps LIBS-341

### DIFF
--- a/src/components/Interpretations/InterpretationModal/InterpretationModal.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationModal.js
@@ -106,7 +106,7 @@ const InterpretationModal = ({
         if (interpretationId) {
             refetch({ id: interpretationId })
         }
-    }, [interpretationId])
+    }, [interpretationId, refetch])
 
     return (
         <>

--- a/src/components/Interpretations/InterpretationModal/InterpretationModal.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationModal.js
@@ -130,7 +130,9 @@ const InterpretationModal = ({
                         {i18n.t(
                             'Viewing interpretation: {{- visualisationName}}',
                             {
-                                visualisationName: visualization.displayName,
+                                visualisationName:
+                                    visualization.displayName ||
+                                    visualization.name,
                                 nsSeparator: '^^',
                             }
                         )}
@@ -237,10 +239,6 @@ const InterpretationModal = ({
 
 InterpretationModal.propTypes = {
     currentUser: PropTypes.object.isRequired,
-    downloadMenuComponent: PropTypes.oneOfType([
-        PropTypes.object,
-        PropTypes.func,
-    ]).isRequired,
     interpretationId: PropTypes.string.isRequired,
     isVisualizationLoading: PropTypes.bool.isRequired,
     pluginComponent: PropTypes.oneOfType([PropTypes.object, PropTypes.func])
@@ -248,6 +246,10 @@ InterpretationModal.propTypes = {
     visualization: PropTypes.object.isRequired,
     onClose: PropTypes.func.isRequired,
     onResponsesReceived: PropTypes.func.isRequired,
+    downloadMenuComponent: PropTypes.oneOfType([
+        PropTypes.object,
+        PropTypes.func,
+    ]),
     initialFocus: PropTypes.bool,
     onInterpretationUpdate: PropTypes.func,
 }

--- a/src/components/Interpretations/InterpretationModal/InterpretationThread.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationThread.js
@@ -36,32 +36,38 @@ const InterpretationThread = ({
                 {DownloadMenu && (
                     <DownloadMenu relativePeriodDate={interpretation.created} />
                 )}
-                <Interpretation
-                    currentUser={currentUser}
-                    interpretation={interpretation}
-                    onReplyIconClick={() => focusRef.current?.focus()}
-                    onUpdated={() => onThreadUpdated(true)}
-                    onDeleted={onInterpretationDeleted}
-                />
-                <div className={'comments'}>
-                    {interpretation.comments.map((comment) => (
-                        <Comment
-                            key={comment.id}
-                            comment={comment}
-                            currentUser={currentUser}
-                            interpretationId={interpretation.id}
-                            onThreadUpdated={onThreadUpdated}
-                        />
-                    ))}
+                <div className={'thread'}>
+                    <Interpretation
+                        currentUser={currentUser}
+                        interpretation={interpretation}
+                        onReplyIconClick={() => focusRef.current?.focus()}
+                        onUpdated={() => onThreadUpdated(true)}
+                        onDeleted={onInterpretationDeleted}
+                    />
+                    <div className={'comments'}>
+                        {interpretation.comments.map((comment) => (
+                            <Comment
+                                key={comment.id}
+                                comment={comment}
+                                currentUser={currentUser}
+                                interpretationId={interpretation.id}
+                                onThreadUpdated={onThreadUpdated}
+                            />
+                        ))}
+                    </div>
+                    <CommentAddForm
+                        currentUser={currentUser}
+                        interpretationId={interpretation.id}
+                        onSave={() => onThreadUpdated(true)}
+                        focusRef={focusRef}
+                    />
                 </div>
-                <CommentAddForm
-                    currentUser={currentUser}
-                    interpretationId={interpretation.id}
-                    onSave={() => onThreadUpdated(true)}
-                    focusRef={focusRef}
-                />
             </div>
             <style jsx>{`
+                .thread {
+                    margin-top: var(--spacers-dp16);
+                }
+
                 .container {
                     position: relative;
                     overflow: hidden;

--- a/src/components/Interpretations/InterpretationModal/InterpretationThread.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationThread.js
@@ -33,7 +33,9 @@ const InterpretationThread = ({
                     <IconClock16 color={colors.grey700} />
                     {moment(interpretation.created).format('LLL')}
                 </div>
-                <DownloadMenu relativePeriodDate={interpretation.created} />
+                {DownloadMenu && (
+                    <DownloadMenu relativePeriodDate={interpretation.created} />
+                )}
                 <Interpretation
                     currentUser={currentUser}
                     interpretation={interpretation}
@@ -130,13 +132,13 @@ const InterpretationThread = ({
 
 InterpretationThread.propTypes = {
     currentUser: PropTypes.object.isRequired,
-    downloadMenuComponent: PropTypes.oneOfType([
-        PropTypes.object,
-        PropTypes.func,
-    ]).isRequired,
     fetching: PropTypes.bool.isRequired,
     interpretation: PropTypes.object.isRequired,
     onInterpretationDeleted: PropTypes.func.isRequired,
+    downloadMenuComponent: PropTypes.oneOfType([
+        PropTypes.object,
+        PropTypes.func,
+    ]),
     initialFocus: PropTypes.bool,
     onThreadUpdated: PropTypes.func,
 }

--- a/src/components/Interpretations/InterpretationModal/InterpretationThread.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationThread.js
@@ -24,7 +24,7 @@ const InterpretationThread = ({
                 focusRef.current.focus()
             })
         }
-    }, [initialFocus, focusRef.current])
+    }, [initialFocus])
 
     return (
         <div className={cx('container', { fetching })}>

--- a/src/components/Interpretations/InterpretationsUnit/InterpretationsUnit.js
+++ b/src/components/Interpretations/InterpretationsUnit/InterpretationsUnit.js
@@ -10,6 +10,7 @@ import {
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, {
+    useCallback,
     useEffect,
     useState,
     useImperativeHandle,
@@ -58,23 +59,23 @@ export const InterpretationsUnit = forwardRef(
             }
         )
 
-        const onCompleteAction = () => {
+        const onCompleteAction = useCallback(() => {
             refetch({ type, id })
-        }
+        }, [type, id, refetch])
 
         useImperativeHandle(
             ref,
             () => ({
                 refresh: onCompleteAction,
             }),
-            []
+            [onCompleteAction]
         )
 
         useEffect(() => {
             if (id) {
                 refetch({ type, id })
             }
-        }, [type, id])
+        }, [type, id, refetch])
 
         return (
             <div

--- a/src/components/Interpretations/common/RichTextEditor/RichTextEditor.js
+++ b/src/components/Interpretations/common/RichTextEditor/RichTextEditor.js
@@ -199,7 +199,7 @@ export const RichTextEditor = forwardRef(
         const internalRef = useRef()
         const textareaRef = externalRef || internalRef
 
-        useEffect(() => textareaRef.current?.focus(), [textareaRef.current])
+        useEffect(() => textareaRef.current?.focus(), [textareaRef])
 
         return (
             <div className="container">

--- a/src/components/Interpretations/common/RichTextEditor/styles/RichTextEditor.style.js
+++ b/src/components/Interpretations/common/RichTextEditor/styles/RichTextEditor.style.js
@@ -56,8 +56,10 @@ export const toolbarClasses = css`
 
     .actionsWrapper {
         display: flex;
+        flex-wrap: wrap;
         gap: ${spacers.dp4};
         align-items: center;
+        justify-content: space-between;
         padding: ${spacers.dp4};
     }
 
@@ -69,7 +71,6 @@ export const toolbarClasses = css`
 
     .sideActions {
         flex-shrink: 0;
-        margin-left: auto;
     }
 
     .previewWrapper {

--- a/src/components/Interpretations/common/UserMention/useUserSearchResults.js
+++ b/src/components/Interpretations/common/UserMention/useUserSearchResults.js
@@ -29,7 +29,7 @@ export const useUserSearchResults = ({ searchText }) => {
         }
 
         return () => debouncedRefetch.cancel()
-    }, [searchText])
+    }, [searchText, debouncedRefetch])
 
     useEffect(() => {
         if (data) {


### PR DESCRIPTION
Implements [LIBS-341](https://dhis2.atlassian.net/browse/LIBS-341)

**Relates to https://github.com/dhis2/maps-app/pull/2228**

---

### Key features

1. make the downloadComponent of the InterpretationModal **not** required
2. fix the cut-off issue when editing an interpretation comment
3. fallback to `name` when `displayName` is not available in the passed AO

---

### Description

All issues are well explained in the ticket.

---

### Screenshots

2 before:
<img width="354" alt="Screenshot 2022-08-23 at 09 25 24" src="https://user-images.githubusercontent.com/150978/186112266-f3caae28-b1ea-41e9-8919-929f1c3bc500.png">

2 after:
<img width="338" alt="Screenshot 2022-08-23 at 09 46 35" src="https://user-images.githubusercontent.com/150978/186112295-b5b42bf0-37a0-48db-9e64-5f12ae251cf6.png">

3 before:
![Screenshot 2022-08-15 at 15 43 18](https://user-images.githubusercontent.com/150978/186112461-65f1727b-7aff-4ed8-8415-6e9adb740cf5.png)

3 after:
![Screenshot 2022-08-22 at 14 38 10](https://user-images.githubusercontent.com/150978/186112334-4f415256-ef87-4035-a08d-e83074b9eb7f.png)

