### PR TITLE
feat: add renderId prop in AboutAO and Interpretation units

### DIFF
--- a/src/components/AboutAOUnit/AboutAOUnit.js
+++ b/src/components/AboutAOUnit/AboutAOUnit.js
@@ -54,7 +54,7 @@ const getUnsubscribeMutation = (type, id) => ({
     type: 'delete',
 })
 
-const AboutAOUnit = forwardRef(({ type, id }, ref) => {
+const AboutAOUnit = forwardRef(({ type, id, renderId }, ref) => {
     const [isExpanded, setIsExpanded] = useState(true)
 
     const queries = useMemo(() => getQueries(type), [type])
@@ -103,7 +103,7 @@ const AboutAOUnit = forwardRef(({ type, id }, ref) => {
         if (id) {
             refetch({ id })
         }
-    }, [id, refetch])
+    }, [id, renderId, refetch])
 
     useImperativeHandle(
         ref,
@@ -298,6 +298,7 @@ AboutAOUnit.displayName = 'AboutUnit'
 AboutAOUnit.propTypes = {
     id: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
+    renderId: PropTypes.number,
 }
 
 export default AboutAOUnit

--- a/src/components/Interpretations/InterpretationsUnit/InterpretationsUnit.js
+++ b/src/components/Interpretations/InterpretationsUnit/InterpretationsUnit.js
@@ -47,6 +47,7 @@ export const InterpretationsUnit = forwardRef(
             onInterpretationClick,
             onReplyIconClick,
             disabled,
+            renderId,
         },
         ref
     ) => {
@@ -75,7 +76,7 @@ export const InterpretationsUnit = forwardRef(
             if (id) {
                 refetch({ type, id })
             }
-        }, [type, id, refetch])
+        }, [type, id, renderId, refetch])
 
         return (
             <div
@@ -187,6 +188,7 @@ InterpretationsUnit.propTypes = {
     id: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
     disabled: PropTypes.bool,
+    renderId: PropTypes.number,
     onInterpretationClick: PropTypes.func,
     onReplyIconClick: PropTypes.func,
 }


### PR DESCRIPTION
**Relates to https://github.com/dhis2/line-listing-app/pull/201**

---

### Key features

1. add `renderId` prop to AboutAOUnit
2. add `renderId` prop to InterpretationsUnit

---

### Description

This is another approach for triggering a re-render of the components from the consumer app, instead of using the imperative handle hook.