### PR TITLE
fix: typo in dataTest

### DIFF
--- a/src/components/DimensionsPanel/List/DimensionItem.js
+++ b/src/components/DimensionsPanel/List/DimensionItem.js
@@ -101,7 +101,7 @@ class DimensionItem extends Component {
                     className="label"
                     tabIndex={0}
                     style={styles.label}
-                    dataTest={`${dataTest}-button-${id}`}
+                    data-test={`${dataTest}-button-${id}`}
                 >
                     <div style={styles.iconWrapper}>{Icon}</div>
                     <div style={styles.labelWrapper}>

--- a/src/components/DimensionsPanel/List/__tests__/__snapshots__/DimensionItem.spec.js.snap
+++ b/src/components/DimensionsPanel/List/__tests__/__snapshots__/DimensionItem.spec.js.snap
@@ -20,7 +20,7 @@ exports[`DimensionItem matches the snapshot 1`] = `
 >
   <div
     className="label"
-    dataTest="undefined-button-pe"
+    data-test="undefined-button-pe"
     style={
       Object {
         "display": "flex",
@@ -96,7 +96,7 @@ exports[`DimensionItem matches the snapshot with locked 1`] = `
 >
   <div
     className="label"
-    dataTest="undefined-button-pe"
+    data-test="undefined-button-pe"
     style={
       Object {
         "display": "flex",
@@ -183,7 +183,7 @@ exports[`DimensionItem matches the snapshot with onOptionsClick 1`] = `
 >
   <div
     className="label"
-    dataTest="undefined-button-pe"
+    data-test="undefined-button-pe"
     style={
       Object {
         "display": "flex",
@@ -270,7 +270,7 @@ exports[`DimensionItem matches the snapshot with recommended 1`] = `
 >
   <div
     className="label"
-    dataTest="undefined-button-pe"
+    data-test="undefined-button-pe"
     style={
       Object {
         "display": "flex",
@@ -348,7 +348,7 @@ exports[`DimensionItem matches the snapshot with selected 1`] = `
 >
   <div
     className="label"
-    dataTest="undefined-button-pe"
+    data-test="undefined-button-pe"
     style={
       Object {
         "display": "flex",


### PR DESCRIPTION
https://github.com/dhis2/analytics/pull/1390/files#diff-f0a9f676ea0191ad7500f5d8249d8af5e177ceef0f2f262c8113f6f4677b4190R100 contains a typo, `dataTest` is used, but the DOM element was changed from a component (`DimensionLabel`) to a regular element (`div`), so `data-test` should've been used instead.
An easy thing to overlook, but turns out this is causing 250 failing tests in DV here https://github.com/dhis2/data-visualizer-app/pull/2222 😢 