### PR TITLE
fix: use page number from response DHIS2-11505

### DIFF
--- a/src/components/OpenFileDialog/OpenFileDialog.js
+++ b/src/components/OpenFileDialog/OpenFileDialog.js
@@ -144,6 +144,11 @@ export const OpenFileDialog = ({
 
     const { loading, error, data, refetch } = useDataQuery(filesQuery, {
         lazy: true,
+        onComplete: (response) => {
+            if (page !== response.files.pager.page) {
+                setPage(response.files.pager.page)
+            }
+        },
     })
 
     const resetFilters = () => {
@@ -420,7 +425,7 @@ export const OpenFileDialog = ({
                                 0 && (
                                 <div className="pagination-controls">
                                     <PaginationControls
-                                        page={page}
+                                        page={data.files.pager.page}
                                         pager={data.files.pager}
                                         onPageChange={setPage}
                                     />


### PR DESCRIPTION
Fixes an issue related to [DHIS2-11505](https://dhis2.atlassian.net/browse/DHIS2-11505)

---

### Key features

1. reset current page in local state from pager data in response

---

### Description

This is to avoid the edge case where a page does not exist anymore after deleting the visualization that was listed in it.

The page in the component state needs to be set to the page returned in the response when it differs.

Unfortunately there is an extra request with the not existing page, because until we get the response from the api we don't know if a page has been removed or not as a consequence of deleting visualizations.

---

### Screenshots

_supporting text_


[DHIS2-11505]: https://dhis2.atlassian.net/browse/DHIS2-11505?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ