### PR TITLE
feat: use multi-calendar-dates library to generate fixed periods

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,11 @@
         "styled-jsx": "^4.0.1",
         "typeface-roboto": "^0.0.75"
     },
+    "jest": {
+        "transformIgnorePatterns": [
+            "/!node_modules\\/multi-calendar-dates/"
+        ]
+    },
     "peerDependencies": {
         "@dhis2/app-runtime": "^3",
         "@dhis2/d2-i18n": "^1.1",
@@ -59,6 +64,7 @@
     },
     "dependencies": {
         "@dhis2/d2-ui-rich-text": "^7.4.0",
+        "@dhis2/multi-calendar-dates": "1.0.0-beta.21",
         "classnames": "^2.3.1",
         "d2-utilizr": "^0.2.16",
         "d3-color": "^1.2.3",

--- a/src/components/PeriodDimension/PeriodTransfer.js
+++ b/src/components/PeriodDimension/PeriodTransfer.js
@@ -25,7 +25,7 @@ const PeriodTransfer = ({
     rightFooter,
     excludedPeriodTypes,
 }) => {
-    const { systemInfo = {} } = useConfig()
+    const { systemInfo } = useConfig()
     const { calendar = 'gregory' } = systemInfo
 
     const defaultRelativePeriodType = excludedPeriodTypes.includes(MONTHLY)

--- a/src/components/PeriodDimension/PeriodTransfer.js
+++ b/src/components/PeriodDimension/PeriodTransfer.js
@@ -35,9 +35,10 @@ const PeriodTransfer = ({
         ? getFixedPeriodsOptionsById(QUARTERLY, calendar)
         : getFixedPeriodsOptionsById(MONTHLY, calendar)
 
+    const now = getNowInCalendar(calendar)
     // use ".eraYear" rather than ".year" because in Ethiopian calendar, eraYear is what our users expect to see (for other calendars, it doesn't matter)
     // there is still a pending decision in Temporal regarding which era to use by default: https://github.com/js-temporal/temporal-polyfill/blob/9350ee7dd0d29f329fc097debf923a517c32f813/lib/calendar.ts#L1964
-    const defaultFixedPeriodYear = getNowInCalendar(calendar).eraYear
+    const defaultFixedPeriodYear = now.eraYear || now.year
 
     const fixedPeriodConfig = (year) => ({
         offset: year - defaultFixedPeriodYear,

--- a/src/components/PeriodDimension/PeriodTransfer.js
+++ b/src/components/PeriodDimension/PeriodTransfer.js
@@ -1,3 +1,5 @@
+import { useConfig } from '@dhis2/app-runtime'
+import { getNowInCalendar } from '@dhis2/multi-calendar-dates'
 import { TabBar, Tab, Transfer } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
@@ -23,13 +25,20 @@ const PeriodTransfer = ({
     rightFooter,
     excludedPeriodTypes,
 }) => {
+    const { systemInfo = {} } = useConfig()
+    const { calendar = 'gregory' } = systemInfo
+
     const defaultRelativePeriodType = excludedPeriodTypes.includes(MONTHLY)
         ? getRelativePeriodsOptionsById(QUARTERLY)
         : getRelativePeriodsOptionsById(MONTHLY)
     const defaultFixedPeriodType = excludedPeriodTypes.includes(MONTHLY)
-        ? getFixedPeriodsOptionsById(QUARTERLY)
-        : getFixedPeriodsOptionsById(MONTHLY)
-    const defaultFixedPeriodYear = new Date().getFullYear()
+        ? getFixedPeriodsOptionsById(QUARTERLY, calendar)
+        : getFixedPeriodsOptionsById(MONTHLY, calendar)
+
+    // use ".eraYear" rather than ".year" because in Ethiopian calendar, eraYear is what our users expect to see (for other calendars, it doesn't matter)
+    // there is still a pending decision in Temporal regarding which era to use by default: https://github.com/js-temporal/temporal-polyfill/blob/9350ee7dd0d29f329fc097debf923a517c32f813/lib/calendar.ts#L1964
+    const defaultFixedPeriodYear = getNowInCalendar(calendar).eraYear
+
     const fixedPeriodConfig = (year) => ({
         offset: year - defaultFixedPeriodYear,
         filterFuturePeriods: false,
@@ -60,7 +69,8 @@ const PeriodTransfer = ({
                           relativeFilter.periodType
                       ).getPeriods()
                     : getFixedPeriodsOptionsById(
-                          fixedFilter.periodType
+                          fixedFilter.periodType,
+                          calendar
                       ).getPeriods(fixedPeriodConfig(Number(fixedFilter.year)))
             )
         }
@@ -134,8 +144,9 @@ const PeriodTransfer = ({
     const onSelectFixedPeriods = (filter) => {
         setFixedFilter(filter)
         setAllPeriods(
-            getFixedPeriodsOptionsById(filter.periodType).getPeriods(
-                fixedPeriodConfig(Number(filter.year))
+            getFixedPeriodsOptionsById(filter.periodType, calendar).getPeriods(
+                fixedPeriodConfig(Number(filter.year)),
+                calendar
             )
         )
     }

--- a/src/components/PeriodDimension/__tests__/PeriodSelector.spec.js
+++ b/src/components/PeriodDimension/__tests__/PeriodSelector.spec.js
@@ -2,6 +2,10 @@ import { shallow } from 'enzyme'
 import React from 'react'
 import PeriodTransfer from '../PeriodTransfer.js'
 
+jest.mock('@dhis2/app-runtime', () => ({
+    useConfig: () => ({ systemInfo: {} }),
+}))
+
 describe('The Period Selector component', () => {
     let props
     let shallowPeriodTransfer

--- a/src/components/PeriodDimension/utils/fixedPeriods.js
+++ b/src/components/PeriodDimension/utils/fixedPeriods.js
@@ -50,7 +50,9 @@ const getPeriods = ({ periodType, config, fnFilter, calendar }) => {
     const isReverse = periodType.match(/^FY|YEARLY/)
         ? true
         : config.reversePeriods
-    const year = getNowInCalendar(calendar).eraYear + offset
+
+    const now = getNowInCalendar(calendar)
+    const year = (now.eraYear || now.year) + offset
 
     const params = {
         periodType,

--- a/src/components/PeriodDimension/utils/fixedPeriods.js
+++ b/src/components/PeriodDimension/utils/fixedPeriods.js
@@ -1,3 +1,7 @@
+import {
+    generateFixedPeriods,
+    getNowInCalendar,
+} from '@dhis2/multi-calendar-dates'
 import i18n from '../../../locales/index.js'
 import {
     DAILY,
@@ -40,510 +44,169 @@ const PERIOD_TYPE_REGEX = {
     [FYAPR]: /^([0-9]{4})April$/, // YYYY"April"
 }
 
-const getMonthName = (key) => {
-    const monthNames = [
-        i18n.t('January'),
-        i18n.t('February'),
-        i18n.t('March'),
-        i18n.t('April'),
-        i18n.t('May'),
-        i18n.t('June'),
-        i18n.t('July'),
-        i18n.t('August'),
-        i18n.t('September'),
-        i18n.t('October'),
-        i18n.t('November'),
-        i18n.t('December'),
-    ]
+const getPeriods = ({ periodType, config, fnFilter, calendar }) => {
+    const offset = parseInt(config.offset, 10)
+    const isFilter = config.filterFuturePeriods
+    const isReverse = periodType.match(/^FY|YEARLY/)
+        ? true
+        : config.reversePeriods
+    const year = getNowInCalendar(calendar).eraYear + offset
 
-    return monthNames[key]
+    const params = {
+        periodType,
+        year,
+        calendar,
+        locale: 'en',
+        startingDay: config.startDay,
+    }
+
+    let periods = generateFixedPeriods(params)
+
+    periods = isFilter ? fnFilter(periods) : periods
+    periods = !isReverse ? periods : periods.reverse()
+
+    return periods
 }
 
-const getDailyPeriodType = (formatYyyyMmDd, fnFilter) => {
+const getDailyPeriodType = (fnFilter, calendar) => {
     return (config) => {
-        let periods = []
-        const offset = parseInt(config.offset, 10)
-        const isFilter = config.filterFuturePeriods
-        const isReverse = config.reversePeriods
-        const year = new Date(Date.now()).getFullYear() + offset
-        const date = new Date(`01 Jan ${year}`)
-
-        while (date.getFullYear() === year) {
-            const period = {}
-            period.startDate = formatYyyyMmDd(date)
-            period.endDate = period.startDate
-            period.name = period.startDate
-            period.iso = period.startDate.replace(/-/g, '')
-            period.id = period.iso
-            periods.push(period)
-            date.setDate(date.getDate() + 1)
-        }
-
-        periods = isFilter ? fnFilter(periods) : periods
-        periods = isReverse ? periods.reverse() : periods
-
-        return periods
+        return getPeriods({
+            periodType: 'DAILY',
+            config,
+            fnFilter,
+            calendar,
+        })
     }
 }
 
-const getWeeklyPeriodType = (formatYyyyMmDd, weekObj, fnFilter) => {
-    // Calculate the first date of an EPI year base on ISO standard  ( first week always contains 4th Jan )
-    const getEpiWeekStartDay = (year, startDayOfWeek) => {
-        const jan4 = new Date(year, 0, 4)
-        const jan4DayOfWeek = jan4.getDay()
-        const startDate = jan4
-        const dayDiff = jan4DayOfWeek - startDayOfWeek
-
-        if (dayDiff > 0) {
-            startDate.setDate(jan4.getDate() - dayDiff)
-        } else if (dayDiff < 0) {
-            startDate.setDate(jan4.getDate() - dayDiff)
-            startDate.setDate(startDate.getDate() - 7)
-        }
-
-        return startDate
-    }
-
+const getWeeklyPeriodType = (weekObj, fnFilter, calendar) => {
     return (config) => {
-        let periods = []
-        const offset = parseInt(config.offset, 10)
-        const isFilter = config.filterFuturePeriods
-        const isReverse = config.reversePeriods
-        const year = new Date(Date.now()).getFullYear() + offset
-        const date = getEpiWeekStartDay(year, weekObj.startDay)
-        let week = 1
-
-        while (date.getFullYear() <= year) {
-            const period = {}
-            period.startDate = formatYyyyMmDd(date)
-            period.iso = `${year}${weekObj.shortName}W${week}`
-            period.id = period.iso
-            date.setDate(date.getDate() + 6)
-            period.endDate = formatYyyyMmDd(date)
-
-            const weekNumber = week
-            period.name = `${i18n.t('Week {{weekNumber}}', { weekNumber })} - ${
-                period.startDate
-            } - ${period.endDate}`
-
-            // if end date is Jan 4th or later, week belongs to next year
-            if (date.getFullYear() > year && date.getDate() >= 4) {
-                break
-            }
-
-            periods.push(period)
-            date.setDate(date.getDate() + 1)
-
-            week += 1
-        }
-
-        periods = isFilter ? fnFilter(periods) : periods
-        periods = isReverse ? periods.reverse() : periods
-
-        return periods
+        return getPeriods({
+            periodType: 'WEEKLY',
+            config: {
+                ...config,
+                startDay: weekObj.startDay,
+            },
+            fnFilter,
+            calendar,
+        })
     }
 }
 
-const getBiWeeklyPeriodType = (formatYyyyMmDd, fnFilter) => {
+const getBiWeeklyPeriodType = (fnFilter, calendar) => {
     return (config) => {
-        let periods = []
-        const offset = parseInt(config.offset, 10)
-        const isFilter = config.filterFuturePeriods
-        const isReverse = config.reversePeriods
-        const year = new Date(Date.now()).getFullYear() + offset
-        const date = new Date(`01 Jan ${year}`)
-        const day = date.getDay()
-        let biWeek = 1
-
-        if (day <= 4) {
-            date.setDate(date.getDate() - (day - 1))
-        } else {
-            date.setDate(date.getDate() + (8 - day))
-        }
-
-        while (date.getFullYear() <= year) {
-            const period = {}
-
-            period.iso = `${year}BiW${biWeek}`
-            period.id = period.iso
-            period.startDate = formatYyyyMmDd(date)
-            date.setDate(date.getDate() + 13)
-
-            period.endDate = formatYyyyMmDd(date)
-            const biWeekNumber = biWeek
-            period.name = `${i18n.t('Bi-Week {{biWeekNumber}}', {
-                biWeekNumber,
-            })} - ${period.startDate} - ${period.endDate}`
-
-            // if end date is Jan 4th or later, biweek belongs to next year
-            if (date.getFullYear() > year && date.getDate() >= 4) {
-                break
-            }
-
-            periods.push(period)
-
-            date.setDate(date.getDate() + 1)
-
-            biWeek += 1
-        }
-
-        periods = isFilter ? fnFilter(periods) : periods
-        periods = isReverse ? periods.reverse() : periods
-
-        return periods
+        return getPeriods({
+            periodType: 'BIWEEKLY',
+            config,
+            fnFilter,
+            calendar,
+        })
     }
 }
 
-const getMonthlyPeriodType = (formatYyyyMmDd, fnFilter) => {
-    const formatIso = (date) => {
-        const y = date.getFullYear()
-        let m = String(date.getMonth() + 1)
-
-        m = m.length < 2 ? `0${m}` : m
-
-        return y + m
-    }
-
+const getMonthlyPeriodType = (fnFilter, calendar) => {
     return (config) => {
-        let periods = []
-
-        const offset = parseInt(config.offset, 10)
-        const isFilter = config.filterFuturePeriods
-        const isReverse = config.reversePeriods
-        const year = new Date(Date.now()).getFullYear() + offset
-        const date = new Date(`31 Dec ${year}`)
-
-        while (date.getFullYear() === year) {
-            const period = {}
-
-            period.endDate = formatYyyyMmDd(date)
-            date.setDate(1)
-            period.startDate = formatYyyyMmDd(date)
-            const monthName = getMonthName(date.getMonth())
-            period.name = `${monthName} ${year}`
-            period.iso = formatIso(date)
-            period.id = period.iso
-
-            periods.push(period)
-            date.setDate(0)
-        }
-
-        periods = isFilter ? fnFilter(periods) : periods
-        periods = isReverse ? periods : periods.reverse()
-        // Months are collected backwards. If isReverse is true, then do nothing. Else reverse to correct order and return.
-
-        return periods
+        return getPeriods({ periodType: 'MONTHLY', config, fnFilter, calendar })
     }
 }
 
-const getBiMonthlyPeriodType = (formatYyyyMmDd, fnFilter) => {
+const getBiMonthlyPeriodType = (fnFilter, calendar) => {
     return (config) => {
-        let periods = []
-        const offset = parseInt(config.offset, 10)
-        const isFilter = config.filterFuturePeriods
-        const isReverse = config.reversePeriods
-        const year = new Date(Date.now()).getFullYear() + offset
-        const date = new Date(`31 Dec ${year}`)
-        let index = 6
-
-        while (date.getFullYear() === year) {
-            const period = {}
-
-            period.endDate = formatYyyyMmDd(date)
-            date.setDate(0)
-            date.setDate(1)
-            period.startDate = formatYyyyMmDd(date)
-            const monthStart = getMonthName(date.getMonth())
-            const monthEnd = getMonthName(date.getMonth() + 1)
-            const fullYear = date.getFullYear()
-            period.name = `${monthStart} - ${monthEnd} ${fullYear}`
-            period.iso = `${year}0${index}B`
-            period.id = period.iso
-            periods.push(period)
-            date.setDate(0)
-
-            index--
-        }
-
-        periods = isFilter ? fnFilter(periods) : periods
-        periods = isReverse ? periods : periods.reverse()
-        // Bi-months are collected backwards. If isReverse is true, then do nothing. Else reverse to correct order and return.
-
-        return periods
+        return getPeriods({
+            periodType: 'BIMONTHLY',
+            config,
+            fnFilter,
+            calendar,
+        })
     }
 }
 
-const getQuarterlyPeriodType = (formatYyyyMmDd, fnFilter) => {
+const getQuarterlyPeriodType = (fnFilter, calendar) => {
     return (config) => {
-        let periods = []
-        const offset = parseInt(config.offset, 10)
-        const isFilter = config.filterFuturePeriods
-        const isReverse = config.reversePeriods
-        const year = new Date(Date.now()).getFullYear() + offset
-        const date = new Date(`31 Dec ${year}`)
-        let quarter = 4
-
-        while (date.getFullYear() === year) {
-            const period = {}
-            period.endDate = formatYyyyMmDd(date)
-            date.setDate(0)
-            date.setDate(0)
-            date.setDate(1)
-            period.startDate = formatYyyyMmDd(date)
-            const monthStart = getMonthName(date.getMonth())
-            const monthEnd = getMonthName(date.getMonth() + 2)
-            const fullYear = date.getFullYear()
-            period.name = `${monthStart} - ${monthEnd} ${fullYear}`
-            period.iso = `${year}Q${quarter}`
-            period.id = period.iso
-            periods.push(period)
-            date.setDate(0)
-            quarter -= 1
-        }
-
-        periods = isFilter ? fnFilter(periods) : periods
-        periods = isReverse ? periods : periods.reverse()
-        // Quarters are collected backwards. If isReverse is true, then do nothing. Else reverse to correct order and return.
-
-        return periods
+        return getPeriods({
+            periodType: 'QUARTERLY',
+            config,
+            fnFilter,
+            calendar,
+        })
     }
 }
 
-const getSixMonthlyPeriodType = (fnFilter) => {
+const getSixMonthlyPeriodType = (fnFilter, calendar) => {
     return (config) => {
-        let periods = []
-        const offset = parseInt(config.offset, 10)
-        const isFilter = config.filterFuturePeriods
-        const isReverse = config.reversePeriods
-        const year = new Date(Date.now()).getFullYear() + offset
-
-        let period = {}
-        period.startDate = `${year}-01-01`
-        period.endDate = `${year}-06-30`
-        period.name = `${getMonthName(0)} - ${getMonthName(5)} ${year}`
-        period.iso = `${year}S1`
-        period.id = period.iso
-        periods.push(period)
-
-        period = {}
-        period.startDate = `${year}-07-01`
-        period.endDate = `${year}-12-31`
-        period.name = `${getMonthName(6)} - ${getMonthName(11)} ${year}`
-        period.iso = `${year}S2`
-        period.id = period.iso
-        periods.push(period)
-
-        periods = isFilter ? fnFilter(periods) : periods
-        periods = isReverse ? periods.reverse() : periods
-
-        return periods
+        return getPeriods({
+            periodType: 'SIXMONTHLY',
+            config,
+            fnFilter,
+            calendar,
+        })
     }
 }
 
-const getSixMonthlyAprilPeriodType = (fnFilter) => {
+const getSixMonthlyAprilPeriodType = (fnFilter, calendar) => {
     return (config) => {
-        let periods = []
-        const offset = parseInt(config.offset, 10)
-        const isFilter = config.filterFuturePeriods
-        const isReverse = config.reversePeriods
-        const year = new Date(Date.now()).getFullYear() + offset
-
-        let period = {}
-        period.startDate = `${year}-04-01`
-        period.endDate = `${year}-09-30`
-        period.name = `${getMonthName(3)} - ${getMonthName(8)} ${year}`
-        period.iso = `${year}AprilS1`
-        period.id = period.iso
-        periods.push(period)
-
-        period = {}
-        period.startDate = `${year}-10-01`
-        period.endDate = `${year + 1}-03-31`
-        period.name = `${getMonthName(9)} ${year} - ${getMonthName(2)} ${
-            year + 1
-        }`
-        period.iso = `${year}AprilS2`
-        period.id = period.iso
-        periods.push(period)
-
-        periods = isFilter ? fnFilter(periods) : periods
-        periods = isReverse ? periods.reverse() : periods
-
-        return periods
+        return getPeriods({
+            periodType: 'SIXMONTHLYAPR',
+            config,
+            fnFilter,
+            calendar,
+        })
     }
 }
 
-const getYearlyPeriodType = (formatYyyyMmDd, fnFilter) => {
+const getYearlyPeriodType = (fnFilter, calendar) => {
     return (config) => {
-        let periods = []
-        const offset = parseInt(config.offset, 10)
-        const isFilter = config.filterFuturePeriods
-        const isReverse = config.reversePeriods
-        const year = new Date(Date.now()).getFullYear() + offset
-        const date = new Date(`31 Dec ${year}`)
-
-        while (year - date.getFullYear() < 10) {
-            const period = {}
-            period.endDate = formatYyyyMmDd(date)
-            date.setMonth(0, 1)
-            period.startDate = formatYyyyMmDd(date)
-            const dateString = date.getFullYear().toString()
-            period.name = dateString
-            period.iso = date.getFullYear().toString()
-            period.id = period.iso.toString()
-            periods.push(period)
-            date.setDate(0)
-        }
-
-        periods = isFilter ? fnFilter(periods) : periods
-        periods = isReverse ? periods : periods.reverse()
-        // Years are collected backwards. If isReverse is true, then do nothing. Else reverse to correct order and return.
-
-        return periods
+        return getPeriods({
+            periodType: 'YEARLY',
+            config,
+            fnFilter,
+            calendar,
+        })
     }
 }
 
-const getFinancialOctoberPeriodType = (formatYyyyMmDd, fnFilter) => {
+const getFinancialOctoberPeriodType = (fnFilter, calendar) => {
     return (config) => {
-        let periods = []
-        const offset = parseInt(config.offset, 10)
-        const isFilter = config.filterFuturePeriods
-        const isReverse = config.reversePeriods
-        const year = new Date(Date.now()).getFullYear() + offset
-        const date = new Date(`30 Sep ${year + 1}`)
-
-        for (let i = 0; i < 10; i++) {
-            const period = {}
-            period.endDate = formatYyyyMmDd(date)
-            date.setYear(date.getFullYear() - 1)
-            date.setDate(date.getDate() + 1)
-            period.startDate = formatYyyyMmDd(date)
-            const yearStart = date.getFullYear()
-            const yearEnd = date.getFullYear() + 1
-            period.name = `${getMonthName(9)} ${yearStart} - ${getMonthName(
-                8
-            )} ${yearEnd}`
-            period.id = `${date.getFullYear()}Oct`
-            periods.push(period)
-            date.setDate(date.getDate() - 1)
-        }
-
-        periods = isFilter ? fnFilter(periods) : periods
-        periods = isReverse ? periods : periods.reverse()
-        // FinancialOctober periods are collected backwards. If isReverse is true, then do nothing. Else reverse to correct order and return.
-
-        return periods
+        return getPeriods({
+            periodType: 'FYOCT',
+            config,
+            fnFilter,
+            calendar,
+        })
     }
 }
 
-const getFinancialNovemberPeriodType = (formatYyyyMmDd, fnFilter) => {
+const getFinancialNovemberPeriodType = (fnFilter, calendar) => {
     return (config) => {
-        let periods = []
-        const offset = parseInt(config.offset, 10)
-        const isFilter = config.filterFuturePeriods
-        const isReverse = config.reversePeriods
-        const year = new Date(Date.now()).getFullYear() + offset
-        const date = new Date(`31 Oct ${year + 1}`)
-
-        for (let i = 0; i < 10; i++) {
-            const period = {}
-            period.endDate = formatYyyyMmDd(date)
-            date.setYear(date.getFullYear() - 1)
-            date.setDate(date.getDate() + 1)
-            period.startDate = formatYyyyMmDd(date)
-            const yearStart = date.getFullYear()
-            const yearEnd = date.getFullYear() + 1
-            period.name = `${getMonthName(10)} ${yearStart} - ${getMonthName(
-                9
-            )} ${yearEnd}`
-            period.id = `${date.getFullYear()}Nov`
-            periods.push(period)
-            date.setDate(date.getDate() - 1)
-        }
-
-        periods = isFilter ? fnFilter(periods) : periods
-        periods = isReverse ? periods : periods.reverse()
-        // FinancialNovember periods are collected backwards. If isReverse is true, then do nothing. Else reverse to correct order and return.
-
-        return periods
+        return getPeriods({
+            periodType: 'FYNOV',
+            config,
+            fnFilter,
+            calendar,
+        })
     }
 }
 
-const getFinancialJulyPeriodType = (formatYyyyMmDd, fnFilter) => {
+const getFinancialJulyPeriodType = (fnFilter, calendar) => {
     return (config) => {
-        let periods = []
-        const offset = parseInt(config.offset, 10)
-        const isFilter = config.filterFuturePeriods
-        const isReverse = config.reversePeriods
-        const year = new Date(Date.now()).getFullYear() + offset
-        const date = new Date(`30 Jun ${year + 1}`)
-
-        for (let i = 0; i < 10; i++) {
-            const period = {}
-            period.endDate = formatYyyyMmDd(date)
-            date.setYear(date.getFullYear() - 1)
-            date.setDate(date.getDate() + 1)
-            period.startDate = formatYyyyMmDd(date)
-            const yearStart = date.getFullYear()
-            const yearEnd = date.getFullYear() + 1
-            period.name = `${getMonthName(6)} ${yearStart} - ${getMonthName(
-                5
-            )} ${yearEnd}`
-            period.id = `${date.getFullYear()}July`
-            periods.push(period)
-            date.setDate(date.getDate() - 1)
-        }
-
-        periods = isFilter ? fnFilter(periods) : periods
-        periods = isReverse ? periods : periods.reverse()
-        // FinancialJuly periods are collected backwards. If isReverse is true, then do nothing. Else reverse to correct order and return.
-
-        return periods
+        return getPeriods({
+            periodType: 'FYJUL',
+            config,
+            fnFilter,
+            calendar,
+        })
     }
 }
 
-const getFinancialAprilPeriodType = (formatYyyyMmDd, fnFilter) => {
+const getFinancialAprilPeriodType = (fnFilter, calendar) => {
     return (config) => {
-        let periods = []
-        const offset = parseInt(config.offset, 10)
-        const isFilter = config.filterFuturePeriods
-        const isReverse = config.reversePeriods
-        const year = new Date(Date.now()).getFullYear() + offset
-        const date = new Date(`31 Mar ${year + 1}`)
-
-        for (let i = 0; i < 10; i++) {
-            const period = {}
-            period.endDate = formatYyyyMmDd(date)
-            date.setYear(date.getFullYear() - 1)
-            date.setDate(date.getDate() + 1)
-            period.startDate = formatYyyyMmDd(date)
-            const yearStart = date.getFullYear()
-            const yearEnd = date.getFullYear() + 1
-            period.name = `${getMonthName(3)} ${yearStart} - ${getMonthName(
-                2
-            )} ${yearEnd}`
-            period.id = `${date.getFullYear()}April`
-            periods.push(period)
-            date.setDate(date.getDate() - 1)
-        }
-
-        periods = isFilter ? fnFilter(periods) : periods
-        periods = isReverse ? periods : periods.reverse()
-        // FinancialApril periods are collected backwards. If isReverse is true, then do nothing. Else reverse to correct order and return.
-
-        return periods
+        return getPeriods({
+            periodType: 'FYAPR',
+            config,
+            fnFilter,
+            calendar,
+        })
     }
-}
-
-const formatYyyyMmDd = (date) => {
-    const y = date.getFullYear()
-    let m = String(date.getMonth() + 1)
-    let d = String(date.getDate())
-
-    m = m.length < 2 ? `0${m}` : m
-    d = d.length < 2 ? `0${d}` : d
-
-    return `${y}-${m}-${d}`
 }
 
 const filterFuturePeriods = (periods) => {
@@ -559,128 +222,134 @@ const filterFuturePeriods = (periods) => {
     return array
 }
 
-const getOptions = () => [
-    {
-        id: DAILY,
-        getPeriods: getDailyPeriodType(formatYyyyMmDd, filterFuturePeriods),
-        name: i18n.t('Daily'),
-    },
-    {
-        id: WEEKLY,
-        getPeriods: getWeeklyPeriodType(
-            formatYyyyMmDd,
-            { shortName: '', startDay: 1 },
-            filterFuturePeriods
-        ),
-        name: i18n.t('Weekly'),
-    },
-    {
-        id: WEEKLYWED,
-        getPeriods: getWeeklyPeriodType(
-            formatYyyyMmDd,
-            { shortName: 'Wed', startDay: 3 },
-            filterFuturePeriods
-        ),
-        name: i18n.t('Weekly (Start Wednesday)'),
-    },
-    {
-        id: WEEKLYTHU,
-        getPeriods: getWeeklyPeriodType(
-            formatYyyyMmDd,
-            { shortName: 'Thu', startDay: 4 },
-            filterFuturePeriods
-        ),
-        name: i18n.t('Weekly (Start Thursday)'),
-    },
-    {
-        id: WEEKLYSAT,
-        getPeriods: getWeeklyPeriodType(
-            formatYyyyMmDd,
-            { shortName: 'Sat', startDay: 6 },
-            filterFuturePeriods
-        ),
-        name: i18n.t('Weekly (Start Saturday)'),
-    },
-    {
-        id: WEEKLYSUN,
-        getPeriods: getWeeklyPeriodType(
-            formatYyyyMmDd,
-            { shortName: 'Sun', startDay: 7 },
-            filterFuturePeriods
-        ),
-        name: i18n.t('Weekly (Start Sunday)'),
-    },
-    {
-        id: BIWEEKLY,
-        getPeriods: getBiWeeklyPeriodType(formatYyyyMmDd, filterFuturePeriods),
-        name: i18n.t('Bi-weekly'),
-    },
-    {
-        id: MONTHLY,
-        getPeriods: getMonthlyPeriodType(formatYyyyMmDd, filterFuturePeriods),
-        name: i18n.t('Monthly'),
-    },
-    {
-        id: BIMONTHLY,
-        getPeriods: getBiMonthlyPeriodType(formatYyyyMmDd, filterFuturePeriods),
-        name: i18n.t('Bi-monthly'),
-    },
-    {
-        id: QUARTERLY,
-        getPeriods: getQuarterlyPeriodType(formatYyyyMmDd, filterFuturePeriods),
-        name: i18n.t('Quarterly'),
-    },
-    {
-        id: SIXMONTHLY,
-        getPeriods: getSixMonthlyPeriodType(filterFuturePeriods),
-        name: i18n.t('Six-monthly'),
-    },
-    {
-        id: SIXMONTHLYAPR,
-        getPeriods: getSixMonthlyAprilPeriodType(filterFuturePeriods),
-        name: i18n.t('Six-monthly April'),
-    },
-    {
-        id: YEARLY,
-        getPeriods: getYearlyPeriodType(formatYyyyMmDd, filterFuturePeriods),
-        name: i18n.t('Yearly'),
-    },
-    {
-        id: FYNOV,
-        getPeriods: getFinancialNovemberPeriodType(
-            formatYyyyMmDd,
-            filterFuturePeriods
-        ),
-        name: i18n.t('Financial year (Start November)'),
-    },
-    {
-        id: FYOCT,
-        getPeriods: getFinancialOctoberPeriodType(
-            formatYyyyMmDd,
-            filterFuturePeriods
-        ),
-        name: i18n.t('Financial year (Start October)'),
-    },
-    {
-        id: FYJUL,
-        getPeriods: getFinancialJulyPeriodType(
-            formatYyyyMmDd,
-            filterFuturePeriods
-        ),
-        name: i18n.t('Financial year (Start July)'),
-    },
-    {
-        id: FYAPR,
-        getPeriods: getFinancialAprilPeriodType(
-            formatYyyyMmDd,
-            filterFuturePeriods
-        ),
-        name: i18n.t('Financial year (Start April)'),
-    },
-]
+const getOptions = (calendar = 'gregory') => {
+    return [
+        {
+            id: DAILY,
+            getPeriods: getDailyPeriodType(filterFuturePeriods, calendar),
+            name: i18n.t('Daily'),
+        },
+        {
+            id: WEEKLY,
+            getPeriods: getWeeklyPeriodType(
+                { startDay: 1 },
+                filterFuturePeriods,
+                calendar
+            ),
+            name: i18n.t('Weekly'),
+        },
+        {
+            id: WEEKLYWED,
+            getPeriods: getWeeklyPeriodType(
+                { startDay: 3 },
+                filterFuturePeriods,
+                calendar
+            ),
+            name: i18n.t('Weekly (Start Wednesday)'),
+        },
+        {
+            id: WEEKLYTHU,
+            getPeriods: getWeeklyPeriodType(
+                { startDay: 4 },
+                filterFuturePeriods,
+                calendar
+            ),
+            name: i18n.t('Weekly (Start Thursday)'),
+        },
+        {
+            id: WEEKLYSAT,
+            getPeriods: getWeeklyPeriodType(
+                { startDay: 6 },
+                filterFuturePeriods,
+                calendar
+            ),
+            name: i18n.t('Weekly (Start Saturday)'),
+        },
+        {
+            id: WEEKLYSUN,
+            getPeriods: getWeeklyPeriodType(
+                { startDay: 7 },
+                filterFuturePeriods,
+                calendar
+            ),
+            name: i18n.t('Weekly (Start Sunday)'),
+        },
+        {
+            id: BIWEEKLY,
+            getPeriods: getBiWeeklyPeriodType(filterFuturePeriods, calendar),
+            name: i18n.t('Bi-weekly'),
+        },
+        {
+            id: MONTHLY,
+            getPeriods: getMonthlyPeriodType(filterFuturePeriods, calendar),
+            name: i18n.t('Monthly'),
+        },
+        {
+            id: BIMONTHLY,
+            getPeriods: getBiMonthlyPeriodType(filterFuturePeriods, calendar),
+            name: i18n.t('Bi-monthly'),
+        },
+        {
+            id: QUARTERLY,
+            getPeriods: getQuarterlyPeriodType(filterFuturePeriods, calendar),
+            name: i18n.t('Quarterly'),
+        },
+        {
+            id: SIXMONTHLY,
+            getPeriods: getSixMonthlyPeriodType(filterFuturePeriods, calendar),
+            name: i18n.t('Six-monthly'),
+        },
+        {
+            id: SIXMONTHLYAPR,
+            getPeriods: getSixMonthlyAprilPeriodType(
+                filterFuturePeriods,
+                calendar
+            ),
+            name: i18n.t('Six-monthly April'),
+        },
+        {
+            id: YEARLY,
+            getPeriods: getYearlyPeriodType(filterFuturePeriods, calendar),
+            name: i18n.t('Yearly'),
+        },
+        {
+            id: FYNOV,
+            getPeriods: getFinancialNovemberPeriodType(
+                filterFuturePeriods,
+                calendar
+            ),
+            name: i18n.t('Financial year (Start November)'),
+        },
+        {
+            id: FYOCT,
+            getPeriods: getFinancialOctoberPeriodType(
+                filterFuturePeriods,
+                calendar
+            ),
+            name: i18n.t('Financial year (Start October)'),
+        },
+        {
+            id: FYJUL,
+            getPeriods: getFinancialJulyPeriodType(
+                filterFuturePeriods,
+                calendar
+            ),
+            name: i18n.t('Financial year (Start July)'),
+        },
+        {
+            id: FYAPR,
+            getPeriods: getFinancialAprilPeriodType(
+                filterFuturePeriods,
+                calendar
+            ),
+            name: i18n.t('Financial year (Start April)'),
+        },
+    ]
+}
 
-export const getFixedPeriodsOptionsById = (id) =>
-    getOptions().find((option) => option.id === id)
+export const getFixedPeriodsOptionsById = (id, calendar = 'gregory') => {
+    return getOptions(calendar).find((option) => option.id === id)
+}
 
 export const getFixedPeriodsOptions = () => getOptions()
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2202,6 +2202,14 @@
     markdown-it "^8.4.2"
     prop-types "^15.6.2"
 
+"@dhis2/multi-calendar-dates@1.0.0-beta.21":
+  version "1.0.0-beta.21"
+  resolved "https://registry.yarnpkg.com/@dhis2/multi-calendar-dates/-/multi-calendar-dates-1.0.0-beta.21.tgz#389c7bc2e707214255ae92adacb3194fec8428ed"
+  integrity sha512-3ck+r4u+xgUgZOnt9CvUJZ9HoxO01PFBwsJhycCJu/sNJB7frLol+GywLWW0pRZkJiNuTbLyqGmzI3byuJwCXA==
+  dependencies:
+    "@js-temporal/polyfill" "^0.4.2"
+    classnames "^2.3.2"
+
 "@dhis2/prop-types@^3.1.2":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@dhis2/prop-types/-/prop-types-3.1.2.tgz#65b8ad2da8cd2f72bc8b951049a6c9d1b97af3e9"
@@ -2935,6 +2943,14 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@js-temporal/polyfill@^0.4.2":
+  version "0.4.3"
+  resolved "https://registry.yarnpkg.com/@js-temporal/polyfill/-/polyfill-0.4.3.tgz#e8f8cf86745eb5050679c46a5ebedb9a9cc1f09b"
+  integrity sha512-6Fmjo/HlkyVCmJzAPnvtEWlcbQUSRhi8qlN9EtJA/wP7FqXsevLLrlojR44kzNzrRkpf7eDJ+z7b4xQD/Ycypw==
+  dependencies:
+    jsbi "^4.1.0"
+    tslib "^2.3.1"
 
 "@juggle/resize-observer@^3.3.1":
   version "3.3.1"
@@ -6979,6 +6995,11 @@ classnames@^2.2.5, classnames@^2.2.6, classnames@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.1.tgz#dfcfa3891e306ec1dad105d0e88f4417b8535e8e"
   integrity sha512-OlQdbZ7gLfGarSqxesMesDa5uz7KFbID8Kpq/SxIoNGDqY8lSYs0D+hhtBXhcdB3rcbXArFr7vlHheLk1voeNA==
+
+classnames@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
+  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
 
 clean-css@^4.2.3:
   version "4.2.3"
@@ -12655,6 +12676,11 @@ js-yaml@^3.13.1:
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
+
+jsbi@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/jsbi/-/jsbi-4.3.0.tgz#b54ee074fb6fcbc00619559305c8f7e912b04741"
+  integrity sha512-SnZNcinB4RIcnEyZqFPdGPVgrg2AcnykiBy0sHVJQKHYeaLUvi3Exj+iaPpLnFVkDPZIV4U0yvgC9/R4uEAZ9g==
 
 jsbn@~0.1.0:
   version "0.1.1"
@@ -18701,6 +18727,11 @@ tslib@^2.0.0, tslib@^2.0.1:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.1.0.tgz#da60860f1c2ecaa5703ab7d39bc05b6bf988b97a"
   integrity sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
+
+tslib@^2.3.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.4.1.tgz#0d0bfbaac2880b91e22df0768e55be9753a5b17e"
+  integrity sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==
 
 tsutils@^3.17.1:
   version "3.17.1"


### PR DESCRIPTION
This PR updates the logic that calculates the fixed periods to use the [multi-calendar-dates](https://github.com/dhis2/multi-calendar-dates/pull/7) library to generate fixed periods in calendrical systems other than Gregorian (i.e. Ethiopic and Nepali)

Implements [DHIS2-14226](https://dhis2.atlassian.net/browse/DHIS2-14226)

**Relates to  [Support period generation in multi-calendar-dates library](https://github.com/dhis2/multi-calendar-dates/pull/7)** - this PR should not be merged at least until that PR is approved and merged.

### Why?

The multi-calendar-dates library aims to encapsulate and abstract all date related operations for use across DHIS2 frontend stack. It relies on the [Temporal proposal](https://tc39.es/proposal-temporal) which solves many problems with the native JS Date. In our context, the proposal supports calendars other than the Gregorian calendar making it possible to support Nepali and Ethiopic calendars for example. It also provides ways to do arithmetic operations on dates (adding and subtracting periods) in a DST-safe timezone aware manner.  This ability is what powers the period generation here.

The [calendar component](https://pr-1162--dhis2-ui.netlify.app/components/calendar/) was already implemented (beta) in the UI library, and the next requirement was the one addressed here to allow period generation in different calendars.
 
For more context on the multi-calendar project. You can refer to:

- [The project specs](https://docs.google.com/document/d/19zjyB45oBbqC5KeubaU8E7cw9fGhFc3tOXY0GkzZKqc/edit#)
- [ADR on why we used Temporal](https://github.com/dhis2/multi-calendar-dates/blob/beta/doc/architecture/decisions/0002-use-temporal-api-as-the-backbone-for-the-engine.md)
- proj-multi-calendar channel on Slack

---

### Key features

1. Generate fixed periods in multiple calendrical systems (i.e. Gregorian, Nepali, Ethiopic etc...)
2. Get the current date in multiple calendars
3. Consume and use the currently configured calendar in DHIS2

---

### BREAKING CHANGE

No breaking change. The existing period generation logic in analytics came with an exhaustive suite of tests. The library used those as a specs to guide the implementation, and make sure they all pass, so the library should not change the existing behaviour, only extend it to support other calendars ✅ 

---

### TODO

-   [x] The [multi-calendar-dates PR](https://github.com/dhis2/multi-calendar-dates/pull/7) is still in review. Once merged and published to beta and main channels, then the dependency here should be updated. **There is a [task](https://dhis2.atlassian.net/browse/DHIS2-14226) to update these dependencies once we have a final version**
-  [x]  Test with DHIS2 backends that actually implement analytics in other calendrical systems (i.e. The Ethiopia PR / fork) - **this can be done once a version of this library is published**
-  [x] Localisation - we rely on Intl.Locale to localise the date parts. This works for almost all locales (except Nepali which is not part of the unicode locale repository). I need to do more testing and investigation to know what values we exactly pass, and whether that could lead to unexpected behaviour - there is also a related task in the backlog to make the library more resilient to locale requests, falling back to english if a passed locale is not supported.
- [x] We initially thought we will build a set of hooks to be consumed from the multi-calendar-dates library. I chose not to, as I wanted the changes to analytics to be as minimal as possible, but we can discuss this further to see if it's necessary.

---

### Known issues

None so far. I used the tests from analytics to mimic the previous behaviour exactly, and the tests seem quite extensive. But it's a major change, and should go through much more testing.


---

### Screenshots

https://user-images.githubusercontent.com/1014725/210541982-38e59822-0b9b-4508-9041-bd4b0747661a.mov




[DHIS2-14226]: https://dhis2.atlassian.net/browse/DHIS2-14226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-14226]: https://dhis2.atlassian.net/browse/DHIS2-14226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ