### PR TITLE
fix: do not pass translation object when value is empty

### DIFF
--- a/src/components/TranslationDialog/TranslationModal/TranslationForm.js
+++ b/src/components/TranslationDialog/TranslationModal/TranslationForm.js
@@ -64,13 +64,33 @@ export const TranslationForm = ({
 
         const translationIndex = getTranslationIndexForField(field)
 
-        setNewTranslations(
-            translationIndex === -1
-                ? [...newTranslations, newTranslation]
-                : newTranslations.map((translation, index) =>
-                      index === translationIndex ? newTranslation : translation
-                  )
-        )
+        if (translationIndex === -1) {
+            // non existing translation, adding new
+            setNewTranslations([...newTranslations, newTranslation])
+        } else {
+            // cleared existing translation, remove it from the list
+            if (!translation) {
+                setNewTranslations(
+                    newTranslations.reduce((tmp, translation, index) => {
+                        if (index !== translationIndex) {
+                            tmp.push(translation)
+                        }
+
+                        return tmp
+                    }, [])
+                )
+            }
+            // replace existing translation with new one
+            else {
+                setNewTranslations(
+                    newTranslations.map((translation, index) =>
+                        index === translationIndex
+                            ? newTranslation
+                            : translation
+                    )
+                )
+            }
+        }
     }
 
     const i18nMutationRef = useRef({


### PR DESCRIPTION
Fixes [DHIS2-14347](https://dhis2.atlassian.net/browse/DHIS2-14347)

---

### Key features

1. fix payload to avoid 409 conflict when saving an empty translation

---

### Description

This causes a 409 response from the translations API. If the input field is cleared, assuming the user wants to remove a translation for a language/string entirely, do not pass the object with an empty value, but remove it entirely from the list of translations. We still need to pass the full list of translations because the API does not support PATCH requests so the logic is a bit more complex.

### Screencast

Screencast demonstrating the fix, no errors are thrown when saving empty translations:

https://user-images.githubusercontent.com/150978/208868968-9d34409e-0945-44bd-ac17-36b89b9c4377.mov

