### PR TITLE
fix: require onSaveAs function to enable save as in file menu (DHIS2-14087)

### DIFF
--- a/src/components/FileMenu/FileMenu.js
+++ b/src/components/FileMenu/FileMenu.js
@@ -122,7 +122,7 @@ export const FileMenu = ({
                     <SaveAsDialog
                         type={fileType}
                         object={fileObject}
-                        onSaveAs={onSaveAs}
+                        onSaveAs={onSaveAs || Function.prototype}
                         onClose={onDialogClose}
                     />
                 )
@@ -225,9 +225,9 @@ export const FileMenu = ({
                                 icon={
                                     <IconSave24
                                         color={
-                                            fileObject?.id
-                                                ? iconActiveColor
-                                                : iconInactiveColor
+                                            !(onSaveAs && fileObject?.id)
+                                                ? iconInactiveColor
+                                                : iconActiveColor
                                         }
                                     />
                                 }
@@ -352,7 +352,6 @@ FileMenu.defaultProps = {
     onNew: Function.prototype,
     onOpen: Function.prototype,
     onRename: Function.prototype,
-    onSaveAs: Function.prototype,
     onShare: Function.prototype,
     onTranslate: Function.prototype,
 }

--- a/src/components/FileMenu/FileMenu.js
+++ b/src/components/FileMenu/FileMenu.js
@@ -231,7 +231,7 @@ export const FileMenu = ({
                                         }
                                     />
                                 }
-                                disabled={!fileObject?.id}
+                                disabled={!(onSaveAs && fileObject?.id)}
                                 onClick={onMenuItemClick('saveas')}
                                 dataTest="file-menu-saveas"
                             />


### PR DESCRIPTION
Part of the fix for [DHIS2-14087](https://dhis2.atlassian.net/browse/DHIS2-14087)

Line 234 is the key in this PR.

**Previous behaviour**
Only `fileObject?.id` was needed to enable "Save as" in the file menu. The `onSaveAs` function was not required. The save as dialog is not useful without this function though, so all apps using the file menu are passing it.

**New behaviour**
The `onSaveAs` function is now required to enable "Save as" in the file menu. This allows apps to disable "Save as" by not passing the function. This flexibility is needed in e.g. the Line Listing app because of a possible state where a saved visualization is loaded (so there is an id), but then the program is cleared and thus saving is not allowed. This state is called "DIRTY no program" in the table overview in this ticket https://dhis2.atlassian.net/browse/DHIS2-14087.