### PR TITLE
refactor: rewrote fetch logic for infinite scrolling/filtering/search

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-01-25T09:24:22.892Z\n"
-"PO-Revision-Date: 2023-01-25T09:24:22.892Z\n"
+"POT-Creation-Date: 2023-02-01T09:02:27.240Z\n"
+"PO-Revision-Date: 2023-02-01T09:02:27.240Z\n"
 
 msgid "view only"
 msgstr "view only"
@@ -140,6 +140,9 @@ msgstr "Details only"
 msgid "Group"
 msgstr "Group"
 
+msgid "Loading"
+msgstr "Loading"
+
 msgid "Disaggregation"
 msgstr "Disaggregation"
 
@@ -157,9 +160,6 @@ msgstr "All types"
 
 msgid "No data"
 msgstr "No data"
-
-msgid "Loading"
-msgstr "Loading"
 
 msgid "Search by data item name"
 msgstr "Search by data item name"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     },
     "dependencies": {
         "@dhis2/d2-ui-rich-text": "^7.4.0",
+        "@react-hook/debounce": "^4.0.0",
         "classnames": "^2.3.1",
         "d2-utilizr": "^0.2.16",
         "d3-color": "^1.2.3",

--- a/src/components/DataDimension/DataElementSelector.js
+++ b/src/components/DataDimension/DataElementSelector.js
@@ -263,37 +263,39 @@ const DataElementSelector = ({ displayNameProp, onSelect }) => {
                     onChange={(subGroup) => onFilterChange({ subGroup })}
                 />
             </div>
-            <div className="dimension-list-wrapper" ref={rootRef}>
-                {loading && (
-                    <Cover translucent>
-                        <Center>
-                            <CircularLoader />
-                        </Center>
-                    </Cover>
-                )}
-                <div className="dimension-list">
-                    {options.map(({ label, value, type, disabled }) => (
-                        <TransferOption
-                            label={label}
-                            key={value}
-                            value={value}
-                            icon={getIcon(type)}
-                            tooltipText={getTooltipText({
-                                type,
-                            })}
-                            disabled={disabled}
-                            onClick={Function.prototype}
-                            onDoubleClick={onSelect}
-                        />
-                    ))}
-
-                    <div className="scroll-detector">
-                        <IntersectionDetector
-                            onChange={onEndReached}
-                            rootRef={rootRef}
-                        />
+            <div className="dimension-list-container">
+                <div className="dimension-list-scrollbox" ref={rootRef}>
+                    <div className="dimension-list-scroller">
+                        {options.map(({ label, value, type, disabled }) => (
+                            <TransferOption
+                                label={label}
+                                key={value}
+                                value={value}
+                                icon={getIcon(type)}
+                                tooltipText={getTooltipText({
+                                    type,
+                                })}
+                                disabled={disabled}
+                                onDoubleClick={onSelect}
+                            />
+                        ))}
+                        <div className="scroll-detector">
+                            <IntersectionDetector
+                                onChange={onEndReached}
+                                rootRef={rootRef}
+                            />
+                        </div>
                     </div>
                 </div>
+                {loading && (
+                    <div className="dimension-list-overlay">
+                        <Cover>
+                            <Center>
+                                <CircularLoader />
+                            </Center>
+                        </Cover>
+                    </div>
+                )}
             </div>
             <style jsx>{styles}</style>
         </>

--- a/src/components/DataDimension/DataElementSelector.js
+++ b/src/components/DataDimension/DataElementSelector.js
@@ -9,6 +9,7 @@ import {
     SingleSelectOption,
 } from '@dhis2/ui'
 import { useDebounceCallback } from '@react-hook/debounce'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useEffect, useRef, useState } from 'react'
 import { apiFetchOptions, apiFetchGroups } from '../../api/dimensions.js'
@@ -264,7 +265,10 @@ const DataElementSelector = ({ displayNameProp, onSelect }) => {
                 />
             </div>
             <div className="dimension-list-container">
-                <div className="dimension-list-scrollbox" ref={rootRef}>
+                <div
+                    className={cx('dimension-list-scrollbox', { loading })}
+                    ref={rootRef}
+                >
                     <div className="dimension-list-scroller">
                         {options.map(({ label, value, type, disabled }) => (
                             <TransferOption

--- a/src/components/DataDimension/styles/DataElementSelector.style.js
+++ b/src/components/DataDimension/styles/DataElementSelector.style.js
@@ -2,7 +2,11 @@ import { colors, spacers } from '@dhis2/ui'
 import css from 'styled-jsx/css'
 
 export default css`
-    .dimension-list-wrapper {
+    .dimension-list-container {
+        position: relative;
+    }
+
+    .dimension-list-scrollbox {
         position: relative;
         width: 100%;
         height: 300px;
@@ -12,7 +16,7 @@ export default css`
         border: 1px solid ${colors.grey400};
     }
 
-    .dimension-list {
+    .dimension-list-scroller {
         position: relative;
         min-height: 1px;
     }
@@ -29,6 +33,11 @@ export default css`
         position: absolute;
         bottom: 0;
         left: 0;
+    }
+
+    .dimension-list-overlay {
+        width: 100%;
+        height: 100%;
     }
 
     .filter-wrapper {

--- a/src/components/DataDimension/styles/DataElementSelector.style.js
+++ b/src/components/DataDimension/styles/DataElementSelector.style.js
@@ -3,6 +3,8 @@ import css from 'styled-jsx/css'
 
 export default css`
     .dimension-list-wrapper {
+        position: relative;
+        width: 100%;
         height: 300px;
         overflow: hidden;
         overflow-y: auto;

--- a/src/components/DataDimension/styles/DataElementSelector.style.js
+++ b/src/components/DataDimension/styles/DataElementSelector.style.js
@@ -16,6 +16,10 @@ export default css`
         border: 1px solid ${colors.grey400};
     }
 
+    .dimension-list-scrollbox.loading {
+        filter: blur(2px);
+    }
+
     .dimension-list-scroller {
         position: relative;
         min-height: 1px;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3015,6 +3015,13 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
+"@react-hook/debounce@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@react-hook/debounce/-/debounce-4.0.0.tgz#5da87e7bfa158cfe2830ffc997dc1b755e261379"
+  integrity sha512-706Xcg+KKWHk9BuZQUQ0ZQKp9zhv3/MbqFenWVfHcynYpSGRVwQTzJRGvPxvsdtXxJv+HfgKTY/O/hEejakwmA==
+  dependencies:
+    "@react-hook/latest" "^1.0.2"
+
 "@react-hook/latest@^1.0.2":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@react-hook/latest/-/latest-1.0.3.tgz#c2d1d0b0af8b69ec6e2b3a2412ba0768ac82db80"


### PR DESCRIPTION
Part of [DHIS2-13871](https://dhis2.atlassian.net/browse/DHIS2-13871)

---

### Key features

1. rewrote the fetch logic to solve issues with pagination when combined with search and filters
2. added loading spinner while data is fetched
3. populate group filter selector

---

### Description

Infinite scrolling, group and disaggregation (subGroup) filter, search all seem to work.
The loading spinner has the same look as the one used in the `Transfer` component in the `DataDimension` modal.
The group dropdown has been implemented reusing the same fetch function for groups.

[DHIS2-13871]: https://dhis2.atlassian.net/browse/DHIS2-13871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ