### PR TITLE
fix: enable onShare callback (DHIS2-13667)

### DIFF
--- a/src/components/AboutAOUnit/AboutAOUnit.js
+++ b/src/components/AboutAOUnit/AboutAOUnit.js
@@ -16,7 +16,13 @@ import {
 import cx from 'classnames'
 import moment from 'moment'
 import PropTypes from 'prop-types'
-import React, { useEffect, useMemo, useState } from 'react'
+import React, {
+    useEffect,
+    useMemo,
+    useState,
+    forwardRef,
+    useImperativeHandle,
+} from 'react'
 import { formatList } from '../../modules/list.js'
 import styles from './styles/AboutAOUnit.style.js'
 import { getTranslatedString, AOTypeMap } from './utils.js'
@@ -48,7 +54,7 @@ const getUnsubscribeMutation = (type, id) => ({
     type: 'delete',
 })
 
-const AboutAOUnit = ({ type, id }) => {
+const AboutAOUnit = forwardRef(({ type, id }, ref) => {
     const [isExpanded, setIsExpanded] = useState(true)
 
     const queries = useMemo(() => getQueries(type), [type])
@@ -98,6 +104,14 @@ const AboutAOUnit = ({ type, id }) => {
             refetch({ id })
         }
     }, [id, refetch])
+
+    useImperativeHandle(
+        ref,
+        () => ({
+            refresh: refetch,
+        }),
+        [refetch]
+    )
 
     const getAccessLevelString = (access) => {
         const re = new RegExp(`(?<accessLevel>${READ_AND_WRITE}?)`)
@@ -277,7 +291,9 @@ const AboutAOUnit = ({ type, id }) => {
             <style jsx>{styles}</style>
         </div>
     )
-}
+})
+
+AboutAOUnit.displayName = 'AboutUnit'
 
 AboutAOUnit.propTypes = {
     id: PropTypes.string.isRequired,

--- a/src/components/FileMenu/FileMenu.js
+++ b/src/components/FileMenu/FileMenu.js
@@ -38,7 +38,7 @@ export const FileMenu = ({
     onSave,
     onSaveAs,
     onRename,
-    //    onShare,
+    onShare,
     onDelete,
     onError,
     onTranslate,
@@ -93,10 +93,10 @@ export const FileMenu = ({
             case 'sharing':
                 return (
                     <SharingDialog
-                        open={true}
                         type={fileType}
                         id={fileObject.id}
                         onClose={onDialogClose}
+                        onSave={onShare}
                     />
                 )
             case 'getlink':
@@ -353,6 +353,7 @@ FileMenu.defaultProps = {
     onOpen: Function.prototype,
     onRename: Function.prototype,
     onSaveAs: Function.prototype,
+    onShare: Function.prototype,
     onTranslate: Function.prototype,
 }
 
@@ -369,7 +370,7 @@ FileMenu.propTypes = {
     onRename: PropTypes.func,
     onSave: PropTypes.func,
     onSaveAs: PropTypes.func,
-    //    onShare: PropTypes.func,
+    onShare: PropTypes.func,
     onTranslate: PropTypes.func,
 }
 


### PR DESCRIPTION
Implements [DHIS2-13667](https://dhis2.atlassian.net/browse/DHIS2-13667)

**Relates to https://github.com/dhis2/line-listing-app/pull/201**

---

### Key features

1. enable `onShare` callback in `FileMenu`
2. implement a mechanism for triggering a refresh in `AboutAOUnit` from the consumer app

---

### Description

The sharing dialog component supports a callback for when the sharing settings request is successful.
This however was never propagated via the `FileMenu` to the consumer app.

The `AboutAOUnit` component has been modified to provide a way of triggering a refresh of its content from the consumer app.
The mechanism is the same already used in the `InterpretationsUnit` component, which also can be refreshed whenever there is an action in the `InterpretationModal`.