### PR TITLE
feat: export TranslationDialog component

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-08-23T12:46:15.410Z\n"
-"PO-Revision-Date: 2022-08-23T12:46:15.410Z\n"
+"POT-Creation-Date: 2022-09-22T13:25:32.620Z\n"
+"PO-Revision-Date: 2022-09-22T13:25:32.620Z\n"
 
 msgid "view only"
 msgstr "view only"
@@ -374,6 +374,9 @@ msgstr "Searching for \"{{- searchText}}\""
 
 msgid "No results found"
 msgstr "No results found"
+
+msgid "Not available offline"
+msgstr "Not available offline"
 
 msgid "Created by"
 msgstr "Created by"
@@ -853,6 +856,9 @@ msgstr "Translate: {{objectName}}"
 
 msgid "Save translations"
 msgstr "Save translations"
+
+msgid "Cannot save while offline"
+msgstr "Cannot save while offline"
 
 msgid "Could not load translations"
 msgstr "Could not load translations"

--- a/src/components/OfflineTooltip.js
+++ b/src/components/OfflineTooltip.js
@@ -1,0 +1,49 @@
+import { useOnlineStatus } from '@dhis2/app-runtime'
+import i18n from '@dhis2/d2-i18n'
+import { Tooltip } from '@dhis2/ui'
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import React from 'react'
+import classes from './styles/OfflineTooltip.module.css'
+
+const OfflineTooltip = ({ disabledWhenOffline, disabled, content, children }) => {
+    const { offline } = useOnlineStatus()
+
+    const notAllowed = disabled || (disabledWhenOffline && offline)
+
+    return (
+        <Tooltip
+            content={content || i18n.t('Not available offline')}
+            openDelay={200}
+            closeDelay={100}
+        >
+            {({ onMouseOver, onMouseOut, ref }) => (
+                <span
+                    className={cx(
+                        classes.span,
+                        notAllowed && classes.notAllowed
+                    )}
+                    onMouseOver={() => notAllowed && onMouseOver()}
+                    onMouseOut={() => notAllowed && onMouseOut()}
+                    ref={ref}
+                >
+                    {children}
+                </span>
+            )}
+        </Tooltip>
+    )
+}
+
+OfflineTooltip.propTypes = {
+    children: PropTypes.node,
+    content: PropTypes.string,
+    disabled: PropTypes.bool,
+    disabledWhenOffline: PropTypes.bool,
+}
+
+OfflineTooltip.defaultProps = {
+    disabled: false,
+    disabledWhenOffline: true,
+}
+
+export { OfflineTooltip }

--- a/src/components/OfflineTooltip.js
+++ b/src/components/OfflineTooltip.js
@@ -6,7 +6,12 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import classes from './styles/OfflineTooltip.module.css'
 
-const OfflineTooltip = ({ disabledWhenOffline, disabled, content, children }) => {
+const OfflineTooltip = ({
+    disabledWhenOffline,
+    disabled,
+    content,
+    children,
+}) => {
     const { offline } = useOnlineStatus()
 
     const notAllowed = disabled || (disabledWhenOffline && offline)

--- a/src/components/TranslationDialog/TranslationModal/TranslationModalActions.js
+++ b/src/components/TranslationDialog/TranslationModal/TranslationModalActions.js
@@ -41,9 +41,7 @@ export const TranslationModalActions = ({
                     <OfflineTooltip
                         content={i18n.t('Cannot save while offline')}
                     >
-                        <SaveButton
-                            disabled={true}
-                        />
+                        <SaveButton disabled={true} />
                     </OfflineTooltip>
                 ) : (
                     <SaveButton

--- a/src/components/TranslationDialog/TranslationModal/TranslationModalActions.js
+++ b/src/components/TranslationDialog/TranslationModal/TranslationModalActions.js
@@ -1,30 +1,61 @@
+import { useOnlineStatus } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import { Button, ButtonStrip, ModalActions } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { OfflineTooltip } from '../../OfflineTooltip.js'
+
+const SaveButton = ({ disabled, loading, onClick }) => (
+    <Button primary onClick={onClick} loading={loading} disabled={disabled}>
+        {i18n.t('Save translations')}
+    </Button>
+)
+
+SaveButton.defaultProps = {
+    disabled: false,
+    loading: false,
+    onClick: Function.prototype,
+}
+
+SaveButton.propTypes = {
+    disabled: PropTypes.bool.isRequired,
+    loading: PropTypes.bool.isRequired,
+    onClick: PropTypes.func.isRequired,
+}
 
 export const TranslationModalActions = ({
     onClose,
     onSave,
     saveInProgress,
     saveButtonDisabled,
-}) => (
-    <ModalActions>
-        <ButtonStrip>
-            <Button secondary onClick={onClose}>
-                {i18n.t('Cancel')}
-            </Button>
-            <Button
-                primary
-                onClick={onSave}
-                loading={saveInProgress}
-                disabled={saveButtonDisabled}
-            >
-                {i18n.t('Save translations')}
-            </Button>
-        </ButtonStrip>
-    </ModalActions>
-)
+}) => {
+    const { offline } = useOnlineStatus()
+
+    return (
+        <ModalActions>
+            <ButtonStrip>
+                <Button secondary onClick={onClose}>
+                    {i18n.t('Cancel')}
+                </Button>
+                {offline ? (
+                    <OfflineTooltip
+                        content={i18n.t('Cannot save while offline')}
+                    >
+                        <SaveButton
+                            disabled={true}
+                        />
+                    </OfflineTooltip>
+                ) : (
+                    <SaveButton
+                        onClick={onSave}
+                        loading={saveInProgress}
+                        disabled={saveButtonDisabled}
+                    />
+                )}
+            </ButtonStrip>
+        </ModalActions>
+    )
+}
 
 TranslationModalActions.propTypes = {
     onClose: PropTypes.func.isRequired,

--- a/src/components/styles/OfflineTooltip.module.css
+++ b/src/components/styles/OfflineTooltip.module.css
@@ -1,0 +1,11 @@
+.span {
+    display: inline-flex;
+    pointer-events: all;
+}
+.span > :global(button:disabled) {
+    pointer-events: none;
+}
+
+.notAllowed {
+    cursor: not-allowed;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -34,6 +34,8 @@ export { InterpretationModal } from './components/Interpretations/Interpretation
 
 export { TranslationDialog } from './components/TranslationDialog/index.js'
 
+export { OfflineTooltip } from './components/OfflineTooltip.js'
+
 export {
     CachedDataQueryProvider,
     useCachedDataQuery,

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,8 @@ export { default as AboutAOUnit } from './components/AboutAOUnit/AboutAOUnit.js'
 export { InterpretationsUnit } from './components/Interpretations/InterpretationsUnit/InterpretationsUnit.js'
 export { InterpretationModal } from './components/Interpretations/InterpretationModal/InterpretationModal.js'
 
+export { TranslationDialog } from './components/TranslationDialog/index.js'
+
 export {
     CachedDataQueryProvider,
     useCachedDataQuery,


### PR DESCRIPTION
**Relates to https://github.com/dhis2/dashboard-app/pull/2111**

---

### Key features

1. export `TranslationDialog` component for direct use

---

### Description

The `TranslationDialog` component is normally used via the `FileMenu` in most apps.
However in some cases it's used directly in the app, ie. in dashboard app which does not use the `FileMenu`.
In order to be used directly it needs to be exported.