### PR TITLE
fix: pass required prop to plugin used in interpretation modal

### DIFF
--- a/src/components/Interpretations/InterpretationModal/InterpretationModal.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationModal.js
@@ -165,7 +165,7 @@ const InterpretationModal = ({
                                         }
                                         displayProperty={
                                             currentUser.settings
-                                                .keyAnalysisDisplayProperty
+                                                ?.keyAnalysisDisplayProperty
                                         }
                                     />
                                 </div>

--- a/src/components/Interpretations/InterpretationModal/InterpretationModal.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationModal.js
@@ -163,6 +163,10 @@ const InterpretationModal = ({
                                         onResponsesReceived={
                                             onResponsesReceived
                                         }
+                                        displayProperty={
+                                            currentUser.settings
+                                                .keyAnalysisDisplayProperty
+                                        }
                                     />
                                 </div>
                                 <div className="thread-wrap">


### PR DESCRIPTION
**Relates to https://github.com/dhis2/data-visualizer-app/pull/2166**
**Relates to https://github.com/dhis2/line-listing-app/pull/252**

---

### Key features

1. pass `displayProperty` prop to the visualization plugin used in the interpretation modal

---

### Description

Some refactoring was needed in the plugins to make them work independently from the app, so that they can be used directly in dashboard app.
This required some changes to remove any code dependant on the app.
Instead, the required data needs to be passed to the plugin in props or directly accessed by the plugin itself.
Some of this data requires api requests which are typically already done in the apps using the plugin.
This is the case for `displayProperty` which is needed in the analytics request.
This comes from the user settings, which all apps fetch at some point, so it can be passed to plugin.

The `InterpretationModal` component is another consumer of the plugins, and has access to the user settings, so it also needs to pass the `displayProperty` prop to the plugins.