### PR TITLE
fix: make icon prop not required

### DIFF
--- a/src/components/OpenFileDialog/CustomSelectOption.js
+++ b/src/components/OpenFileDialog/CustomSelectOption.js
@@ -39,11 +39,11 @@ export const CustomSelectOption = (props) =>
     )
 
 CustomSelectOption.propTypes = {
-    icon: PropTypes.element.isRequired,
     label: PropTypes.string.isRequired,
     value: PropTypes.string.isRequired,
     active: PropTypes.bool,
     disabled: PropTypes.bool,
+    icon: PropTypes.element,
     onClick: PropTypes.func,
 }
 


### PR DESCRIPTION

### Key features

1. remove `required` attribute for the `icon` prop

---

### Description

There are 2 instances of this component where there is no icon: **All types** and **All charts**.
The required prop caused a warning in the console.

---

### Screenshots

This is the component that caused the warning.
The first 2 options don't have an icon.

<img width="303" alt="Screenshot 2023-01-13 at 10 14 30" src="https://user-images.githubusercontent.com/150978/212283069-bb62746a-1d2a-4fd4-9491-726677c825bc.png">

