### PR TITLE
fix: parse markdown in description DHIS2-13911

### DIFF
--- a/src/components/AboutAOUnit/AboutAOUnit.js
+++ b/src/components/AboutAOUnit/AboutAOUnit.js
@@ -1,5 +1,6 @@
 import { useDataQuery, useDataMutation } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
+import { Parser as RichTextParser } from '@dhis2/d2-ui-rich-text'
 import {
     Button,
     CircularLoader,
@@ -190,9 +191,13 @@ const AboutAOUnit = forwardRef(({ type, id, renderId }, ref) => {
                                     noDescription: !data.ao.displayDescription,
                                 })}
                             >
-                                {data.ao.displayDescription
-                                    ? data.ao.displayDescription
-                                    : i18n.t('No description')}
+                                {data.ao.displayDescription ? (
+                                    <RichTextParser>
+                                        {data.ao.displayDescription}
+                                    </RichTextParser>
+                                ) : (
+                                    i18n.t('No description')
+                                )}
                             </p>
                             <div>
                                 <p className="detailLine">


### PR DESCRIPTION
Implements [DHIS2-13911](https://dhis2.atlassian.net/browse/DHIS2-13911)

---

### Key features

1. parse markdown in AO description

---

### Description

The old `d2-ui` interpretations component parsed the markdown in the AO description.
This PR fixes the regression.
The regression applies to DV, LL and Maps analytics apps.

---

### Screenshots

DV:
<img width="400" alt="Screenshot 2022-10-13 at 16 21 01" src="https://user-images.githubusercontent.com/150978/195623925-8b80f48a-faf1-4049-99f5-413856232c7b.png">

LL:
<img width="395" alt="Screenshot 2022-10-13 at 16 20 49" src="https://user-images.githubusercontent.com/150978/195623958-40bac4b4-ff21-489f-8527-1673675fb3ba.png">

