### PR TITLE
fix: change default value for Save as (DHIS2-13328)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-08-22T09:12:05.760Z\n"
-"PO-Revision-Date: 2022-08-22T09:12:05.760Z\n"
+"POT-Creation-Date: 2022-08-23T12:46:15.410Z\n"
+"PO-Revision-Date: 2022-08-23T12:46:15.410Z\n"
 
 msgid "view only"
 msgstr "view only"
@@ -256,6 +256,9 @@ msgstr "Description"
 
 msgid "Rename"
 msgstr "Rename"
+
+msgid "{{objectName}} (copy)"
+msgstr "{{objectName}} (copy)"
 
 msgid "Save {{fileType}} as"
 msgstr "Save {{fileType}} as"

--- a/src/__demo__/FileMenu.stories.js
+++ b/src/__demo__/FileMenu.stories.js
@@ -19,10 +19,10 @@ const visObject = {
     href: 'http://localhost:8080/api/32/visualizations/a8LrqsBQlHP',
     id: 'a8LrqsBQlHP',
     created: '2012-11-05T09:17:23.388',
-    name: 'ANC: 1-3 dropout rate Yearly copy1',
+    name: 'ANC: 1-3 dropout rate Yearly',
     publicAccess: '--------',
     displayDescription: 'some _italic (10%)_ and some *bold (10%)*',
-    displayName: 'ANC: 1-3 dropout rate Yearly copy1',
+    displayName: 'ANC: 1-3 dropout rate Yearly',
     description: 'some _italic (10%)_ and some *bold (10%)*',
     externalAccess: false,
     access: {

--- a/src/components/FileMenu/SaveAsDialog.js
+++ b/src/components/FileMenu/SaveAsDialog.js
@@ -16,7 +16,13 @@ import { supportedFileTypes, labelForFileType } from './utils.js'
 const NAME_MAXLENGTH = 230
 
 export const SaveAsDialog = ({ type, object, onClose, onSaveAs }) => {
-    const [name, setName] = useState(object?.name)
+    const [name, setName] = useState(
+        object?.name
+            ? i18n.t('{{objectName}} (copy)', {
+                  objectName: object.name,
+              })
+            : ''
+    )
     const [description, setDescription] = useState(object?.description)
 
     // the actual API request is done in the app

--- a/src/components/FileMenu/SaveAsDialog.js
+++ b/src/components/FileMenu/SaveAsDialog.js
@@ -17,7 +17,7 @@ const NAME_MAXLENGTH = 230
 
 export const SaveAsDialog = ({ type, object, onClose, onSaveAs }) => {
     const [name, setName] = useState(
-        object?.name
+        object?.displayName || object?.name
             ? i18n.t('{{objectName}} (copy)', {
                   objectName: object.name,
               })
@@ -85,6 +85,7 @@ export const SaveAsDialog = ({ type, object, onClose, onSaveAs }) => {
 SaveAsDialog.propTypes = {
     object: PropTypes.shape({
         description: PropTypes.string,
+        displayName: PropTypes.string,
         name: PropTypes.string,
     }),
     type: PropTypes.oneOf(supportedFileTypes),

--- a/src/components/FileMenu/__tests__/SaveAsDialog.spec.js
+++ b/src/components/FileMenu/__tests__/SaveAsDialog.spec.js
@@ -45,7 +45,7 @@ describe('The FileMenu - SaveAsDialog component', () => {
             (n) => n.prop('label') === 'Name'
         )
 
-        expect(nameInputField.prop('value')).toEqual(props.object.name)
+        expect(nameInputField.prop('value')).toEqual('Save as name test (copy)')
     })
 
     it('renders a TextAreaField for description with prefilled value from the object prop', () => {
@@ -62,7 +62,7 @@ describe('The FileMenu - SaveAsDialog component', () => {
         getSaveAsDialogComponent(props).find(Button).at(1).simulate('click')
 
         expect(onSaveAs).toHaveBeenCalledWith({
-            name: props.object.name,
+            name: 'Save as name test (copy)',
             description: props.object.description,
         })
     })


### PR DESCRIPTION
Implements [DHIS2-13328](https://jira.dhis2.org/browse/DHIS2-13328)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/2152**

---

### Key features

1. Changes the default value to the Save as modal to append "(copy)" to the end of the original name

---

### Description

Clicking "Save as" for an AO, e.g. "My AO", will now prefill the modal with the name "My AO (copy)"

---

### TODO

- Should look for "(copy)" in the name already to prevent a name like "My AO (copy) (copy)"? Or is this actually considered a feature?

---

### Screenshots

_example of an AO called "My AO"_
![image](https://user-images.githubusercontent.com/12590483/186164717-f14f4c56-fbc3-44b9-ad7d-39aacadff2f0.png)

_saving an AO again appends "(copy)" to the end of the name, resulting in "My AO (copy)"_
![image](https://user-images.githubusercontent.com/12590483/186164747-44a88369-d589-492f-a572-9be71c83cf9e.png)

_saving an AO for the first time leaves the input empty_
![image](https://user-images.githubusercontent.com/12590483/186164831-a7e83334-0834-40af-9d3e-24ca01a76e71.png)
