### PR TITLE
fix: avoid canceled request error in TranslationDialog

### DIFF
--- a/src/components/FileMenu/FileMenu.js
+++ b/src/components/FileMenu/FileMenu.js
@@ -87,7 +87,10 @@ export const FileMenu = ({
                         objectToTranslate={fileObject}
                         fieldsToTranslate={['name', 'description']}
                         onClose={onDialogClose}
-                        onTranslationSaved={onTranslate}
+                        onTranslationSaved={() => {
+                            onDialogClose()
+                            onTranslate()
+                        }}
                     />
                 )
             case 'sharing':

--- a/src/components/TranslationDialog/TranslationModal/TranslationForm.js
+++ b/src/components/TranslationDialog/TranslationModal/TranslationForm.js
@@ -95,7 +95,6 @@ export const TranslationForm = ({
         {
             onComplete: () => {
                 onTranslationSaved()
-                onClose()
             },
             onError: (error) => showError(error),
         }


### PR DESCRIPTION
Implements [DHIS2-14145](https://dhis2.atlassian.net/browse/DHIS2-14145)

**Relates to https://github.com/dhis2/line-listing-app/pull/285**

---

### Key features

1. avoid canceled request error in TranslationDialog

---

### Description

There is an edge case where the TranslationModal is rendered after the translations are saved just before it's closed.
This re-render causes a `useEffect` to run where a request to `i18n` API is performed.
This request is canceled as soon as the modal is closed, throwing an error that is shown in the AlertBar.

This request can be avoided if the Modal is closed after saving the translations *before* the callback is called.

This issue happened in LL app.

---

### Screenshots

Before: error shown in the `AlertBar`:

<img width="505" alt="Screenshot 2022-11-17 at 11 51 06" src="https://user-images.githubusercontent.com/150978/202427256-ae996478-cc11-4c24-812c-94034ce7a64d.png">

Before: canceled request:

<img width="503" alt="Screenshot 2022-11-17 at 11 51 17" src="https://user-images.githubusercontent.com/150978/202427243-9bfefb6c-0e23-47bd-9c9c-95fe40441f28.png">

After: the canceled request after saving the translations is gone:

<img width="489" alt="Screenshot 2022-11-17 at 11 59 34" src="https://user-images.githubusercontent.com/150978/202429361-8f9aa8da-91fa-430c-8e50-2ee85bec4e11.png">

