### PR TITLE
feat: dnd for custom calculations

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-01-22T08:46:31.047Z\n"
-"PO-Revision-Date: 2023-01-22T08:46:31.047Z\n"
+"POT-Creation-Date: 2023-01-23T12:59:06.030Z\n"
+"PO-Revision-Date: 2023-01-23T12:59:06.030Z\n"
 
 msgid "view only"
 msgstr "view only"
@@ -185,11 +185,11 @@ msgstr "Nothing found for \"{{- searchTerm}}\""
 msgid "Calculation"
 msgstr "Calculation"
 
-msgid "Math operators"
-msgstr "Math operators"
-
 msgid "<number>"
 msgstr "<number>"
+
+msgid "Math operators"
+msgstr "Math operators"
 
 msgid "Metric type"
 msgstr "Metric type"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-01-23T12:59:06.030Z\n"
-"PO-Revision-Date: 2023-01-23T12:59:06.030Z\n"
+"POT-Creation-Date: 2023-01-24T08:15:45.439Z\n"
+"PO-Revision-Date: 2023-01-24T08:15:45.439Z\n"
 
 msgid "view only"
 msgstr "view only"
@@ -84,6 +84,9 @@ msgstr "Label shown in column/row headers"
 
 msgid "Check formula"
 msgstr "Check formula"
+
+msgid "Remove item"
+msgstr "Remove item"
 
 msgid "Delete calculation"
 msgstr "Delete calculation"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-01-24T08:15:45.439Z\n"
-"PO-Revision-Date: 2023-01-24T08:15:45.439Z\n"
+"POT-Creation-Date: 2023-01-24T08:45:34.342Z\n"
+"PO-Revision-Date: 2023-01-24T08:45:34.342Z\n"
 
 msgid "view only"
 msgstr "view only"
@@ -72,6 +72,21 @@ msgstr "This app could not retrieve required data."
 
 msgid "Network error"
 msgstr "Network error"
+
+msgid "Consecutive math operators"
+msgstr "Consecutive math operators"
+
+msgid "Consecutive data elements"
+msgstr "Consecutive data elements"
+
+msgid "Starts or ends with a math operator"
+msgstr "Starts or ends with a math operator"
+
+msgid "Missing right parenthesis )"
+msgstr "Missing right parenthesis )"
+
+msgid "Missing left parenthesis ("
+msgstr "Missing left parenthesis ("
 
 msgid "Data / Edit calculation"
 msgstr "Data / Edit calculation"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-02-06T14:03:03.841Z\n"
-"PO-Revision-Date: 2023-02-06T14:03:03.841Z\n"
+"POT-Creation-Date: 2023-02-14T08:56:26.627Z\n"
+"PO-Revision-Date: 2023-02-14T08:56:26.627Z\n"
 
 msgid "view only"
 msgstr "view only"
@@ -187,9 +187,6 @@ msgstr "Nothing found for \"{{- searchTerm}}\""
 
 msgid "Calculation"
 msgstr "Calculation"
-
-msgid "<number>"
-msgstr "<number>"
 
 msgid "Math operators"
 msgstr "Math operators"
@@ -1025,6 +1022,9 @@ msgstr "Program indicator"
 
 msgid "Calculations"
 msgstr "Calculations"
+
+msgid "<number>"
+msgstr "<number>"
 
 msgid "Empty formula"
 msgstr "Empty formula"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2023-02-01T09:02:27.240Z\n"
-"PO-Revision-Date: 2023-02-01T09:02:27.240Z\n"
+"POT-Creation-Date: 2023-02-06T14:03:03.841Z\n"
+"PO-Revision-Date: 2023-02-06T14:03:03.841Z\n"
 
 msgid "view only"
 msgstr "view only"
@@ -72,24 +72,6 @@ msgstr "This app could not retrieve required data."
 
 msgid "Network error"
 msgstr "Network error"
-
-msgid "Empty formula"
-msgstr "Empty formula"
-
-msgid "Consecutive math operators"
-msgstr "Consecutive math operators"
-
-msgid "Consecutive data elements"
-msgstr "Consecutive data elements"
-
-msgid "Starts or ends with a math operator"
-msgstr "Starts or ends with a math operator"
-
-msgid "Missing right parenthesis )"
-msgstr "Missing right parenthesis )"
-
-msgid "Missing left parenthesis ("
-msgstr "Missing left parenthesis ("
 
 msgid "Data / Edit calculation"
 msgstr "Data / Edit calculation"
@@ -1043,6 +1025,24 @@ msgstr "Program indicator"
 
 msgid "Calculations"
 msgstr "Calculations"
+
+msgid "Empty formula"
+msgstr "Empty formula"
+
+msgid "Consecutive math operators"
+msgstr "Consecutive math operators"
+
+msgid "Consecutive data elements"
+msgstr "Consecutive data elements"
+
+msgid "Starts or ends with a math operator"
+msgstr "Starts or ends with a math operator"
+
+msgid "Missing right parenthesis )"
+msgstr "Missing right parenthesis )"
+
+msgid "Missing left parenthesis ("
+msgstr "Missing left parenthesis ("
 
 msgid "Extra Small"
 msgstr "Extra Small"

--- a/package.json
+++ b/package.json
@@ -59,6 +59,9 @@
     },
     "dependencies": {
         "@dhis2/d2-ui-rich-text": "^7.4.0",
+        "@dnd-kit/core": "^6.0.7",
+        "@dnd-kit/sortable": "^7.0.2",
+        "@dnd-kit/utilities": "^3.2.1",
         "classnames": "^2.3.1",
         "d2-utilizr": "^0.2.16",
         "d3-color": "^1.2.3",

--- a/src/__demo__/CalculationModal.stories.js
+++ b/src/__demo__/CalculationModal.stories.js
@@ -1,7 +1,280 @@
+import { CustomDataProvider } from '@dhis2/app-runtime'
 import { storiesOf } from '@storybook/react'
 import React from 'react'
 import CalculationModal from '../components/DataDimension/CalculationModal.js'
 
+const DATA_ELEMENTS = {
+    pager: {
+        page: 1,
+        total: 622,
+        pageSize: 50,
+        nextPage:
+            'http://localhost:8080/api/39/dataElements?page=2&filter=domainType%3Aeq%3AAGGREGATE&paging=true&fields=dimensionItem%7Erename%28id%29%2CdisplayName%7Erename%28name%29%2CdimensionItemType&order=displayName%3Aasc',
+        pageCount: 13,
+    },
+    dataElements: [
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'fbfJHSPpUQD',
+            name: 'ANC 1st visit',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'cYeuwXTCPkU',
+            name: 'ANC 2nd visit',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'Jtf34kNZhzP',
+            name: 'ANC 3rd visit',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'hfdmMSPBgLG',
+            name: 'ANC 4th or more visits',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'FHD3wiSM7Sn',
+            name: 'ARI treated with antibiotics (pneumonia) follow-up',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'iKGjnOOaPlE',
+            name: 'ARI treated with antibiotics (pneumonia) new',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'XTqOHygxDj5',
+            name: 'ARI treated with antibiotics (pneumonia) referrals',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'RF4VFVGdFRO',
+            name: 'ARI treated without antibiotics (cough) follow-up',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'Cm4XUw6VAxv',
+            name: 'ARI treated without antibiotics (cough) new',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'oLfWYAJhZb2',
+            name: 'ARI treated without antibiotics (cough) referrals',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'GMd99K8gVut',
+            name: 'ART No clients who stopped TRT due to TRT failure',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'wfKKFhBn0Q0',
+            name: 'ART No clients who stopped TRT due to adverse clinical status/event',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'F53rTVTmSuF',
+            name: 'ART No clients with change of regimen due to drug toxicity',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'rNEpbBxSyu7',
+            name: 'ART No clients with new adverse drug reaction',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'CxlYcbqio4v',
+            name: 'ART No started Opportunist Infection prophylaxis',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'NJnhOzjaLYk',
+            name: 'ART clients with new adverse clinical event',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'aIJZ2d2QgVV',
+            name: 'ART defaulters',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'BOSZApCrBni',
+            name: 'ART enrollment stage 1',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'dGdeotKpRed',
+            name: 'ART enrollment stage 2',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'eRwOwCpMzyP',
+            name: 'ART enrollment stage 3',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'zYkwbCBALhn',
+            name: 'ART enrollment stage 4',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'kVOiLDV4OC6',
+            name: 'ART entry point: No PMTCT',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'I5MLuG16arn',
+            name: 'ART entry point: No diagnostic testing',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'LVaUdM3CERi',
+            name: 'ART entry point: No old patients',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'vJSPn2R6gVe',
+            name: 'ART entry point: No other',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'HDZOFvdXsqE',
+            name: 'ART entry point: No transfer in',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'soACnRV9gOI',
+            name: 'ART entry point: No transfer out',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'FTy5pcJZ3yX',
+            name: 'ART entry point: No walk in',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'Yf4u4QOIdsi',
+            name: 'ART entry point: TB',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'QrhlrvV6Xs8',
+            name: 'ART new clients started on ARV',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'ibL7BD2vn2C',
+            name: 'ART treatment stopped due to death',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'TyQ1vOHM6JO',
+            name: 'ART treatment stopped due to loss to follow-up',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'FTRrcoaog83',
+            name: 'Accute Flaccid Paralysis (Deaths < 5 yrs)',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'P3jJH5Tu5VC',
+            name: 'Acute Flaccid Paralysis (AFP) follow-up',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'FQ2o8UBlcrS',
+            name: 'Acute Flaccid Paralysis (AFP) new',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'M62VHgYT2n0',
+            name: 'Acute Flaccid Paralysis (AFP) referrals',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'uF1DLnZNlWe',
+            name: 'Additional notes related to facility',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'hCVSHjcml9g',
+            name: 'Albendazole given at ANC (2nd trimester)',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'rxt7nvPyRUi',
+            name: 'All access routes are clearly marked and safe',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'RUv0hqER0zV',
+            name: 'All other follow-ups',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'A2VfEfPflHV',
+            name: 'All other new',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'laZLQdnucV1',
+            name: 'All other referrals',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'U7v0q0amJqi',
+            name: 'All sterilisation equipment is validated / licensed',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'sPQgYGhXnXI',
+            name: 'An alternative to communicate if telephone line is off is always available',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'jmWyJFtE7Af',
+            name: 'Anaemia follow-up',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'HLPuaFB7Frw',
+            name: 'Anaemia new',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'yqBkn9CWKih',
+            name: 'Anaemia referrals',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'LjNlMTl9Nq9',
+            name: 'Animal Bites - Rabid (Deaths < 5 yrs)',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 'a57FmdPj3Zl',
+            name: 'Appropriate hand washing facilities are available',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT',
+            id: 's46m5MS0hxu',
+            name: 'BCG doses given',
+        },
+    ],
+}
+
 storiesOf('CalculationModal', module).add('Default', () => {
-    return <CalculationModal />
+    return (
+        <CustomDataProvider data={{ dataElements: DATA_ELEMENTS }}>
+            <CalculationModal
+                displayNameProp="name"
+                onClose={Function.prototype}
+                onDelete={Function.prototype}
+                onSave={Function.prototype}
+            />
+        </CustomDataProvider>
+    )
 })

--- a/src/__demo__/CalculationModal.stories.js
+++ b/src/__demo__/CalculationModal.stories.js
@@ -40,26 +40,6 @@ const DATA_ELEMENTS = {
         },
         {
             dimensionItemType: 'DATA_ELEMENT',
-            id: 'iKGjnOOaPlE',
-            name: 'ARI treated with antibiotics (pneumonia) new',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'XTqOHygxDj5',
-            name: 'ARI treated with antibiotics (pneumonia) referrals',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'RF4VFVGdFRO',
-            name: 'ARI treated without antibiotics (cough) follow-up',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'Cm4XUw6VAxv',
-            name: 'ARI treated without antibiotics (cough) new',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
             id: 'oLfWYAJhZb2',
             name: 'ARI treated without antibiotics (cough) referrals',
         },
@@ -72,26 +52,6 @@ const DATA_ELEMENTS = {
             dimensionItemType: 'DATA_ELEMENT',
             id: 'wfKKFhBn0Q0',
             name: 'ART No clients who stopped TRT due to adverse clinical status/event',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'F53rTVTmSuF',
-            name: 'ART No clients with change of regimen due to drug toxicity',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'rNEpbBxSyu7',
-            name: 'ART No clients with new adverse drug reaction',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'CxlYcbqio4v',
-            name: 'ART No started Opportunist Infection prophylaxis',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'NJnhOzjaLYk',
-            name: 'ART clients with new adverse clinical event',
         },
         {
             dimensionItemType: 'DATA_ELEMENT',
@@ -110,83 +70,8 @@ const DATA_ELEMENTS = {
         },
         {
             dimensionItemType: 'DATA_ELEMENT',
-            id: 'eRwOwCpMzyP',
-            name: 'ART enrollment stage 3',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'zYkwbCBALhn',
-            name: 'ART enrollment stage 4',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'kVOiLDV4OC6',
-            name: 'ART entry point: No PMTCT',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'I5MLuG16arn',
-            name: 'ART entry point: No diagnostic testing',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
             id: 'LVaUdM3CERi',
             name: 'ART entry point: No old patients',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'vJSPn2R6gVe',
-            name: 'ART entry point: No other',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'HDZOFvdXsqE',
-            name: 'ART entry point: No transfer in',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'soACnRV9gOI',
-            name: 'ART entry point: No transfer out',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'FTy5pcJZ3yX',
-            name: 'ART entry point: No walk in',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'Yf4u4QOIdsi',
-            name: 'ART entry point: TB',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'QrhlrvV6Xs8',
-            name: 'ART new clients started on ARV',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'ibL7BD2vn2C',
-            name: 'ART treatment stopped due to death',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'TyQ1vOHM6JO',
-            name: 'ART treatment stopped due to loss to follow-up',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'FTRrcoaog83',
-            name: 'Accute Flaccid Paralysis (Deaths < 5 yrs)',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'P3jJH5Tu5VC',
-            name: 'Acute Flaccid Paralysis (AFP) follow-up',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'FQ2o8UBlcrS',
-            name: 'Acute Flaccid Paralysis (AFP) new',
         },
         {
             dimensionItemType: 'DATA_ELEMENT',
@@ -198,41 +83,7 @@ const DATA_ELEMENTS = {
             id: 'uF1DLnZNlWe',
             name: 'Additional notes related to facility',
         },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'hCVSHjcml9g',
-            name: 'Albendazole given at ANC (2nd trimester)',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'rxt7nvPyRUi',
-            name: 'All access routes are clearly marked and safe',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'RUv0hqER0zV',
-            name: 'All other follow-ups',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'A2VfEfPflHV',
-            name: 'All other new',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'laZLQdnucV1',
-            name: 'All other referrals',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'U7v0q0amJqi',
-            name: 'All sterilisation equipment is validated / licensed',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'sPQgYGhXnXI',
-            name: 'An alternative to communicate if telephone line is off is always available',
-        },
+
         {
             dimensionItemType: 'DATA_ELEMENT',
             id: 'jmWyJFtE7Af',
@@ -243,32 +94,106 @@ const DATA_ELEMENTS = {
             id: 'HLPuaFB7Frw',
             name: 'Anaemia new',
         },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'yqBkn9CWKih',
-            name: 'Anaemia referrals',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'LjNlMTl9Nq9',
-            name: 'Animal Bites - Rabid (Deaths < 5 yrs)',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 'a57FmdPj3Zl',
-            name: 'Appropriate hand washing facilities are available',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT',
-            id: 's46m5MS0hxu',
-            name: 'BCG doses given',
-        },
+    ],
+}
+
+const DATA_ELEMENT_GROUPS = {
+    dataElementGroups: [
+        { id: 'qfxEYY9xAl6', name: 'ANC' },
+        { id: 'yhg8oYU9ekY', name: 'ARI Treated Without Antibiotics (Cough)' },
+        { id: 'M2cth8EmrlT', name: 'ARI treated with antibiotics (Pneumonia)' },
+        { id: 'k1M0nuodfhN', name: 'ART' },
+        { id: 'bdiyMm9qZl5', name: 'ART enrollment' },
+        { id: 's8FiXqB2DhB', name: 'ART entry points' },
+        { id: 'TcxHxMlYzpv', name: 'ART pediatric 1st line' },
+        { id: 'vxIWSNeEcf7', name: 'ART staging' },
+        { id: 'zz1lNBgRKWU', name: 'ART treatment' },
+        { id: 'oDkJh5Ddh7d', name: 'Acute Flaccid Paralysis (AFP) ' },
+        { id: 'GBHN1a1Jddh', name: 'All Others' },
+        { id: 'KmwPVkjp7yl', name: 'Anaemia' },
+        { id: 'oGktdmYkRNo', name: 'Burns' },
+        { id: 'KUSvwZQsMSN', name: 'Cholera' },
+        { id: 'Euvh58hLl61', name: 'Clinical Malnutrition' },
+        { id: 'Svac1cNQhRS', name: 'Commodities' },
+        { id: 'KJKWrWBcJdf', name: 'Commodities Child Health' },
+        { id: 'idD1wcvBISQ', name: 'Commodities Maternal Health' },
+        { id: 'rioWDAi1S7z', name: 'Commodities Newborn Health' },
+        { id: 'IyIa0h8CbCZ', name: 'Commodities Reproductive Health' },
+        { id: 'PfJGQacYpjn', name: 'Deaths' },
+        { id: 't5W0AAqvK5b', name: 'Delivery' },
+        { id: 'mcjC3qZgIkO', name: 'Diarrhoea With Blood (Dysentery)' },
+        { id: 'RSFc8ADyKTw', name: 'Diarrhoea With Severe Dehydration' },
+        { id: 'kE8lP5t0b5R', name: 'Diarrhoea Without Severe Dehydration' },
+        { id: 'qiF051Ue9Ei', name: 'Emergency Response' },
+        { id: 'GbSz3TobZcc', name: 'Expenditures' },
+        { id: 'lLKpwhjd1dM', name: 'Eye Infection' },
+        { id: 'Sp1jJqzsiOi', name: 'Facility infrastructure' },
+        { id: 'g50BzGAsrvu', name: 'Follow-up' },
+        { id: 'URmi41e0SFH', name: 'HIV Care' },
+        { id: 'ID4BbhF7Eli', name: 'HIV Peadriatics' },
+        { id: 'HKU7L73im5r', name: 'HIV/AIDS' },
+        { id: 'jWgEsdH87Jk', name: 'Hypertension' },
+        { id: 'nb3rBNvVHtp', name: 'ICS Children' },
+        { id: 'dMyLpSQn6hu', name: 'ICS mother' },
+        { id: 'b3gDdvmrSFc', name: 'IDSR' },
+        { id: 'h9cuJOkOwY2', name: 'Immunization' },
+        { id: 'OP4dLqk0JTH', name: 'Inpatient morbidity/mortality aggregates' },
+        { id: 'SriP0jBXMr6', name: 'Lassa Fever' },
+        { id: 'U0uJG4kydwE', name: 'Leprosy' },
+        { id: 'eeQCyjnMyGY', name: 'Low birth' },
+        { id: 'LEet4tb49IP', name: 'MNCH Aggregates' },
+        { id: 'TzwKbcw1nUK', name: 'Malaria' },
+        { id: 'qk2KOBMX4Mf', name: 'Measles' },
+        { id: 'lnLbEej0gwe', name: 'Meningitis / Severe Bacterial Infection' },
+        { id: 'SLsJy3zqUbD', name: 'Morbidity' },
+        { id: 'QAc5FhbeFwl', name: 'Mortality' },
+        { id: 'rPGfUFYbcfJ', name: 'Mortality < 5 years' },
+        { id: 'KU0wDurtWDM', name: 'Mortality Narrative' },
+        { id: 'UAEhIWpoQFN', name: 'Neonatal Tetanus' },
+        { id: 'weRMUzBs8T7', name: 'New cases' },
+        { id: 'XGSHYf5uOlJ', name: 'New on ART' },
+        { id: 'u1ilfnoYafG', name: 'Nutrition' },
+        { id: 'HDdnX6XqxIn', name: 'Onchocerciasis' },
+        { id: 'JZ3usxLEcc9', name: 'Otitis Media' },
+        { id: 'WS3MniopkOQ', name: 'PMTCT' },
+        { id: 'e5NGCRQR8Yo', name: 'PMTCT ANC' },
+        { id: 'bXpe2ByvlFR', name: 'PMTCT Maternity/Delivery' },
+        { id: 'sGLusXgmaOT', name: 'PMTCT Postnatal' },
+        { id: 'sP7jTt3YGBb', name: 'Population Estimates' },
+        { id: 'ubJrVb4v5xy', name: 'Postnatal' },
+        { id: 'qkrZMU4Y2h5', name: 'Pregnancy complications and deaths' },
+        { id: 'ZPtRFVLY40u', name: 'Pregnancy-related (PHUF5)' },
+        { id: 'AiytigJkHP6', name: 'Prev month on ART' },
+        { id: 'UWaMbg9h7vF', name: 'Referrals' },
+        { id: 'OJxi4vkcTBS', name: 'Reproductive health' },
+        { id: 'xNrDrDbJgnm', name: 'STI - Genital Discharge' },
+        { id: 'UmyRWILcoed', name: 'STI - Genital Ulcer' },
+        { id: 'LqG1FnAUhyb', name: 'Schistosomiasis' },
+        { id: 'rwG73cCi66Z', name: 'Shift from ART reg.' },
+        { id: 'rgTZ4mKjZza', name: 'Shift to ART reg.' },
+        { id: 'VCoSeRRVS1n', name: 'Skin Infection' },
+        { id: 'rVEe5QNBgDX', name: 'Staffing' },
+        { id: 'pxWhf42tCIs', name: 'Stock PHU' },
+        { id: 'OnAQ2lsilN9', name: 'TB' },
+        { id: 'LgtuBcNaMB3', name: 'Tetanus' },
+        { id: 'yHtsPZqpAxm', name: 'Tuberculosis' },
+        { id: 'dUK38PhdUdV', name: 'Typhoid Fever' },
+        { id: 'U9wcARyKSzx', name: 'VCCT' },
+        { id: 'LzDaTmQYWcj', name: 'Worm Infestation' },
+        { id: 'IUZ0GidX0jh', name: 'Wounds/Trauma' },
+        { id: 'zmWJAEjfv59', name: 'Yaws' },
+        { id: 'HAraPb0v7ex', name: 'Yellow Fever' },
     ],
 }
 
 storiesOf('CalculationModal', module).add('Default', () => {
     return (
-        <CustomDataProvider data={{ dataElements: DATA_ELEMENTS }}>
+        <CustomDataProvider
+            data={{
+                dataElements: DATA_ELEMENTS,
+                dataElementGroups: DATA_ELEMENT_GROUPS,
+            }}
+        >
             <CalculationModal
                 displayNameProp="name"
                 onClose={Function.prototype}

--- a/src/__demo__/CalculationModal.stories.js
+++ b/src/__demo__/CalculationModal.stories.js
@@ -189,7 +189,7 @@ const DATA_ELEMENT_GROUPS = {
 const calculation = {
     id: 'calculationid',
     name: 'My calculation',
-    expression: '#{fbfJHSPpUQD}/10',
+    expression: '#{fbfJHSPpUQD}/10*#{hfdmMSPBgLG}',
 }
 
 storiesOf('CalculationModal', module)

--- a/src/__demo__/CalculationModal.stories.js
+++ b/src/__demo__/CalculationModal.stories.js
@@ -186,20 +186,45 @@ const DATA_ELEMENT_GROUPS = {
     ],
 }
 
-storiesOf('CalculationModal', module).add('Default', () => {
-    return (
-        <CustomDataProvider
-            data={{
-                dataElements: DATA_ELEMENTS,
-                dataElementGroups: DATA_ELEMENT_GROUPS,
-            }}
-        >
-            <CalculationModal
-                displayNameProp="name"
-                onClose={Function.prototype}
-                onDelete={Function.prototype}
-                onSave={Function.prototype}
-            />
-        </CustomDataProvider>
-    )
-})
+const calculation = {
+    id: 'calculationid',
+    name: 'My calculation',
+    expression: '#{fbfJHSPpUQD}/10',
+}
+
+storiesOf('CalculationModal', module)
+    .add('Default', () => {
+        return (
+            <CustomDataProvider
+                data={{
+                    dataElements: DATA_ELEMENTS,
+                    dataElementGroups: DATA_ELEMENT_GROUPS,
+                }}
+            >
+                <CalculationModal
+                    displayNameProp="name"
+                    onClose={Function.prototype}
+                    onDelete={Function.prototype}
+                    onSave={Function.prototype}
+                />
+            </CustomDataProvider>
+        )
+    })
+    .add('With calculation', () => {
+        return (
+            <CustomDataProvider
+                data={{
+                    dataElements: DATA_ELEMENTS,
+                    dataElementGroups: DATA_ELEMENT_GROUPS,
+                }}
+            >
+                <CalculationModal
+                    calculation={calculation}
+                    displayNameProp="name"
+                    onClose={Function.prototype}
+                    onDelete={Function.prototype}
+                    onSave={Function.prototype}
+                />
+            </CustomDataProvider>
+        )
+    })

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -137,8 +137,6 @@ const CalculationModal = ({
         setValidationOutput(result)
     }
 
-    // console.log('expressionArray', expressionArray)
-
     return (
         <>
             <Modal dataTest={`calculation-modal`} position="top" large>
@@ -383,7 +381,7 @@ const CalculationModal = ({
             if (destAxisId === LAST_DROPZONE_ID) {
                 setExpressionArray([...expressionArray, newItem])
             } else if (destAxisId === FORMULA_BOX_ID) {
-                const destIndex = over.data.current.sortable.index
+                const destIndex = over.data.current.sortable.index + 1
                 const sourceList = Array.from(expressionArray)
 
                 const newFormulaItems = [
@@ -422,22 +420,22 @@ const CalculationModal = ({
     }
 
     function getDraggingItem() {
-        const label = draggingItem.value || draggingItem.label
+        const displayLabel = draggingItem.value || draggingItem.label
         if (draggingItem.sortable.containerId === FORMULA_BOX_ID) {
-            // dragging item looks like a formula item
             return (
-                <FormulaItem value={draggingItem.value}>
-                    <span>{label}</span>
+                <FormulaItem type={draggingItem.type}>
+                    <span>{displayLabel}</span>
                 </FormulaItem>
             )
+        } else if ([TYPE_OPERATOR, TYPE_INPUT].includes(draggingItem.type)) {
+            return <Operator label={displayLabel} />
         } else {
-            if ([TYPE_OPERATOR, TYPE_INPUT].includes(draggingItem.type)) {
-                return <Operator label={label} />
-            } else {
-                return (
-                    <TransferOption label={draggingItem.label} value={label} />
-                )
-            }
+            return (
+                <TransferOption
+                    label={draggingItem.label}
+                    value={displayLabel}
+                />
+            )
         }
     }
 

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -250,7 +250,7 @@ const CalculationModal = ({
                                     <DraggingItem
                                         item={{
                                             type: TYPE_INPUT,
-                                            label: '<number>+',
+                                            label: '<number>',
                                             value: '55',
                                         }}
                                     />
@@ -262,7 +262,7 @@ const CalculationModal = ({
                                     <DraggingItem
                                         item={{
                                             type: TYPE_INPUT,
-                                            label: '<number>+',
+                                            label: '<number>',
                                             value: '',
                                         }}
                                     />

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -25,7 +25,13 @@ import {
     parseExpressionToArray,
     parseArrayToExpression,
 } from '../../modules/expressions.js'
-import { TYPE_DATAITEM, LAST_DROPZONE_ID, FORMULA_BOX_ID } from './constants.js'
+import {
+    TYPE_DATAITEM,
+    TYPE_INPUT,
+    TYPE_OPERATOR,
+    LAST_DROPZONE_ID,
+    FORMULA_BOX_ID,
+} from './constants.js'
 import DataElementSelector from './DataElementSelector.js'
 import DraggingItem from './DraggingItem.js'
 import FormulaField from './FormulaField.js'
@@ -184,6 +190,47 @@ const CalculationModal = ({
                                 <p>
                                     {/* TODO: Remove, for testing only */}
                                     {parseArrayToExpression(expressionArray)}
+                                </p>
+                                <p>
+                                    <span>Data element dragging item: </span>
+                                    <DraggingItem
+                                        item={{
+                                            type: TYPE_DATAITEM,
+                                            label: 'ANC 4th or more visits',
+                                        }}
+                                    />
+                                </p>
+                                <p>
+                                    <span>Number dragging item: </span>
+                                    <DraggingItem
+                                        item={{
+                                            type: TYPE_INPUT,
+                                            label: '<number>+',
+                                            value: '55',
+                                        }}
+                                    />
+                                </p>
+                                <p>
+                                    <span>
+                                        Number dragging item w/o value:{' '}
+                                    </span>
+                                    <DraggingItem
+                                        item={{
+                                            type: TYPE_INPUT,
+                                            label: '<number>+',
+                                            value: '',
+                                        }}
+                                    />
+                                </p>
+                                <p>
+                                    <span>Operator dragging item: </span>
+                                    <DraggingItem
+                                        item={{
+                                            type: TYPE_OPERATOR,
+                                            label: '+',
+                                            value: '+',
+                                        }}
+                                    />
                                 </p>
                                 <div className="actions-wrapper">
                                     <Button small onClick={validateExpression}>

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -197,6 +197,45 @@ const CalculationModal = ({
                                     {/* TODO: Remove, for testing only */}
                                     {parseArrayToExpression(expressionArray)}
                                 </p>
+                                <div className="actions-wrapper">
+                                    <Button small onClick={validateExpression}>
+                                        {/* TODO: add loading state to button? */}
+                                        {i18n.t('Check formula')}
+                                    </Button>
+                                    {(selectedPart || selectedPart === 0) && (
+                                        <div className={'remove-button'}>
+                                            <Button
+                                                small
+                                                onClick={() => {
+                                                    setValidationOutput()
+                                                    setExpressionArray(
+                                                        (prevArray) =>
+                                                            prevArray.filter(
+                                                                (_, index) =>
+                                                                    index !=
+                                                                    selectedPart
+                                                            )
+                                                    )
+                                                    setSelectedPart()
+                                                }}
+                                            >
+                                                {i18n.t('Remove item')}
+                                            </Button>
+                                        </div>
+                                    )}
+                                    <span
+                                        className={cx('validation-message', {
+                                            'validation-error':
+                                                expressionStatus ===
+                                                INVALID_EXPRESSION,
+                                            'validation-success':
+                                                expressionStatus ===
+                                                VALID_EXPRESSION,
+                                        })}
+                                    >
+                                        {validationOutput?.message}
+                                    </span>
+                                </div>
                                 <p>
                                     <span>Data element dragging item: </span>
                                     <DraggingItem
@@ -238,45 +277,6 @@ const CalculationModal = ({
                                         }}
                                     />
                                 </p>
-                                <div className="actions-wrapper">
-                                    <Button small onClick={validateExpression}>
-                                        {/* TODO: add loading state to button? */}
-                                        {i18n.t('Check formula')}
-                                    </Button>
-                                    {(selectedPart || selectedPart === 0) && (
-                                        <div className={'remove-button'}>
-                                            <Button
-                                                small
-                                                onClick={() => {
-                                                    setValidationOutput()
-                                                    setExpressionArray(
-                                                        (prevArray) =>
-                                                            prevArray.filter(
-                                                                (_, index) =>
-                                                                    index !=
-                                                                    selectedPart
-                                                            )
-                                                    )
-                                                    setSelectedPart()
-                                                }}
-                                            >
-                                                {i18n.t('Remove item')}
-                                            </Button>
-                                        </div>
-                                    )}
-                                    <span
-                                        className={cx('validation-message', {
-                                            'validation-error':
-                                                expressionStatus ===
-                                                INVALID_EXPRESSION,
-                                            'validation-success':
-                                                expressionStatus ===
-                                                VALID_EXPRESSION,
-                                        })}
-                                    >
-                                        {validationOutput?.message}
-                                    </span>
-                                </div>
                                 {calculation.id && (
                                     <div className="delete-button">
                                         <Button

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -25,17 +25,11 @@ import {
     parseExpressionToArray,
     parseArrayToExpression,
 } from '../../modules/expressions.js'
-import { TransferOption } from '../TransferOption.js'
+import { TYPE_DATAITEM, LAST_DROPZONE_ID, FORMULA_BOX_ID } from './constants.js'
 import DataElementSelector from './DataElementSelector.js'
+import DraggingItem from './DraggingItem.js'
 import FormulaField from './FormulaField.js'
-import { FormulaItem } from './FormulaItem.js'
-import MathOperatorSelector, {
-    getOperators,
-    TYPE_DATAITEM,
-    TYPE_OPERATOR,
-    TYPE_INPUT,
-} from './MathOperatorSelector.js'
-import { Operator } from './Operator.js'
+import MathOperatorSelector, { getOperators } from './MathOperatorSelector.js'
 import styles from './styles/CalculationModal.style.js'
 
 const VALID_EXPRESSION = 'OK'
@@ -48,15 +42,8 @@ const activateAt15pixels = {
 }
 
 const FIRST_POSITION = 0
-// const LAST_POSITION = -1;
-export const FIRST = 'first'
-export const LAST = 'last'
 
 const OPTIONS_PANEL = 'Sortable'
-
-export const FIRST_DROPZONE_ID = 'firstdropzone'
-export const LAST_DROPZONE_ID = 'lastdropzone'
-export const FORMULA_BOX_ID = 'formulabox'
 
 const CalculationModal = ({
     calculation = {},
@@ -254,7 +241,7 @@ const CalculationModal = ({
                         <DragOverlay dropAnimation={null}>
                             {draggingItem ? (
                                 <span className="dragOverlay">
-                                    {getDraggingItem()}
+                                    <DraggingItem item={draggingItem} />
                                 </span>
                             ) : null}
                         </DragOverlay>
@@ -368,7 +355,7 @@ const CalculationModal = ({
 
         if (sourceAxisId === OPTIONS_PANEL) {
             let newItem
-            if (active.data.current.type === 'DATA_ELEMENT') {
+            if (active.data.current.type === TYPE_DATAITEM) {
                 newItem = getNewDataItem(
                     active.data.current.id,
                     active.data.current.label
@@ -412,31 +399,12 @@ const CalculationModal = ({
         setDraggingItem(null)
     }
     function handleDragStart({ active }) {
+        console.log('setDraggingitem', active.data.current)
         setDraggingItem(active.data.current)
     }
 
     function handleDragCancel() {
         setDraggingItem(null)
-    }
-
-    function getDraggingItem() {
-        const displayLabel = draggingItem.value || draggingItem.label
-        if (draggingItem.sortable.containerId === FORMULA_BOX_ID) {
-            return (
-                <FormulaItem type={draggingItem.type}>
-                    <span>{displayLabel}</span>
-                </FormulaItem>
-            )
-        } else if ([TYPE_OPERATOR, TYPE_INPUT].includes(draggingItem.type)) {
-            return <Operator label={displayLabel} />
-        } else {
-            return (
-                <TransferOption
-                    label={draggingItem.label}
-                    value={displayLabel}
-                />
-            )
-        }
     }
 
     function setExpressionItemValue({ index, value }) {

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -137,7 +137,7 @@ const CalculationModal = ({
         setValidationOutput(result)
     }
 
-    console.log('expressionArray', expressionArray)
+    // console.log('expressionArray', expressionArray)
 
     return (
         <>
@@ -414,7 +414,6 @@ const CalculationModal = ({
         setDraggingItem(null)
     }
     function handleDragStart({ active }) {
-        console.log('drag started', active.data.current)
         setDraggingItem(active.data.current)
     }
 
@@ -428,7 +427,7 @@ const CalculationModal = ({
             // dragging item looks like a formula item
             return (
                 <FormulaItem value={draggingItem.value}>
-                    <span>{draggingItem.value}</span>
+                    <span>{label}</span>
                 </FormulaItem>
             )
         } else {
@@ -436,10 +435,7 @@ const CalculationModal = ({
                 return <Operator label={label} />
             } else {
                 return (
-                    <TransferOption
-                        label={draggingItem.label}
-                        value={draggingItem.value}
-                    />
+                    <TransferOption label={draggingItem.label} value={label} />
                 )
             }
         }

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -97,7 +97,7 @@ const CalculationModal = ({
                         : i18n.t('Data / New calculation')}
                 </ModalTitle>
                 <ModalContent dataTest={'calculation-modal-content'}>
-                    <DndContext onDragEnd={addOrMoveItem}>
+                    <DndContext onDragEnd={addOrMoveDraggedItem}>
                         <div className="name-input">
                             <InputField
                                 label={i18n.t(
@@ -293,26 +293,26 @@ const CalculationModal = ({
         </>
     )
 
-    function addOrMoveItem({ active, over }) {
-        const sourceAxisId = active.data.current?.sortable?.containerId
-        const destAxisId = over.data.current?.sortable?.containerId || over.id
+    function addOrMoveDraggedItem({ activeItem, over }) {
+        const sourceAxisId = activeItem.sourceAxisId
+        const destAxisId = over.axisId
 
         if (sourceAxisId === OPTIONS_PANEL) {
             let newItem
-            if (active.data.current.type === TYPE_DATAELEMENT) {
+            if (activeItem.data.type === TYPE_DATAELEMENT) {
                 newItem = getNewDataItem(
-                    active.data.current.id,
-                    active.data.current.label
+                    activeItem.data.id,
+                    activeItem.data.label
                 )
             } else {
                 // adding an item to the formula
-                newItem = getNewOperatorItem(active.id)
+                newItem = getNewOperatorItem(activeItem.id)
             }
 
             if (destAxisId === LAST_DROPZONE_ID) {
                 setExpressionArray([...expressionArray, newItem])
             } else if (destAxisId === FORMULA_BOX_ID) {
-                const destIndex = over.data.current.sortable.index + 1
+                const destIndex = over.index + 1
                 const sourceList = Array.from(expressionArray)
 
                 const newFormulaItems = [
@@ -330,12 +330,12 @@ const CalculationModal = ({
             }
         } else {
             // move an item in the formula
-            const sourceIndex = active.data.current.sortable.index
+            const sourceIndex = activeItem.sourceIndex
             let destIndex
             if (destAxisId === LAST_DROPZONE_ID) {
                 destIndex = expressionArray.length
             } else if (destAxisId === FORMULA_BOX_ID) {
-                destIndex = over.data.current.sortable.index
+                destIndex = over.index
             } else {
                 destIndex = FIRST_POSITION
             }

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -202,54 +202,45 @@ const CalculationModal = ({
                                     onClick={selectItem}
                                     onDoubleClick={removeItem}
                                 />
-                                <div className="formula-actions">
-                                    <p>
-                                        {/* TODO: Remove, for testing only */}
-                                        {parseArrayToExpression(
-                                            expressionArray
-                                        )}
-                                    </p>
-                                    <div className="actions-wrapper">
-                                        <Button
-                                            small
-                                            onClick={validate}
-                                            dataTest="validate-button"
-                                        >
-                                            {/* TODO: add loading state to button? */}
-                                            {i18n.t('Check formula')}
-                                        </Button>
-                                        {selectedItemId !== null && (
-                                            <div className="remove-button">
-                                                <Button
-                                                    small
-                                                    onClick={() =>
-                                                        removeItem(
-                                                            selectedItemId
-                                                        )
-                                                    }
-                                                    dataTest="remove-button"
-                                                >
-                                                    {i18n.t('Remove item')}
-                                                </Button>
-                                            </div>
-                                        )}
-                                        <span
-                                            className={cx(
-                                                'validation-message',
-                                                {
-                                                    'validation-error':
-                                                        expressionStatus ===
-                                                        INVALID_EXPRESSION,
-                                                    'validation-success':
-                                                        expressionStatus ===
-                                                        VALID_EXPRESSION,
+                                <p>
+                                    {/* TODO: Remove, for testing only */}
+                                    {parseArrayToExpression(expressionArray)}
+                                </p>
+                                <div className="actions-wrapper">
+                                    <Button
+                                        small
+                                        onClick={validate}
+                                        dataTest="validate-button"
+                                    >
+                                        {/* TODO: add loading state to button? */}
+                                        {i18n.t('Check formula')}
+                                    </Button>
+                                    {selectedItemId !== null && (
+                                        <div className="remove-button">
+                                            <Button
+                                                small
+                                                onClick={() =>
+                                                    removeItem(selectedItemId)
                                                 }
-                                            )}
-                                            data-test={'validation-message'}
-                                        >
-                                            {validationOutput?.message}
-                                        </span>
-                                    </div>
+                                                dataTest="remove-button"
+                                            >
+                                                {i18n.t('Remove item')}
+                                            </Button>
+                                        </div>
+                                    )}
+                                    <span
+                                        className={cx('validation-message', {
+                                            'validation-error':
+                                                expressionStatus ===
+                                                INVALID_EXPRESSION,
+                                            'validation-success':
+                                                expressionStatus ===
+                                                VALID_EXPRESSION,
+                                        })}
+                                        data-test={'validation-message'}
+                                    >
+                                        {validationOutput?.message}
+                                    </span>
                                     {calculation.id && (
                                         <div className="delete-button">
                                             <Button

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -46,7 +46,6 @@ const CalculationModal = ({
     const [doBackendValidation] = useDataMutation(validateExpressionMutation, {
         onError: (error) => showError(error),
     })
-    const [focusId, setFocusId] = useState(null)
     const [validationOutput, setValidationOutput] = useState(null)
     const [expressionArray, setExpressionArray] = useState(
         parseExpressionToArray(calculation.expression)
@@ -54,27 +53,28 @@ const CalculationModal = ({
     const [name, setName] = useState(calculation.name)
     const [showDeletePrompt, setShowDeletePrompt] = useState(false)
 
+    const [focusId, setFocusId] = useState(null)
     const [selectedId, setSelectedId] = useState(null)
     const [idCounter, setIdCounter] = useState(0)
 
     const expressionStatus = validationOutput?.status
 
-    const selectItem = (id) => {
+    const selectItem = (id) =>
         setSelectedId((prevSelected) => (prevSelected !== id ? id : null))
-    }
 
-    const removeItem = ({ index }) => {
+    const removeItem = (id) => {
         setValidationOutput()
         const sourceList = Array.from(expressionArray)
+        const index = sourceList.findIndex((item) => item.id === id)
         sourceList.splice(index, 1)
         setExpressionArray(sourceList)
     }
 
     const setItemValue = ({ index, value }) => {
-        const updatedFormulaItems = expressionArray.map((expression, i) =>
+        const updatedItems = expressionArray.map((expression, i) =>
             i === index ? Object.assign({}, expression, { value }) : expression
         )
-        setExpressionArray(updatedFormulaItems)
+        setExpressionArray(updatedItems)
     }
 
     const validate = async () => {
@@ -158,21 +158,9 @@ const CalculationModal = ({
                                             <div className={'remove-button'}>
                                                 <Button
                                                     small
-                                                    onClick={() => {
-                                                        setValidationOutput()
-                                                        setExpressionArray(
-                                                            (prevArray) =>
-                                                                prevArray.filter(
-                                                                    (
-                                                                        _,
-                                                                        index
-                                                                    ) =>
-                                                                        index !=
-                                                                        selectedId
-                                                                )
-                                                        )
-                                                        setSelectedId(null)
-                                                    }}
+                                                    onClick={() =>
+                                                        removeItem(selectedId)
+                                                    }
                                                 >
                                                     {i18n.t('Remove item')}
                                                 </Button>

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -420,7 +420,6 @@ const CalculationModal = ({
         setDraggingItem(null)
     }
     function handleDragStart({ active }) {
-        console.log('setDraggingitem', active.data.current)
         setDraggingItem(active.data.current)
     }
 
@@ -493,13 +492,16 @@ const CalculationModal = ({
         droppableContainers,
     }) {
         // create a rect around the pointerCoords for calculating the intersection
+
+        const pointerRectWidth = 40
+        const pointerRectHeight = 40
         const pointerRect = {
-            width: 80,
-            height: 40,
-            top: pointerCoordinates.y - 20,
-            bottom: pointerCoordinates.y + 20,
-            left: pointerCoordinates.x - 40,
-            right: pointerCoordinates.x + 40,
+            width: pointerRectWidth,
+            height: pointerRectHeight,
+            top: pointerCoordinates.y - pointerRectHeight / 2,
+            bottom: pointerCoordinates.y + pointerRectHeight / 2,
+            left: pointerCoordinates.x - pointerRectWidth / 2,
+            right: pointerCoordinates.x + pointerRectWidth / 2,
         }
         const collisions = []
 

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -47,22 +47,20 @@ const CalculationModal = ({
         onError: (error) => showError(error),
     })
     const [focusId, setFocusId] = useState(null)
-    const [validationOutput, setValidationOutput] = useState()
+    const [validationOutput, setValidationOutput] = useState(null)
     const [expressionArray, setExpressionArray] = useState(
         parseExpressionToArray(calculation.expression)
     )
     const [name, setName] = useState(calculation.name)
-    const [showDeletePrompt, setShowDeletePrompt] = useState()
+    const [showDeletePrompt, setShowDeletePrompt] = useState(false)
 
-    const [selectedPart, setSelectedPart] = useState()
+    const [selectedId, setSelectedId] = useState(null)
     const [idCounter, setIdCounter] = useState(0)
 
     const expressionStatus = validationOutput?.status
 
-    const selectItem = (index) => {
-        setSelectedPart((prevSelected) =>
-            prevSelected !== index ? index : null
-        )
+    const selectItem = (id) => {
+        setSelectedId((prevSelected) => (prevSelected !== id ? id : null))
     }
 
     const removeItem = ({ index }) => {
@@ -137,12 +135,12 @@ const CalculationModal = ({
                             </div>
                             <div className="right-section">
                                 <FormulaField
-                                    expressionArray={expressionArray}
-                                    setItemValue={setItemValue}
-                                    highlightItem={selectItem}
-                                    removeItem={removeItem}
-                                    selectedPart={selectedPart}
+                                    items={expressionArray}
+                                    selectedId={selectedId}
                                     focusId={focusId}
+                                    onChange={setItemValue}
+                                    onClick={selectItem}
+                                    onDoubleClick={removeItem}
                                 />
                                 <div className="leftpad">
                                     <p>
@@ -156,8 +154,7 @@ const CalculationModal = ({
                                             {/* TODO: add loading state to button? */}
                                             {i18n.t('Check formula')}
                                         </Button>
-                                        {(selectedPart ||
-                                            selectedPart === 0) && (
+                                        {(selectedId || selectedId === 0) && (
                                             <div className={'remove-button'}>
                                                 <Button
                                                     small
@@ -171,10 +168,10 @@ const CalculationModal = ({
                                                                         index
                                                                     ) =>
                                                                         index !=
-                                                                        selectedPart
+                                                                        selectedId
                                                                 )
                                                         )
-                                                        setSelectedPart()
+                                                        setSelectedId(null)
                                                     }}
                                                 >
                                                     {i18n.t('Remove item')}

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -22,7 +22,7 @@ import {
     VALID_EXPRESSION,
 } from '../../modules/expressions.js'
 import {
-    TYPE_DATAELEMENT,
+    TYPE_DATA_ELEMENT,
     TYPE_NUMBER,
     LAST_DROPZONE_ID,
     FORMULA_BOX_ID,
@@ -85,7 +85,7 @@ const CalculationModal = ({
         const newItem = {
             id: `${data.type}-${newIdCount}`,
             value:
-                data.type === TYPE_DATAELEMENT
+                data.type === TYPE_DATA_ELEMENT
                     ? `#{${data.value}}`
                     : data.value,
             label: data.label,
@@ -161,8 +161,6 @@ const CalculationModal = ({
             moveItem({ sourceIndex: item.sourceIndex, destIndex })
         }
     }
-
-    console.log('exparr', expressionArray)
 
     return (
         <>

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -130,6 +130,13 @@ const CalculationModal = ({
         setValidationOutput(result)
     }
 
+    const removeItem = ({ index }) => {
+        setValidationOutput()
+        const sourceList = Array.from(expressionArray)
+        sourceList.splice(index, 1)
+        setExpressionArray(sourceList)
+    }
+
     return (
         <>
             <Modal dataTest={`calculation-modal`} position="top" large>
@@ -185,6 +192,7 @@ const CalculationModal = ({
                                         setExpressionItemValue
                                     }
                                     onPartSelection={onPartSelection}
+                                    removeItem={removeItem}
                                     selectedPart={selectedPart}
                                 />
                                 <div className="leftpad">

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -88,8 +88,8 @@ const CalculationModal = ({
         const newItem = {
             id: `${type}-${newIdCount}`,
             value: type === TYPE_DATA_ELEMENT ? `#{${value}}` : value,
-            label: label,
-            type: type,
+            label,
+            type,
         }
 
         setNewIdCount(newIdCount + 1)

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -237,7 +237,7 @@ const CalculationModal = ({
                                                 expressionStatus ===
                                                 VALID_EXPRESSION,
                                         })}
-                                        data-test={'validation-message'}
+                                        data-test="validation-message"
                                     >
                                         {validationOutput?.message}
                                     </span>

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -97,7 +97,10 @@ const CalculationModal = ({
                         : i18n.t('Data / New calculation')}
                 </ModalTitle>
                 <ModalContent dataTest={'calculation-modal-content'}>
-                    <DndContext onDragEnd={addOrMoveDraggedItem}>
+                    <DndContext
+                        onDragStart={() => setFocusId(null)}
+                        onDragEnd={addOrMoveDraggedItem}
+                    >
                         <div className="name-input">
                             <InputField
                                 label={i18n.t(

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -25,13 +25,7 @@ import {
     parseExpressionToArray,
     parseArrayToExpression,
 } from '../../modules/expressions.js'
-import {
-    TYPE_DATAITEM,
-    TYPE_INPUT,
-    TYPE_OPERATOR,
-    LAST_DROPZONE_ID,
-    FORMULA_BOX_ID,
-} from './constants.js'
+import { TYPE_DATAITEM, LAST_DROPZONE_ID, FORMULA_BOX_ID } from './constants.js'
 import DataElementSelector from './DataElementSelector.js'
 import DraggingItem from './DraggingItem.js'
 import FormulaField from './FormulaField.js'
@@ -193,102 +187,75 @@ const CalculationModal = ({
                                     onPartSelection={onPartSelection}
                                     selectedPart={selectedPart}
                                 />
-                                <p>
-                                    {/* TODO: Remove, for testing only */}
-                                    {parseArrayToExpression(expressionArray)}
-                                </p>
-                                <div className="actions-wrapper">
-                                    <Button small onClick={validateExpression}>
-                                        {/* TODO: add loading state to button? */}
-                                        {i18n.t('Check formula')}
-                                    </Button>
-                                    {(selectedPart || selectedPart === 0) && (
-                                        <div className={'remove-button'}>
+                                <div className="leftpad">
+                                    <p>
+                                        {/* TODO: Remove, for testing only */}
+                                        {parseArrayToExpression(
+                                            expressionArray
+                                        )}
+                                    </p>
+                                    <div className="actions-wrapper">
+                                        <Button
+                                            small
+                                            onClick={validateExpression}
+                                        >
+                                            {/* TODO: add loading state to button? */}
+                                            {i18n.t('Check formula')}
+                                        </Button>
+                                        {(selectedPart ||
+                                            selectedPart === 0) && (
+                                            <div className={'remove-button'}>
+                                                <Button
+                                                    small
+                                                    onClick={() => {
+                                                        setValidationOutput()
+                                                        setExpressionArray(
+                                                            (prevArray) =>
+                                                                prevArray.filter(
+                                                                    (
+                                                                        _,
+                                                                        index
+                                                                    ) =>
+                                                                        index !=
+                                                                        selectedPart
+                                                                )
+                                                        )
+                                                        setSelectedPart()
+                                                    }}
+                                                >
+                                                    {i18n.t('Remove item')}
+                                                </Button>
+                                            </div>
+                                        )}
+                                        <span
+                                            className={cx(
+                                                'validation-message',
+                                                {
+                                                    'validation-error':
+                                                        expressionStatus ===
+                                                        INVALID_EXPRESSION,
+                                                    'validation-success':
+                                                        expressionStatus ===
+                                                        VALID_EXPRESSION,
+                                                }
+                                            )}
+                                        >
+                                            {validationOutput?.message}
+                                        </span>
+                                    </div>
+                                    {calculation.id && (
+                                        <div className="delete-button">
                                             <Button
                                                 small
-                                                onClick={() => {
-                                                    setValidationOutput()
-                                                    setExpressionArray(
-                                                        (prevArray) =>
-                                                            prevArray.filter(
-                                                                (_, index) =>
-                                                                    index !=
-                                                                    selectedPart
-                                                            )
-                                                    )
-                                                    setSelectedPart()
-                                                }}
+                                                onClick={() =>
+                                                    setShowDeletePrompt(true)
+                                                }
                                             >
-                                                {i18n.t('Remove item')}
+                                                {i18n.t('Delete calculation')}
                                             </Button>
                                         </div>
                                     )}
-                                    <span
-                                        className={cx('validation-message', {
-                                            'validation-error':
-                                                expressionStatus ===
-                                                INVALID_EXPRESSION,
-                                            'validation-success':
-                                                expressionStatus ===
-                                                VALID_EXPRESSION,
-                                        })}
-                                    >
-                                        {validationOutput?.message}
-                                    </span>
                                 </div>
-                                <p>
-                                    <span>Data element dragging item: </span>
-                                    <DraggingItem
-                                        item={{
-                                            type: TYPE_DATAITEM,
-                                            label: 'ANC 4th or more visits',
-                                        }}
-                                    />
-                                </p>
-                                <p>
-                                    <span>Number dragging item: </span>
-                                    <DraggingItem
-                                        item={{
-                                            type: TYPE_INPUT,
-                                            label: '<number>',
-                                            value: '55',
-                                        }}
-                                    />
-                                </p>
-                                <p>
-                                    <span>
-                                        Number dragging item w/o value:{' '}
-                                    </span>
-                                    <DraggingItem
-                                        item={{
-                                            type: TYPE_INPUT,
-                                            label: '<number>',
-                                            value: '',
-                                        }}
-                                    />
-                                </p>
-                                <p>
-                                    <span>Operator dragging item: </span>
-                                    <DraggingItem
-                                        item={{
-                                            type: TYPE_OPERATOR,
-                                            label: '+',
-                                            value: '+',
-                                        }}
-                                    />
-                                </p>
-                                {calculation.id && (
-                                    <div className="delete-button">
-                                        <Button
-                                            small
-                                            onClick={() =>
-                                                setShowDeletePrompt(true)
-                                            }
-                                        >
-                                            {i18n.t('Delete calculation')}
-                                        </Button>
-                                    </div>
-                                )}
                             </div>
                         </div>
                         <style jsx>{styles}</style>

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -164,13 +164,13 @@ const CalculationModal = ({
 
     return (
         <>
-            <Modal dataTest={`calculation-modal`} position="top" large>
-                <ModalTitle dataTest={'calculation-modal-title'}>
+            <Modal dataTest="calculation-modal" position="top" large>
+                <ModalTitle dataTest="calculation-modal-title">
                     {calculation.id
                         ? i18n.t('Data / Edit calculation')
                         : i18n.t('Data / New calculation')}
                 </ModalTitle>
-                <ModalContent dataTest={'calculation-modal-content'}>
+                <ModalContent dataTest="calculation-modal-content">
                     <DndContext
                         onDragStart={() => setFocusItemId(null)}
                         onDragEnd={addOrMoveDraggedItem}
@@ -182,7 +182,7 @@ const CalculationModal = ({
                                 )}
                                 onChange={({ value }) => setName(value)}
                                 value={name}
-                                dataTest={'calculation-label'}
+                                dataTest="calculation-label"
                             />
                         </div>
                         <div className="content">
@@ -213,7 +213,7 @@ const CalculationModal = ({
                                         <Button
                                             small
                                             onClick={validate}
-                                            dataTest={'validate-button'}
+                                            dataTest="validate-button"
                                         >
                                             {/* TODO: add loading state to button? */}
                                             {i18n.t('Check formula')}
@@ -227,7 +227,7 @@ const CalculationModal = ({
                                                             selectedItemId
                                                         )
                                                     }
-                                                    dataTest={'remove-button'}
+                                                    dataTest="remove-button"
                                                 >
                                                     {i18n.t('Remove item')}
                                                 </Button>
@@ -245,7 +245,7 @@ const CalculationModal = ({
                                                         VALID_EXPRESSION,
                                                 }
                                             )}
-                                            dataTest={'validation-message'}
+                                            data-test={'validation-message'}
                                         >
                                             {validationOutput?.message}
                                         </span>
@@ -257,7 +257,7 @@ const CalculationModal = ({
                                                 onClick={() =>
                                                     setShowDeletePrompt(true)
                                                 }
-                                                dataTest={'delete-button'}
+                                                dataTest="delete-button"
                                             >
                                                 {i18n.t('Delete calculation')}
                                             </Button>
@@ -269,9 +269,9 @@ const CalculationModal = ({
                         <style jsx>{styles}</style>
                     </DndContext>
                 </ModalContent>
-                <ModalActions dataTest={'calculation-modal-actions'}>
+                <ModalActions dataTest="calculation-modal-actions">
                     <ButtonStrip>
-                        <Button onClick={onClose} dataTest={'cancel-button'}>
+                        <Button onClick={onClose} dataTest="cancel-button">
                             {i18n.t('Cancel')}
                         </Button>
                         <Tooltip
@@ -320,7 +320,7 @@ const CalculationModal = ({
                                             expressionStatus !==
                                                 VALID_EXPRESSION || !name
                                         }
-                                        dataTest={'save-button'}
+                                        dataTest="save-button"
                                     >
                                         {i18n.t('Save calculation')}
                                     </Button>

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -59,7 +59,7 @@ const CalculationModal = ({
     const [name, setName] = useState(calculation.name)
     const [showDeletePrompt, setShowDeletePrompt] = useState(false)
 
-    const [focusIndex, setFocusIndex] = useState(null)
+    const [focusItemId, setFocusItemId] = useState(null)
     const [selectedItemId, setSelectedItemId] = useState(null)
 
     const expressionStatus = validationOutput?.status
@@ -109,7 +109,7 @@ const CalculationModal = ({
         }
 
         if (newItem.type === TYPE_NUMBER) {
-            setFocusIndex(newItem.id)
+            setFocusItemId(newItem.id)
         }
     }
 
@@ -172,7 +172,7 @@ const CalculationModal = ({
                 </ModalTitle>
                 <ModalContent dataTest={'calculation-modal-content'}>
                     <DndContext
-                        onDragStart={() => setFocusIndex(null)}
+                        onDragStart={() => setFocusItemId(null)}
                         onDragEnd={addOrMoveDraggedItem}
                     >
                         <div className="name-input">
@@ -197,7 +197,7 @@ const CalculationModal = ({
                                 <FormulaField
                                     items={expressionArray}
                                     selectedItemId={selectedItemId}
-                                    focusIndex={focusIndex}
+                                    focusItemId={focusItemId}
                                     onChange={setItemValue}
                                     onClick={selectItem}
                                     onDoubleClick={removeItem}

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -158,7 +158,7 @@ const CalculationModal = ({
                                             {i18n.t('Check formula')}
                                         </Button>
                                         {(selectedId || selectedId === 0) && (
-                                            <div className={'remove-button'}>
+                                            <div className="remove-button">
                                                 <Button
                                                     small
                                                     onClick={() =>

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -18,8 +18,8 @@ import {
     parseExpressionToArray,
     parseArrayToExpression,
     validateExpression,
-    TYPE_DATA_ELEMENT,
-    TYPE_NUMBER,
+    EXPRESSION_TYPE_DATA_ELEMENT,
+    EXPRESSION_TYPE_NUMBER,
     INVALID_EXPRESSION,
     VALID_EXPRESSION,
 } from '../../modules/expressions.js'
@@ -87,7 +87,8 @@ const CalculationModal = ({
 
         const newItem = {
             id: `${type}-${newIdCount}`,
-            value: type === TYPE_DATA_ELEMENT ? `#{${value}}` : value,
+            value:
+                type === EXPRESSION_TYPE_DATA_ELEMENT ? `#{${value}}` : value,
             label,
             type,
         }
@@ -108,7 +109,7 @@ const CalculationModal = ({
             setExpressionArray(newFormulaItems)
         }
 
-        if (newItem.type === TYPE_NUMBER) {
+        if (newItem.type === EXPRESSION_TYPE_NUMBER) {
             setFocusItemId(newItem.id)
         }
     }

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -131,7 +131,7 @@ const CalculationModal = ({
     const validate = async () => {
         const expression = parseArrayToExpression(expressionArray)
         let result = validateExpression(expression)
-        if (!result.length) {
+        if (!result) {
             result = await doBackendValidation({
                 expression,
             })

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -18,18 +18,17 @@ import {
     parseExpressionToArray,
     parseArrayToExpression,
     validateExpression,
+    TYPE_DATA_ELEMENT,
+    TYPE_NUMBER,
     INVALID_EXPRESSION,
     VALID_EXPRESSION,
 } from '../../modules/expressions.js'
-import {
-    TYPE_DATA_ELEMENT,
-    TYPE_NUMBER,
-    LAST_DROPZONE_ID,
-    FORMULA_BOX_ID,
-} from './constants.js'
 import DataElementSelector from './DataElementSelector.js'
 import DndContext, { OPTIONS_PANEL } from './DndContext.js'
-import FormulaField from './FormulaField.js'
+import FormulaField, {
+    LAST_DROPZONE_ID,
+    FORMULA_BOX_ID,
+} from './FormulaField.js'
 import MathOperatorSelector from './MathOperatorSelector.js'
 import styles from './styles/CalculationModal.style.js'
 

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -22,7 +22,7 @@ import {
     VALID_EXPRESSION,
 } from '../../modules/expressions.js'
 import {
-    TYPE_DATAITEM,
+    TYPE_DATAELEMENT,
     TYPE_INPUT,
     LAST_DROPZONE_ID,
     FORMULA_BOX_ID,
@@ -299,7 +299,7 @@ const CalculationModal = ({
 
         if (sourceAxisId === OPTIONS_PANEL) {
             let newItem
-            if (active.data.current.type === TYPE_DATAITEM) {
+            if (active.data.current.type === TYPE_DATAELEMENT) {
                 newItem = getNewDataItem(
                     active.data.current.id,
                     active.data.current.label
@@ -351,7 +351,7 @@ const CalculationModal = ({
             id: `${id}-${idCounter}`,
             value: `#{${id}}`,
             label: label,
-            type: TYPE_DATAITEM,
+            type: TYPE_DATAELEMENT,
         }
         setIdCounter(idCounter + 1)
         return newItem

--- a/src/components/DataDimension/DataElementSelector.js
+++ b/src/components/DataDimension/DataElementSelector.js
@@ -17,6 +17,7 @@ import {
 import { getIcon, getTooltipText } from '../../modules/dimensionListItem.js'
 import { useDebounce } from '../../modules/utils.js'
 import { TransferOption } from '../TransferOption.js'
+import { TYPE_DATAITEM } from './MathOperatorSelector.js'
 import styles from './styles/DataElementSelector.style.js'
 
 const getOptions = () => ({

--- a/src/components/DataDimension/DataElementSelector.js
+++ b/src/components/DataDimension/DataElementSelector.js
@@ -5,6 +5,7 @@ import {
     SingleSelectField,
     SingleSelectOption,
 } from '@dhis2/ui'
+import { useSortable } from '@dnd-kit/sortable'
 import PropTypes from 'prop-types'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 import { apiFetchOptions } from '../../api/dimensions.js'
@@ -14,10 +15,8 @@ import {
     DETAIL,
     DIMENSION_TYPE_DATA_ELEMENT,
 } from '../../modules/dataTypes.js'
-import { getIcon, getTooltipText } from '../../modules/dimensionListItem.js'
 import { useDebounce } from '../../modules/utils.js'
-import { TransferOption } from '../TransferOption.js'
-import { TYPE_DATAITEM } from './MathOperatorSelector.js'
+import DraggableTransferOption from './DraggableTransferOption.js'
 import styles from './styles/DataElementSelector.style.js'
 
 const getOptions = () => ({
@@ -99,6 +98,13 @@ const DataElementSelector = ({
     const [page, setPage] = useState(0)
     const [hasNextPage, setHasNextPage] = useState(true)
     const debouncedSearchTerm = useDebounce(searchInput, 200)
+
+    const { isOver, setNodeRef } = useSortable({
+        id: 'dataitems',
+    })
+    const style = {
+        opacity: isOver ? 1 : 0.5,
+    }
 
     if (selectedItems.length) {
         // FIXME: temporarily removes lint errors
@@ -202,14 +208,15 @@ const DataElementSelector = ({
                     type={'search'}
                 />
                 <GroupSelector
-                    currentValue={filter.group}
+                    currentValue={filter.group || ''}
+                    onChange={Function.prototype}
                     // onChange={(group) => {
                     //     setFilter({ ...filter, group })
                     // }}
                 />
-
                 <DisaggregationSelector
-                    currentValue={filter.subGroup}
+                    currentValue={filter.subGroup || ''}
+                    onChange={Function.prototype}
                     // onChange={(subGroup) => {
                     //     setFilter({ ...filter, subGroup })
                     // }}
@@ -217,19 +224,22 @@ const DataElementSelector = ({
             </div>
             <div className="dimension-list-wrapper" ref={rootRef}>
                 <div className="dimension-list">
-                    {options.map(({ label, value, type, disabled }) => (
-                        <TransferOption
-                            label={label}
-                            key={value}
-                            value={value}
-                            icon={getIcon(type)}
-                            tooltipText={getTooltipText({
-                                type,
-                            })}
-                            disabled={disabled}
-                            onDoubleClick={onSelect}
-                        />
-                    ))}
+                    <div
+                        className="draggable-items"
+                        ref={setNodeRef}
+                        style={style}
+                    >
+                        {options.map(({ label, value, type, disabled }) => (
+                            <DraggableTransferOption
+                                label={label}
+                                key={value}
+                                value={value}
+                                type={type}
+                                disabled={disabled}
+                                onSelect={onSelect}
+                            />
+                        ))}
+                    </div>
 
                     <div className="scroll-detector">
                         <IntersectionDetector

--- a/src/components/DataDimension/DataElementSelector.js
+++ b/src/components/DataDimension/DataElementSelector.js
@@ -99,12 +99,9 @@ const DataElementSelector = ({
     const [hasNextPage, setHasNextPage] = useState(true)
     const debouncedSearchTerm = useDebounce(searchInput, 200)
 
-    const { isOver, setNodeRef } = useSortable({
+    const { setNodeRef } = useSortable({
         id: 'dataitems',
     })
-    const style = {
-        opacity: isOver ? 1 : 0.5,
-    }
 
     if (selectedItems.length) {
         // FIXME: temporarily removes lint errors
@@ -224,11 +221,7 @@ const DataElementSelector = ({
             </div>
             <div className="dimension-list-wrapper" ref={rootRef}>
                 <div className="dimension-list">
-                    <div
-                        className="draggable-items"
-                        ref={setNodeRef}
-                        style={style}
-                    >
+                    <div className="draggable-items" ref={setNodeRef}>
                         {options.map(({ label, value, type, disabled }) => (
                             <DraggableTransferOption
                                 label={label}

--- a/src/components/DataDimension/DataElementSelector.js
+++ b/src/components/DataDimension/DataElementSelector.js
@@ -122,7 +122,7 @@ DisaggregationSelector.propTypes = {
     onChange: PropTypes.func.isRequired,
 }
 
-const DataElementSelector = ({ displayNameProp, onSelect }) => {
+const DataElementSelector = ({ displayNameProp, onDoubleClick }) => {
     const dataEngine = useDataEngine()
 
     const [searchTerm, setSearchTerm] = useState('')
@@ -274,7 +274,7 @@ const DataElementSelector = ({ displayNameProp, onSelect }) => {
                                     value={value}
                                     type={type}
                                     disabled={disabled}
-                                    onDoubleClick={onSelect}
+                                    onDoubleClick={onDoubleClick}
                                 />
                             ))}
                         </div>
@@ -303,7 +303,7 @@ const DataElementSelector = ({ displayNameProp, onSelect }) => {
 
 DataElementSelector.propTypes = {
     displayNameProp: PropTypes.string.isRequired,
-    onSelect: PropTypes.func.isRequired,
+    onDoubleClick: PropTypes.func.isRequired,
 }
 
 export default DataElementSelector

--- a/src/components/DataDimension/DataElementSelector.js
+++ b/src/components/DataDimension/DataElementSelector.js
@@ -274,7 +274,7 @@ const DataElementSelector = ({ displayNameProp, onSelect }) => {
                                     value={value}
                                     type={type}
                                     disabled={disabled}
-                                    onSelect={onSelect}
+                                    onDoubleClick={onSelect}
                                 />
                             ))}
                         </div>

--- a/src/components/DataDimension/DataElementSelector.js
+++ b/src/components/DataDimension/DataElementSelector.js
@@ -131,8 +131,8 @@ const DataElementSelector = ({ displayNameProp, onSelect }) => {
     const [options, setOptions] = useState([])
     const [loading, setLoading] = useState(true)
 
-    const { setNodeRef } = useSortable({
-        id: 'dataitems',
+    const { setNodeRef: setDraggableNodeRef } = useSortable({
+        id: 'dataelements',
     })
 
     const rootRef = useRef()
@@ -272,7 +272,7 @@ const DataElementSelector = ({ displayNameProp, onSelect }) => {
                     ref={rootRef}
                 >
                     <div className="dimension-list-scroller">
-                        <div className="draggable-items" ref={setNodeRef}>
+                        <div ref={setDraggableNodeRef}>
                             {options.map(({ label, value, type, disabled }) => (
                                 <DraggableTransferOption
                                     label={label}

--- a/src/components/DataDimension/DndContext.js
+++ b/src/components/DataDimension/DndContext.js
@@ -58,7 +58,22 @@ const OuterDndContext = ({ children, onDragEnd }) => {
             handleDragCancel()
             return
         }
-        onDragEnd({ active, over })
+
+        const activeItem = {
+            id: active.id,
+            sourceAxisId: active.data.current?.sortable?.containerId,
+            sourceIndex: active.data.current?.sortable?.index,
+            data: {
+                id: active.data.current.id,
+                type: active.data.current.type,
+                label: active.data.current.label,
+            },
+        }
+        const overItem = {
+            axisId: over.data.current?.sortable?.containerId || over.id,
+            index: over.data.current?.sortable?.index,
+        }
+        onDragEnd({ activeItem, over: overItem })
         setDraggingItem(null)
     }
 

--- a/src/components/DataDimension/DndContext.js
+++ b/src/components/DataDimension/DndContext.js
@@ -64,7 +64,6 @@ const OuterDndContext = ({ children, onDragEnd, onDragStart }) => {
             sourceContainerId: active.data.current.sortable.containerId,
             sourceIndex: active.data.current.sortable.index,
             data: {
-                index: active.data.current.index,
                 label: active.data.current.label,
                 value: active.data.current.value,
                 type: active.data.current.type,

--- a/src/components/DataDimension/DndContext.js
+++ b/src/components/DataDimension/DndContext.js
@@ -17,7 +17,7 @@ const activateAt15pixels = {
 
 export const OPTIONS_PANEL = 'Sortable'
 
-const OuterDndContext = ({ children, onDragEnd }) => {
+const OuterDndContext = ({ children, onDragEnd, onDragStart }) => {
     const [draggingItem, setDraggingItem] = useState(null)
     const sensor = useSensor(PointerSensor, activateAt15pixels)
     const sensors = useSensors(sensor)
@@ -43,6 +43,7 @@ const OuterDndContext = ({ children, onDragEnd }) => {
 
     function handleDragStart({ active }) {
         setDraggingItem(active.data.current)
+        onDragStart && onDragStart()
     }
 
     function handleDragCancel() {
@@ -158,6 +159,7 @@ const OuterDndContext = ({ children, onDragEnd }) => {
 OuterDndContext.propTypes = {
     onDragEnd: PropTypes.func.isRequired,
     children: PropTypes.node,
+    onDragStart: PropTypes.func,
 }
 
 export default OuterDndContext

--- a/src/components/DataDimension/DndContext.js
+++ b/src/components/DataDimension/DndContext.js
@@ -32,7 +32,7 @@ const OuterDndContext = ({ children, onDragEnd, onDragStart }) => {
             <DragOverlay dropAnimation={null}>
                 {draggingItem ? (
                     <span className="dragOverlay">
-                        <DraggingItem item={draggingItem} />
+                        <DraggingItem {...draggingItem} />
                     </span>
                 ) : null}
             </DragOverlay>
@@ -51,7 +51,8 @@ const OuterDndContext = ({ children, onDragEnd, onDragStart }) => {
     function handleDragEnd({ active, over }) {
         if (
             !over?.id ||
-            over?.data?.current?.sortable?.containerId === OPTIONS_PANEL
+            over?.data?.current?.sortable?.containerId === OPTIONS_PANEL ||
+            !active.data.current
         ) {
             // dropped over non-droppable or over options panel
             handleDragCancel()
@@ -60,8 +61,8 @@ const OuterDndContext = ({ children, onDragEnd, onDragStart }) => {
 
         const item = {
             id: active.id,
-            sourceContainerId: active.data.current?.sortable?.containerId,
-            sourceIndex: active.data.current?.sortable?.index,
+            sourceContainerId: active.data.current.sortable.containerId,
+            sourceIndex: active.data.current.sortable.index,
             data: {
                 index: active.data.current.index,
                 label: active.data.current.label,
@@ -70,9 +71,10 @@ const OuterDndContext = ({ children, onDragEnd, onDragStart }) => {
             },
         }
         const destination = {
-            containerId: over.data.current?.sortable?.containerId || over.id,
-            index: over.data.current?.sortable?.index,
+            containerId: over.data.current?.sortable.containerId || over.id,
+            index: over.data.current?.sortable.index,
         }
+
         onDragEnd({ item, destination })
         setDraggingItem(null)
     }

--- a/src/components/DataDimension/DndContext.js
+++ b/src/components/DataDimension/DndContext.js
@@ -1,0 +1,148 @@
+import {
+    DndContext,
+    DragOverlay,
+    useSensor,
+    useSensors,
+    PointerSensor,
+} from '@dnd-kit/core'
+import PropTypes from 'prop-types'
+import React, { useState } from 'react'
+import DraggingItem from './DraggingItem.js'
+
+const activateAt15pixels = {
+    activationConstraint: {
+        distance: 15,
+    },
+}
+
+export const OPTIONS_PANEL = 'Sortable'
+
+const OuterDndContext = ({ children, onDragEnd }) => {
+    const [draggingItem, setDraggingItem] = useState(null)
+    const sensor = useSensor(PointerSensor, activateAt15pixels)
+    const sensors = useSensors(sensor)
+
+    return (
+        <DndContext
+            collisionDetection={rectIntersectionCustom}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+            onDragCancel={handleDragCancel}
+            sensors={sensors}
+        >
+            {children}
+            <DragOverlay dropAnimation={null}>
+                {draggingItem ? (
+                    <span className="dragOverlay">
+                        <DraggingItem item={draggingItem} />
+                    </span>
+                ) : null}
+            </DragOverlay>
+        </DndContext>
+    )
+
+    function handleDragStart({ active }) {
+        setDraggingItem(active.data.current)
+    }
+
+    function handleDragCancel() {
+        setDraggingItem(null)
+    }
+
+    function handleDragEnd({ active, over }) {
+        if (
+            !over?.id ||
+            over?.data?.current?.sortable?.containerId === OPTIONS_PANEL
+        ) {
+            // dropped over non-droppable or over options panel
+            handleDragCancel()
+            return
+        }
+        onDragEnd({ active, over })
+        setDraggingItem(null)
+    }
+
+    function getIntersectionRatio(entry, target) {
+        const top = Math.max(target.top, entry.top)
+        const left = Math.max(target.left, entry.left)
+        const right = Math.min(
+            target.left + target.width,
+            entry.left + entry.width
+        )
+        const bottom = Math.min(
+            target.top + target.height,
+            entry.top + entry.height
+        )
+        const width = right - left
+        const height = bottom - top
+
+        if (left < right && top < bottom) {
+            const targetArea = target.width * target.height
+            const entryArea = entry.width * entry.height
+            const intersectionArea = width * height
+            const intersectionRatio =
+                intersectionArea / (targetArea + entryArea - intersectionArea)
+            return Number(intersectionRatio.toFixed(4))
+        } // Rectangles do not overlap, or overlap has an area of zero (edge/corner overlap)
+
+        return 0
+    }
+    function sortCollisionsDesc(
+        { data: { value: a } },
+        { data: { value: b } }
+    ) {
+        return b - a
+    }
+
+    function rectIntersectionCustom({
+        pointerCoordinates,
+        droppableContainers,
+    }) {
+        // create a rect around the pointerCoords for calculating the intersection
+
+        const pointerRectWidth = 40
+        const pointerRectHeight = 40
+        const pointerRect = {
+            width: pointerRectWidth,
+            height: pointerRectHeight,
+            top: pointerCoordinates.y - pointerRectHeight / 2,
+            bottom: pointerCoordinates.y + pointerRectHeight / 2,
+            left: pointerCoordinates.x - pointerRectWidth / 2,
+            right: pointerCoordinates.x + pointerRectWidth / 2,
+        }
+        const collisions = []
+
+        for (const droppableContainer of droppableContainers) {
+            const {
+                id,
+                rect: { current: rect },
+            } = droppableContainer
+
+            if (rect) {
+                const intersectionRatio = getIntersectionRatio(
+                    rect,
+                    pointerRect
+                )
+
+                if (intersectionRatio > 0) {
+                    collisions.push({
+                        id,
+                        data: {
+                            droppableContainer,
+                            value: intersectionRatio,
+                        },
+                    })
+                }
+            }
+        }
+
+        return collisions.sort(sortCollisionsDesc)
+    }
+}
+
+OuterDndContext.propTypes = {
+    onDragEnd: PropTypes.func.isRequired,
+    children: PropTypes.node,
+}
+
+export default OuterDndContext

--- a/src/components/DataDimension/DndContext.js
+++ b/src/components/DataDimension/DndContext.js
@@ -58,21 +58,22 @@ const OuterDndContext = ({ children, onDragEnd, onDragStart }) => {
             return
         }
 
-        const activeItem = {
+        const item = {
             id: active.id,
-            sourceAxisId: active.data.current?.sortable?.containerId,
+            sourceContainerId: active.data.current?.sortable?.containerId,
             sourceIndex: active.data.current?.sortable?.index,
             data: {
-                id: active.data.current.id,
-                type: active.data.current.type,
+                index: active.data.current.index,
                 label: active.data.current.label,
+                value: active.data.current.value,
+                type: active.data.current.type,
             },
         }
-        const overItem = {
-            axisId: over.data.current?.sortable?.containerId || over.id,
+        const destination = {
+            containerId: over.data.current?.sortable?.containerId || over.id,
             index: over.data.current?.sortable?.index,
         }
-        onDragEnd({ activeItem, over: overItem })
+        onDragEnd({ item, destination })
         setDraggingItem(null)
     }
 

--- a/src/components/DataDimension/DndContext.js
+++ b/src/components/DataDimension/DndContext.js
@@ -9,17 +9,15 @@ import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import DraggingItem from './DraggingItem.js'
 
-const activateAt15pixels = {
-    activationConstraint: {
-        distance: 15,
-    },
-}
-
 export const OPTIONS_PANEL = 'Sortable'
 
 const OuterDndContext = ({ children, onDragEnd, onDragStart }) => {
     const [draggingItem, setDraggingItem] = useState(null)
-    const sensor = useSensor(PointerSensor, activateAt15pixels)
+    const sensor = useSensor(PointerSensor, {
+        activationConstraint: {
+            distance: 15,
+        },
+    })
     const sensors = useSensors(sensor)
 
     return (

--- a/src/components/DataDimension/DragHandleIcon.js
+++ b/src/components/DataDimension/DragHandleIcon.js
@@ -1,0 +1,16 @@
+import React from 'react'
+
+export default (
+    <svg
+        height="16"
+        viewBox="0 0 16 16"
+        width="16"
+        xmlns="http://www.w3.org/2000/svg"
+    >
+        <path
+            d="M6 11a1 1 0 110 2 1 1 0 010-2zm4 0a1 1 0 110 2 1 1 0 010-2zM6 7a1 1 0 110 2 1 1 0 010-2zm4 0a1 1 0 110 2 1 1 0 010-2zM6 3a1 1 0 110 2 1 1 0 010-2zm4 0a1 1 0 110 2 1 1 0 010-2z"
+            fill="#A0ADBA"
+            fillRule="evenodd"
+        ></path>
+    </svg>
+)

--- a/src/components/DataDimension/DraggableTransferOption.js
+++ b/src/components/DataDimension/DraggableTransferOption.js
@@ -45,6 +45,7 @@ const DraggableTransferOption = ({
                         type,
                     })}
                     disabled={disabled}
+                    onClick={Function.prototype}
                     onDoubleClick={onSelect}
                 />
             </div>

--- a/src/components/DataDimension/DraggableTransferOption.js
+++ b/src/components/DataDimension/DraggableTransferOption.js
@@ -1,0 +1,62 @@
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import PropTypes from 'prop-types'
+import React from 'react'
+import { getIcon, getTooltipText } from '../../modules/dimensionListItem.js'
+import { TransferOption } from '../TransferOption.js'
+import styles from './styles/Operator.style.js'
+
+const DraggableTransferOption = ({
+    label,
+    value,
+    type,
+    disabled,
+    onSelect,
+}) => {
+    const { attributes, listeners, setNodeRef, transform } = useSortable({
+        id: value,
+        data: { id: value, label, type },
+    })
+    const style = {
+        // Outputs `translate3d(x, y, 0)`
+        transform: CSS.Translate.toString(transform),
+    }
+
+    return (
+        <>
+            <div
+                className="draggabledataitem"
+                {...attributes}
+                {...listeners}
+                ref={setNodeRef}
+                style={style}
+            >
+                <TransferOption
+                    label={label}
+                    key={value}
+                    value={value}
+                    type={type}
+                    icon={getIcon(type)}
+                    tooltipText={getTooltipText({
+                        type,
+                    })}
+                    disabled={disabled}
+                    onDoubleClick={onSelect}
+                />
+            </div>
+            <style jsx>{styles}</style>
+        </>
+    )
+}
+
+DraggableTransferOption.propTypes = {
+    disabled: PropTypes.bool,
+    id: PropTypes.string,
+    label: PropTypes.string,
+    type: PropTypes.string,
+    value: PropTypes.string,
+    onDblClick: PropTypes.func,
+    onSelect: PropTypes.func,
+}
+
+export default DraggableTransferOption

--- a/src/components/DataDimension/DraggableTransferOption.js
+++ b/src/components/DataDimension/DraggableTransferOption.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { getIcon, getTooltipText } from '../../modules/dimensionListItem.js'
 import { TransferOption } from '../TransferOption.js'
-import styles from './styles/Operator.style.js'
+import styles from './styles/DraggableTransferOption.style.js'
 
 const DraggableTransferOption = ({
     label,
@@ -20,6 +20,10 @@ const DraggableTransferOption = ({
     const style = {
         // Outputs `translate3d(x, y, 0)`
         transform: CSS.Translate.toString(transform),
+    }
+
+    if (transform) {
+        console.log('dataitem transform', transform)
     }
 
     return (

--- a/src/components/DataDimension/DraggableTransferOption.js
+++ b/src/components/DataDimension/DraggableTransferOption.js
@@ -18,18 +18,13 @@ const DraggableTransferOption = ({
         data: { id: value, label, type },
     })
     const style = {
-        // Outputs `translate3d(x, y, 0)`
         transform: CSS.Translate.toString(transform),
-    }
-
-    if (transform) {
-        console.log('dataitem transform', transform)
     }
 
     return (
         <>
             <div
-                className="draggabledataitem"
+                className="draggable-item"
                 {...attributes}
                 {...listeners}
                 ref={setNodeRef}

--- a/src/components/DataDimension/DraggableTransferOption.js
+++ b/src/components/DataDimension/DraggableTransferOption.js
@@ -15,7 +15,7 @@ const DraggableTransferOption = ({
 }) => {
     const { attributes, listeners, setNodeRef, transform } = useSortable({
         id: value,
-        data: { id: value, label, type },
+        data: { value, label, type, index: -1 },
     })
     const style = {
         transform: CSS.Translate.toString(transform),
@@ -41,7 +41,9 @@ const DraggableTransferOption = ({
                     })}
                     disabled={disabled}
                     onClick={Function.prototype}
-                    onDoubleClick={onDoubleClick}
+                    onDoubleClick={({ label, value }) =>
+                        onDoubleClick({ label, value, type })
+                    }
                 />
             </div>
             <style jsx>{styles}</style>

--- a/src/components/DataDimension/DraggableTransferOption.js
+++ b/src/components/DataDimension/DraggableTransferOption.js
@@ -11,7 +11,7 @@ const DraggableTransferOption = ({
     value,
     type,
     disabled,
-    onSelect,
+    onDoubleClick,
 }) => {
     const { attributes, listeners, setNodeRef, transform } = useSortable({
         id: value,
@@ -41,7 +41,7 @@ const DraggableTransferOption = ({
                     })}
                     disabled={disabled}
                     onClick={Function.prototype}
-                    onDoubleClick={onSelect}
+                    onDoubleClick={onDoubleClick}
                 />
             </div>
             <style jsx>{styles}</style>
@@ -55,8 +55,7 @@ DraggableTransferOption.propTypes = {
     label: PropTypes.string,
     type: PropTypes.string,
     value: PropTypes.string,
-    onDblClick: PropTypes.func,
-    onSelect: PropTypes.func,
+    onDoubleClick: PropTypes.func,
 }
 
 export default DraggableTransferOption

--- a/src/components/DataDimension/DraggingItem.js
+++ b/src/components/DataDimension/DraggingItem.js
@@ -2,13 +2,12 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../modules/dataTypes.js'
 import { getIcon } from '../../modules/dimensionListItem.js'
-import { TYPE_DATAITEM } from './constants.js'
+import { TYPE_DATAITEM, TYPE_INPUT } from './constants.js'
 import styles from './styles/DraggingItem.style.js'
 
 const DraggingItem = ({ item }) => {
-    const displayLabel = item.value || item.label
-
-    console.log('item', item)
+    const displayLabel =
+        item.type === TYPE_INPUT ? item.value || item.label : item.label
 
     return (
         <>

--- a/src/components/DataDimension/DraggingItem.js
+++ b/src/components/DataDimension/DraggingItem.js
@@ -1,8 +1,9 @@
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../modules/dataTypes.js'
 import { getIcon } from '../../modules/dimensionListItem.js'
-import { TYPE_DATAITEM, TYPE_INPUT } from './constants.js'
+import { TYPE_DATAITEM, TYPE_INPUT, TYPE_OPERATOR } from './constants.js'
 import styles from './styles/DraggingItem.style.js'
 
 const DraggingItem = ({ item }) => {
@@ -11,15 +12,19 @@ const DraggingItem = ({ item }) => {
 
     return (
         <>
-            <div className="draggingItem">
-                <div className="iconAndLabelWrapper">
-                    {item.type === TYPE_DATAITEM && (
-                        <span className="icon">
-                            {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
-                        </span>
-                    )}
-                    <span className="label">{displayLabel}</span>
-                </div>
+            <div
+                className={cx('draggingItem', {
+                    operator: item.type === TYPE_OPERATOR,
+                    number: item.type === TYPE_INPUT,
+                    dataelement: item.type === TYPE_DATAITEM,
+                })}
+            >
+                {item.type === TYPE_DATAITEM && (
+                    <span className="icon">
+                        {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
+                    </span>
+                )}
+                <span>{displayLabel}</span>
             </div>
             <style jsx>{styles}</style>
         </>

--- a/src/components/DataDimension/DraggingItem.js
+++ b/src/components/DataDimension/DraggingItem.js
@@ -1,0 +1,43 @@
+import PropTypes from 'prop-types'
+import React from 'react'
+import { DIMENSION_TYPE_DATA_ELEMENT } from '../../modules/dataTypes.js'
+import { getIcon } from '../../modules/dimensionListItem.js'
+import { TYPE_DATAITEM } from './constants.js'
+import styles from './styles/DraggingItem.style.js'
+
+const DraggingItem = ({ item }) => {
+    const displayLabel = item.value || item.label
+
+    console.log('item', item)
+
+    return (
+        <>
+            <div className="draggingItem">
+                <div className="iconAndLabelWrapper">
+                    {item.type === TYPE_DATAITEM && (
+                        <span className="icon">
+                            {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
+                        </span>
+                    )}
+                    <span className="label">{displayLabel}</span>
+                </div>
+            </div>
+            <style jsx>{styles}</style>
+        </>
+    )
+}
+
+DraggingItem.propTypes = {
+    item: PropTypes.shape({
+        label: PropTypes.string,
+        sortable: PropTypes.object,
+        type: PropTypes.string,
+        value: PropTypes.string,
+    }),
+}
+
+DraggingItem.defaultProps = {
+    onClick: Function.prototype,
+}
+
+export default DraggingItem

--- a/src/components/DataDimension/DraggingItem.js
+++ b/src/components/DataDimension/DraggingItem.js
@@ -40,8 +40,4 @@ DraggingItem.propTypes = {
     }),
 }
 
-DraggingItem.defaultProps = {
-    onClick: Function.prototype,
-}
-
 export default DraggingItem

--- a/src/components/DataDimension/DraggingItem.js
+++ b/src/components/DataDimension/DraggingItem.js
@@ -3,19 +3,19 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../modules/dataTypes.js'
 import { getIcon } from '../../modules/dimensionListItem.js'
-import { TYPE_DATAELEMENT, TYPE_INPUT, TYPE_OPERATOR } from './constants.js'
+import { TYPE_DATAELEMENT, TYPE_NUMBER, TYPE_OPERATOR } from './constants.js'
 import styles from './styles/DraggingItem.style.js'
 
 const DraggingItem = ({ item }) => {
     const displayLabel =
-        item.type === TYPE_INPUT ? item.value || item.label : item.label
+        item.type === TYPE_NUMBER ? item.value || item.label : item.label
 
     return (
         <>
             <div
                 className={cx('dragging-item', {
                     operator: item.type === TYPE_OPERATOR,
-                    number: item.type === TYPE_INPUT,
+                    number: item.type === TYPE_NUMBER,
                     dataelement: item.type === TYPE_DATAELEMENT,
                 })}
             >

--- a/src/components/DataDimension/DraggingItem.js
+++ b/src/components/DataDimension/DraggingItem.js
@@ -4,25 +4,26 @@ import React from 'react'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../modules/dataTypes.js'
 import { getIcon } from '../../modules/dimensionListItem.js'
 import {
-    TYPE_DATA_ELEMENT,
-    TYPE_NUMBER,
-    TYPE_OPERATOR,
+    EXPRESSION_TYPE_DATA_ELEMENT,
+    EXPRESSION_TYPE_NUMBER,
+    EXPRESSION_TYPE_OPERATOR,
 } from '../../modules/expressions.js'
 import styles from './styles/DraggingItem.style.js'
 
 const DraggingItem = ({ label, type, value }) => {
-    const displayLabel = type === TYPE_NUMBER ? value || label : label
+    const displayLabel =
+        type === EXPRESSION_TYPE_NUMBER ? value || label : label
 
     return (
         <>
             <div
                 className={cx('dragging-item', {
-                    operator: type === TYPE_OPERATOR,
-                    number: type === TYPE_NUMBER,
-                    'data-element': type === TYPE_DATA_ELEMENT,
+                    operator: type === EXPRESSION_TYPE_OPERATOR,
+                    number: type === EXPRESSION_TYPE_NUMBER,
+                    'data-element': type === EXPRESSION_TYPE_DATA_ELEMENT,
                 })}
             >
-                {type === TYPE_DATA_ELEMENT && (
+                {type === EXPRESSION_TYPE_DATA_ELEMENT && (
                     <span className="icon">
                         {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
                     </span>

--- a/src/components/DataDimension/DraggingItem.js
+++ b/src/components/DataDimension/DraggingItem.js
@@ -3,7 +3,11 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../modules/dataTypes.js'
 import { getIcon } from '../../modules/dimensionListItem.js'
-import { TYPE_DATA_ELEMENT, TYPE_NUMBER, TYPE_OPERATOR } from './constants.js'
+import {
+    TYPE_DATA_ELEMENT,
+    TYPE_NUMBER,
+    TYPE_OPERATOR,
+} from '../../modules/expressions.js'
 import styles from './styles/DraggingItem.style.js'
 
 const DraggingItem = ({ label, type, value }) => {

--- a/src/components/DataDimension/DraggingItem.js
+++ b/src/components/DataDimension/DraggingItem.js
@@ -3,23 +3,22 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../modules/dataTypes.js'
 import { getIcon } from '../../modules/dimensionListItem.js'
-import { TYPE_DATAELEMENT, TYPE_NUMBER, TYPE_OPERATOR } from './constants.js'
+import { TYPE_DATA_ELEMENT, TYPE_NUMBER, TYPE_OPERATOR } from './constants.js'
 import styles from './styles/DraggingItem.style.js'
 
-const DraggingItem = ({ item }) => {
-    const displayLabel =
-        item.type === TYPE_NUMBER ? item.value || item.label : item.label
+const DraggingItem = ({ label, type, value }) => {
+    const displayLabel = type === TYPE_NUMBER ? value || label : label
 
     return (
         <>
             <div
                 className={cx('dragging-item', {
-                    operator: item.type === TYPE_OPERATOR,
-                    number: item.type === TYPE_NUMBER,
-                    dataelement: item.type === TYPE_DATAELEMENT,
+                    operator: type === TYPE_OPERATOR,
+                    number: type === TYPE_NUMBER,
+                    'data-element': type === TYPE_DATA_ELEMENT,
                 })}
             >
-                {item.type === TYPE_DATAELEMENT && (
+                {type === TYPE_DATA_ELEMENT && (
                     <span className="icon">
                         {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
                     </span>
@@ -32,12 +31,9 @@ const DraggingItem = ({ item }) => {
 }
 
 DraggingItem.propTypes = {
-    item: PropTypes.shape({
-        label: PropTypes.string,
-        sortable: PropTypes.object,
-        type: PropTypes.string,
-        value: PropTypes.string,
-    }),
+    label: PropTypes.string,
+    type: PropTypes.string,
+    value: PropTypes.string,
 }
 
 export default DraggingItem

--- a/src/components/DataDimension/DraggingItem.js
+++ b/src/components/DataDimension/DraggingItem.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../modules/dataTypes.js'
 import { getIcon } from '../../modules/dimensionListItem.js'
-import { TYPE_DATAITEM, TYPE_INPUT, TYPE_OPERATOR } from './constants.js'
+import { TYPE_DATAELEMENT, TYPE_INPUT, TYPE_OPERATOR } from './constants.js'
 import styles from './styles/DraggingItem.style.js'
 
 const DraggingItem = ({ item }) => {
@@ -13,13 +13,13 @@ const DraggingItem = ({ item }) => {
     return (
         <>
             <div
-                className={cx('draggingItem', {
+                className={cx('dragging-item', {
                     operator: item.type === TYPE_OPERATOR,
                     number: item.type === TYPE_INPUT,
-                    dataelement: item.type === TYPE_DATAITEM,
+                    dataelement: item.type === TYPE_DATAELEMENT,
                 })}
             >
-                {item.type === TYPE_DATAITEM && (
+                {item.type === TYPE_DATAELEMENT && (
                     <span className="icon">
                         {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
                     </span>

--- a/src/components/DataDimension/DropZone.js
+++ b/src/components/DataDimension/DropZone.js
@@ -2,7 +2,7 @@ import { useDroppable } from '@dnd-kit/core'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { FIRST_DROPZONE_ID } from './CalculationModal.js'
+import { FIRST_DROPZONE_ID } from './constants.js'
 import styles from './styles/DropZone.style.js'
 
 const DropZone = ({ firstElementId, overLastDropZone }) => {

--- a/src/components/DataDimension/DropZone.js
+++ b/src/components/DataDimension/DropZone.js
@@ -18,18 +18,20 @@ const DropZone = ({ firstElementId, overLastDropZone }) => {
     }
 
     return (
-        <div
-            ref={setNodeRef}
-            className={cx(styles.dropZone, {
-                [styles.isOver]: draggingOver,
-                [styles.isEmpty]: !firstElementId,
-            })}
-        ></div>
+        <>
+            <div
+                ref={setNodeRef}
+                className={cx('firstDropZone', {
+                    isOver: draggingOver,
+                    isEmpty: !firstElementId,
+                })}
+            ></div>
+            <style jsx>{styles}</style>
+        </>
     )
 }
 
 DropZone.propTypes = {
-    // axisId: PropTypes.string,
     firstElementId: PropTypes.string,
     overLastDropZone: PropTypes.bool,
 }

--- a/src/components/DataDimension/DropZone.js
+++ b/src/components/DataDimension/DropZone.js
@@ -1,0 +1,37 @@
+import { useDroppable } from '@dnd-kit/core'
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import React from 'react'
+import { FIRST_DROPZONE_ID } from './CalculationModal.js'
+import styles from './styles/DropZone.style.js'
+
+const DropZone = ({ firstElementId, overLastDropZone }) => {
+    const { isOver, setNodeRef, active } = useDroppable({
+        id: FIRST_DROPZONE_ID,
+    })
+
+    let draggingOver = false
+    if (overLastDropZone && !firstElementId) {
+        draggingOver = true
+    } else {
+        draggingOver = firstElementId === active?.id ? false : isOver
+    }
+
+    return (
+        <div
+            ref={setNodeRef}
+            className={cx(styles.dropZone, {
+                [styles.isOver]: draggingOver,
+                [styles.isEmpty]: !firstElementId,
+            })}
+        ></div>
+    )
+}
+
+DropZone.propTypes = {
+    // axisId: PropTypes.string,
+    firstElementId: PropTypes.string,
+    overLastDropZone: PropTypes.bool,
+}
+
+export default DropZone

--- a/src/components/DataDimension/DropZone.js
+++ b/src/components/DataDimension/DropZone.js
@@ -2,12 +2,11 @@ import { useDroppable } from '@dnd-kit/core'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { FIRST_DROPZONE_ID } from './constants.js'
 import styles from './styles/DropZone.style.js'
 
 const DropZone = ({ firstElementId, overLastDropZone }) => {
     const { isOver, setNodeRef, active } = useDroppable({
-        id: FIRST_DROPZONE_ID,
+        id: 'firstdropzone',
     })
 
     let draggingOver = false

--- a/src/components/DataDimension/DropZone.js
+++ b/src/components/DataDimension/DropZone.js
@@ -22,7 +22,7 @@ const DropZone = ({ firstElementId, overLastDropZone }) => {
             <div
                 ref={setNodeRef}
                 className={cx('first-dropzone', {
-                    over: draggingOver,
+                    'dragging-over': draggingOver,
                     empty: !firstElementId,
                 })}
             ></div>

--- a/src/components/DataDimension/DropZone.js
+++ b/src/components/DataDimension/DropZone.js
@@ -21,9 +21,9 @@ const DropZone = ({ firstElementId, overLastDropZone }) => {
         <>
             <div
                 ref={setNodeRef}
-                className={cx('firstDropZone', {
-                    isOver: draggingOver,
-                    isEmpty: !firstElementId,
+                className={cx('first-dropzone', {
+                    over: draggingOver,
+                    empty: !firstElementId,
                 })}
             ></div>
             <style jsx>{styles}</style>

--- a/src/components/DataDimension/FormulaField.js
+++ b/src/components/DataDimension/FormulaField.js
@@ -2,7 +2,7 @@ import { useDroppable } from '@dnd-kit/core'
 import { SortableContext } from '@dnd-kit/sortable'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { LAST_DROPZONE_ID, FORMULA_BOX_ID } from './CalculationModal.js'
+import { LAST_DROPZONE_ID, FORMULA_BOX_ID } from './constants.js'
 import DropZone from './DropZone.js'
 import DraggableFormulaItem from './FormulaItem.js'
 import styles from './styles/FormulaField.style.js'
@@ -14,13 +14,9 @@ const FormulaField = ({
     onPartSelection,
     setExpressionItemValue,
 }) => {
-    const { over, isOver, setNodeRef } = useDroppable({
+    const { over, setNodeRef } = useDroppable({
         id: LAST_DROPZONE_ID,
     })
-
-    const style = {
-        opacity: isOver ? 1 : 0.5,
-    }
 
     const overLastDropZone = over?.id === LAST_DROPZONE_ID
 
@@ -44,7 +40,7 @@ const FormulaField = ({
     }
 
     return (
-        <div className="wrapper lastDropZone" ref={setNodeRef} style={style}>
+        <div className="wrapper lastDropZone" ref={setNodeRef}>
             <SortableContext id={FORMULA_BOX_ID} items={itemIds}>
                 <>
                     <DropZone

--- a/src/components/DataDimension/FormulaField.js
+++ b/src/components/DataDimension/FormulaField.js
@@ -1,16 +1,11 @@
 import { useDroppable } from '@dnd-kit/core'
 import { SortableContext } from '@dnd-kit/sortable'
-import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { DIMENSION_TYPE_DATA_ELEMENT } from '../../modules/dataTypes.js'
-import { getIcon } from '../../modules/dimensionListItem.js'
 import { LAST_DROPZONE_ID, FORMULA_BOX_ID } from './CalculationModal.js'
 import DropZone from './DropZone.js'
-import FormulaItem from './FormulaItem.js'
+import DraggableFormulaItem from './FormulaItem.js'
 import styles from './styles/FormulaField.style.js'
-
-const partIsDimension = (part) => part.startsWith('#{') && part.endsWith('}')
 
 // TODO: Add fn for double-clicking on a part to remove it from the formula
 const FormulaField = ({
@@ -33,13 +28,10 @@ const FormulaField = ({
 
     function getFormulaItems() {
         return expressionArray.map((item, i) => (
-            <FormulaItem
+            <DraggableFormulaItem
                 key={`${item.label}-${i}`}
                 id={item.id}
                 index={i}
-                className={cx('part', {
-                    dimension: partIsDimension(item.value),
-                })}
                 label={item.label}
                 type={item.type}
                 value={item.value}
@@ -52,7 +44,7 @@ const FormulaField = ({
     }
 
     return (
-        <div className="wrapper" ref={setNodeRef} style={style}>
+        <div className="wrapper lastDropZone" ref={setNodeRef} style={style}>
             <SortableContext id={FORMULA_BOX_ID} items={itemIds}>
                 <>
                     <DropZone

--- a/src/components/DataDimension/FormulaField.js
+++ b/src/components/DataDimension/FormulaField.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { LAST_DROPZONE_ID, FORMULA_BOX_ID } from './constants.js'
 import DropZone from './DropZone.js'
-import DraggableFormulaItem from './FormulaItem.js'
+import FormulaItem from './FormulaItem.js'
 import styles from './styles/FormulaField.style.js'
 
 // TODO: Add fn for double-clicking on a part to remove it from the formula
@@ -24,7 +24,7 @@ const FormulaField = ({
 
     function getFormulaItems() {
         return expressionArray.map((item, i) => (
-            <DraggableFormulaItem
+            <FormulaItem
                 key={`${item.label}-${i}`}
                 id={item.id}
                 index={i}

--- a/src/components/DataDimension/FormulaField.js
+++ b/src/components/DataDimension/FormulaField.js
@@ -7,7 +7,6 @@ import DropZone from './DropZone.js'
 import FormulaItem from './FormulaItem.js'
 import styles from './styles/FormulaField.style.js'
 
-// TODO: Add fn for double-clicking on a part to remove it from the formula
 const FormulaField = ({
     expressionArray,
     selectedPart,
@@ -22,32 +21,28 @@ const FormulaField = ({
 
     const itemIds = expressionArray.map((item) => item.id)
 
-    function getFormulaItems() {
-        return expressionArray.map((item, i) => (
-            <FormulaItem
-                key={`${item.label}-${i}`}
-                id={item.id}
-                index={i}
-                label={item.label}
-                type={item.type}
-                value={item.value}
-                onChange={setExpressionItemValue}
-                isLast={i === expressionArray.length - 1}
-                highlighted={i === selectedPart}
-                onClickItem={() => onPartSelection(i)}
-            />
-        ))
-    }
-
     return (
-        <div className="wrapper lastDropZone" ref={setNodeRef}>
+        <div className="formulaField lastDropZone" ref={setNodeRef}>
             <SortableContext id={FORMULA_BOX_ID} items={itemIds}>
                 <>
                     <DropZone
                         firstElementId={itemIds[0]}
                         overLastDropZone={overLastDropZone}
                     />
-                    {getFormulaItems()}
+                    {expressionArray.map((item, i) => (
+                        <FormulaItem
+                            key={`${item.label}-${i}`}
+                            id={item.id}
+                            index={i}
+                            label={item.label}
+                            type={item.type}
+                            value={item.value}
+                            onChange={setExpressionItemValue}
+                            isLast={i === expressionArray.length - 1}
+                            highlighted={i === selectedPart}
+                            onClickItem={() => onPartSelection(i)}
+                        />
+                    ))}
                 </>
             </SortableContext>
             <style jsx>{styles}</style>

--- a/src/components/DataDimension/FormulaField.js
+++ b/src/components/DataDimension/FormulaField.js
@@ -1,45 +1,72 @@
+import { useDroppable } from '@dnd-kit/core'
+import { SortableContext } from '@dnd-kit/sortable'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../modules/dataTypes.js'
 import { getIcon } from '../../modules/dimensionListItem.js'
+import { LAST_DROPZONE_ID, FORMULA_BOX_ID } from './CalculationModal.js'
+import DropZone from './DropZone.js'
+import FormulaItem from './FormulaItem.js'
 import styles from './styles/FormulaField.style.js'
 
 const partIsDimension = (part) => part.startsWith('#{') && part.endsWith('}')
 
 // TODO: Add fn for double-clicking on a part to remove it from the formula
-const FormulaField = ({ expression }) => {
-    const renderParts = () =>
-        expression.map((part, index) => (
-            <>
-                <span
-                    className={cx('part', {
-                        dimension: partIsDimension(part.value),
-                    })}
-                    key={index}
-                >
-                    {partIsDimension(part.value) && (
-                        <span className="icon">
-                            {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
-                        </span>
-                    )}
-                    {part.label}
-                </span>
-                <style jsx>{styles}</style>
-            </>
+const FormulaField = ({ expressionArray, setExpressionItemValue }) => {
+    const { over, isOver, setNodeRef } = useDroppable({
+        id: LAST_DROPZONE_ID,
+    })
+
+    const style = {
+        opacity: isOver ? 1 : 0.5,
+    }
+
+    const overLastDropZone = over?.id === LAST_DROPZONE_ID
+
+    const itemIds = expressionArray.map((item) => item.id)
+
+    function getFormulaItems() {
+        return expressionArray.map((item, i) => (
+            <FormulaItem
+                key={`${item.label}-${i}`}
+                id={item.id}
+                index={i}
+                className={cx('part', {
+                    dimension: partIsDimension(item.value),
+                })}
+                label={item.label}
+                type={item.type}
+                value={item.value}
+                onChange={setExpressionItemValue}
+                isLast={i === expressionArray.length - 1}
+            />
         ))
+    }
+
     return (
-        <>
-            <div className="wrapper">{renderParts()}</div>
+        <div className="wrapper" ref={setNodeRef} style={style}>
+            <SortableContext id={FORMULA_BOX_ID} items={itemIds}>
+                <>
+                    <DropZone
+                        firstElementId={itemIds[0]}
+                        overLastDropZone={overLastDropZone}
+                    />
+                    {getFormulaItems()}
+                </>
+            </SortableContext>
             <style jsx>{styles}</style>
-        </>
+        </div>
     )
 }
 
 FormulaField.propTypes = {
-    expression: PropTypes.arrayOf(
+    setExpressionItemValue: PropTypes.func.isRequired,
+    expressionArray: PropTypes.arrayOf(
         PropTypes.shape({
+            id: PropTypes.string,
             label: PropTypes.string,
+            type: PropTypes.string,
             value: PropTypes.string,
         })
     ),

--- a/src/components/DataDimension/FormulaField.js
+++ b/src/components/DataDimension/FormulaField.js
@@ -9,8 +9,8 @@ import styles from './styles/FormulaField.style.js'
 
 const FormulaField = ({
     items,
-    selectedIndex,
-    focusIndex,
+    selectedItemId,
+    focusItemId,
     onChange,
     onClick,
     onDoubleClick,
@@ -37,8 +37,8 @@ const FormulaField = ({
                             label={label}
                             type={type}
                             value={value}
-                            hasFocus={focusIndex === index}
-                            isHighlighted={selectedIndex === index}
+                            hasFocus={focusItemId === id}
+                            isHighlighted={selectedItemId === id}
                             isLast={index === items.length - 1}
                             onChange={onChange}
                             onClick={onClick}
@@ -56,7 +56,7 @@ FormulaField.propTypes = {
     onChange: PropTypes.func.isRequired,
     onClick: PropTypes.func.isRequired,
     onDoubleClick: PropTypes.func.isRequired,
-    focusIndex: PropTypes.number,
+    focusItemId: PropTypes.string,
     items: PropTypes.arrayOf(
         PropTypes.shape({
             id: PropTypes.string,
@@ -65,7 +65,7 @@ FormulaField.propTypes = {
             value: PropTypes.string,
         })
     ),
-    selectedIndex: PropTypes.number,
+    selectedItemId: PropTypes.string,
 }
 
 export default FormulaField

--- a/src/components/DataDimension/FormulaField.js
+++ b/src/components/DataDimension/FormulaField.js
@@ -12,7 +12,7 @@ const FormulaField = ({
     selectedPart,
     highlightItem,
     removeItem,
-    setExpressionItemValue,
+    setItemValue,
     focusId,
 }) => {
     const { over, setNodeRef } = useDroppable({
@@ -41,7 +41,7 @@ const FormulaField = ({
                             isLast={i === expressionArray.length - 1}
                             hasFocus={focusId === item.id}
                             highlighted={i === selectedPart}
-                            onChange={setExpressionItemValue}
+                            onChange={setItemValue}
                             onClick={highlightItem}
                             onDblClick={removeItem}
                         />
@@ -56,7 +56,7 @@ const FormulaField = ({
 FormulaField.propTypes = {
     highlightItem: PropTypes.func.isRequired,
     removeItem: PropTypes.func.isRequired,
-    setExpressionItemValue: PropTypes.func.isRequired,
+    setItemValue: PropTypes.func.isRequired,
     expressionArray: PropTypes.arrayOf(
         PropTypes.shape({
             id: PropTypes.string,

--- a/src/components/DataDimension/FormulaField.js
+++ b/src/components/DataDimension/FormulaField.js
@@ -11,6 +11,7 @@ const FormulaField = ({
     expressionArray,
     selectedPart,
     onPartSelection,
+    removeItem,
     setExpressionItemValue,
 }) => {
     const { over, setNodeRef } = useDroppable({
@@ -42,6 +43,7 @@ const FormulaField = ({
                             isLast={i === expressionArray.length - 1}
                             highlighted={i === selectedPart}
                             onClickItem={() => onPartSelection(i)}
+                            onDblClick={removeItem}
                         />
                     ))}
                 </SortableContext>
@@ -52,6 +54,7 @@ const FormulaField = ({
 }
 
 FormulaField.propTypes = {
+    removeItem: PropTypes.func.isRequired,
     setExpressionItemValue: PropTypes.func.isRequired,
     expressionArray: PropTypes.arrayOf(
         PropTypes.shape({

--- a/src/components/DataDimension/FormulaField.js
+++ b/src/components/DataDimension/FormulaField.js
@@ -9,8 +9,8 @@ import styles from './styles/FormulaField.style.js'
 
 const FormulaField = ({
     items,
-    selectedId,
-    focusId,
+    selectedIndex,
+    focusIndex,
     onChange,
     onClick,
     onDoubleClick,
@@ -32,14 +32,13 @@ const FormulaField = ({
                     />
                     {items.map(({ id, label, type, value }, index) => (
                         <FormulaItem
-                            key={`${label}-${index}`}
+                            key={id}
                             id={id}
-                            index={index}
                             label={label}
                             type={type}
                             value={value}
-                            hasFocus={focusId === id}
-                            isHighlighted={selectedId === id}
+                            hasFocus={focusIndex === index}
+                            isHighlighted={selectedIndex === index}
                             isLast={index === items.length - 1}
                             onChange={onChange}
                             onClick={onClick}
@@ -57,7 +56,7 @@ FormulaField.propTypes = {
     onChange: PropTypes.func.isRequired,
     onClick: PropTypes.func.isRequired,
     onDoubleClick: PropTypes.func.isRequired,
-    focusId: PropTypes.string,
+    focusIndex: PropTypes.number,
     items: PropTypes.arrayOf(
         PropTypes.shape({
             id: PropTypes.string,
@@ -66,7 +65,7 @@ FormulaField.propTypes = {
             value: PropTypes.string,
         })
     ),
-    selectedId: PropTypes.string,
+    selectedIndex: PropTypes.number,
 }
 
 export default FormulaField

--- a/src/components/DataDimension/FormulaField.js
+++ b/src/components/DataDimension/FormulaField.js
@@ -2,10 +2,12 @@ import { useDroppable } from '@dnd-kit/core'
 import { SortableContext } from '@dnd-kit/sortable'
 import PropTypes from 'prop-types'
 import React from 'react'
-import { LAST_DROPZONE_ID, FORMULA_BOX_ID } from './constants.js'
 import DropZone from './DropZone.js'
 import FormulaItem from './FormulaItem.js'
 import styles from './styles/FormulaField.style.js'
+
+export const LAST_DROPZONE_ID = 'lastdropzone'
+export const FORMULA_BOX_ID = 'formulabox'
 
 const FormulaField = ({
     items,
@@ -21,6 +23,8 @@ const FormulaField = ({
 
     const itemIds = items.map((item) => item.id)
 
+    const overLastDropZone = over?.id === LAST_DROPZONE_ID
+
     return (
         <div className="container">
             <div className="border"></div>
@@ -28,7 +32,7 @@ const FormulaField = ({
                 <SortableContext id={FORMULA_BOX_ID} items={itemIds}>
                     <DropZone
                         firstElementId={itemIds[0]}
-                        overLastDropZone={over?.id === LAST_DROPZONE_ID}
+                        overLastDropZone={overLastDropZone}
                     />
                     {items.map(({ id, label, type, value }, index) => (
                         <FormulaItem
@@ -43,6 +47,7 @@ const FormulaField = ({
                             onChange={onChange}
                             onClick={onClick}
                             onDoubleClick={onDoubleClick}
+                            overLastDropZone={overLastDropZone}
                         />
                     ))}
                 </SortableContext>

--- a/src/components/DataDimension/FormulaField.js
+++ b/src/components/DataDimension/FormulaField.js
@@ -8,18 +8,18 @@ import FormulaItem from './FormulaItem.js'
 import styles from './styles/FormulaField.style.js'
 
 const FormulaField = ({
-    expressionArray,
-    selectedPart,
-    highlightItem,
-    removeItem,
-    setItemValue,
+    items,
+    selectedId,
     focusId,
+    onChange,
+    onClick,
+    onDoubleClick,
 }) => {
     const { over, setNodeRef } = useDroppable({
         id: LAST_DROPZONE_ID,
     })
 
-    const itemIds = expressionArray.map((item) => item.id)
+    const itemIds = items.map((item) => item.id)
 
     return (
         <div className="container">
@@ -30,20 +30,20 @@ const FormulaField = ({
                         firstElementId={itemIds[0]}
                         overLastDropZone={over?.id === LAST_DROPZONE_ID}
                     />
-                    {expressionArray.map((item, i) => (
+                    {items.map(({ id, label, type, value }, index) => (
                         <FormulaItem
-                            key={`${item.label}-${i}`}
-                            id={item.id}
-                            index={i}
-                            label={item.label}
-                            type={item.type}
-                            value={item.value}
-                            isLast={i === expressionArray.length - 1}
-                            hasFocus={focusId === item.id}
-                            highlighted={i === selectedPart}
-                            onChange={setItemValue}
-                            onClick={highlightItem}
-                            onDblClick={removeItem}
+                            key={`${label}-${index}`}
+                            id={id}
+                            index={index}
+                            label={label}
+                            type={type}
+                            value={value}
+                            hasFocus={focusId === id}
+                            isHighlighted={selectedId === id}
+                            isLast={index === items.length - 1}
+                            onChange={onChange}
+                            onClick={onClick}
+                            onDoubleClick={onDoubleClick}
                         />
                     ))}
                 </SortableContext>
@@ -54,10 +54,11 @@ const FormulaField = ({
 }
 
 FormulaField.propTypes = {
-    highlightItem: PropTypes.func.isRequired,
-    removeItem: PropTypes.func.isRequired,
-    setItemValue: PropTypes.func.isRequired,
-    expressionArray: PropTypes.arrayOf(
+    onChange: PropTypes.func.isRequired,
+    onClick: PropTypes.func.isRequired,
+    onDoubleClick: PropTypes.func.isRequired,
+    focusId: PropTypes.string,
+    items: PropTypes.arrayOf(
         PropTypes.shape({
             id: PropTypes.string,
             label: PropTypes.string,
@@ -65,8 +66,7 @@ FormulaField.propTypes = {
             value: PropTypes.string,
         })
     ),
-    focusId: PropTypes.string,
-    selectedPart: PropTypes.number,
+    selectedId: PropTypes.number,
 }
 
 export default FormulaField

--- a/src/components/DataDimension/FormulaField.js
+++ b/src/components/DataDimension/FormulaField.js
@@ -22,9 +22,10 @@ const FormulaField = ({
     const itemIds = expressionArray.map((item) => item.id)
 
     return (
-        <div className="formulaField lastDropZone" ref={setNodeRef}>
-            <SortableContext id={FORMULA_BOX_ID} items={itemIds}>
-                <>
+        <div className="container">
+            <div className="border"></div>
+            <div className="formulaField lastDropZone" ref={setNodeRef}>
+                <SortableContext id={FORMULA_BOX_ID} items={itemIds}>
                     <DropZone
                         firstElementId={itemIds[0]}
                         overLastDropZone={overLastDropZone}
@@ -43,8 +44,8 @@ const FormulaField = ({
                             onClickItem={() => onPartSelection(i)}
                         />
                     ))}
-                </>
-            </SortableContext>
+                </SortableContext>
+            </div>
             <style jsx>{styles}</style>
         </div>
     )

--- a/src/components/DataDimension/FormulaField.js
+++ b/src/components/DataDimension/FormulaField.js
@@ -10,15 +10,14 @@ import styles from './styles/FormulaField.style.js'
 const FormulaField = ({
     expressionArray,
     selectedPart,
-    onPartSelection,
+    highlightItem,
     removeItem,
     setExpressionItemValue,
+    focusId,
 }) => {
     const { over, setNodeRef } = useDroppable({
         id: LAST_DROPZONE_ID,
     })
-
-    const overLastDropZone = over?.id === LAST_DROPZONE_ID
 
     const itemIds = expressionArray.map((item) => item.id)
 
@@ -29,7 +28,7 @@ const FormulaField = ({
                 <SortableContext id={FORMULA_BOX_ID} items={itemIds}>
                     <DropZone
                         firstElementId={itemIds[0]}
-                        overLastDropZone={overLastDropZone}
+                        overLastDropZone={over?.id === LAST_DROPZONE_ID}
                     />
                     {expressionArray.map((item, i) => (
                         <FormulaItem
@@ -39,10 +38,11 @@ const FormulaField = ({
                             label={item.label}
                             type={item.type}
                             value={item.value}
-                            onChange={setExpressionItemValue}
                             isLast={i === expressionArray.length - 1}
+                            hasFocus={focusId === item.id}
                             highlighted={i === selectedPart}
-                            onClickItem={() => onPartSelection(i)}
+                            onChange={setExpressionItemValue}
+                            onClick={highlightItem}
                             onDblClick={removeItem}
                         />
                     ))}
@@ -54,6 +54,7 @@ const FormulaField = ({
 }
 
 FormulaField.propTypes = {
+    highlightItem: PropTypes.func.isRequired,
     removeItem: PropTypes.func.isRequired,
     setExpressionItemValue: PropTypes.func.isRequired,
     expressionArray: PropTypes.arrayOf(
@@ -64,8 +65,8 @@ FormulaField.propTypes = {
             value: PropTypes.string,
         })
     ),
+    focusId: PropTypes.string,
     selectedPart: PropTypes.number,
-    onPartSelection: PropTypes.func,
 }
 
 export default FormulaField

--- a/src/components/DataDimension/FormulaField.js
+++ b/src/components/DataDimension/FormulaField.js
@@ -15,7 +15,7 @@ const FormulaField = ({
     onClick,
     onDoubleClick,
 }) => {
-    const { over, setNodeRef } = useDroppable({
+    const { over, setNodeRef: setLastDropzoneRef } = useDroppable({
         id: LAST_DROPZONE_ID,
     })
 
@@ -24,7 +24,7 @@ const FormulaField = ({
     return (
         <div className="container">
             <div className="border"></div>
-            <div className="formulaField lastDropZone" ref={setNodeRef}>
+            <div className="formula-field" ref={setLastDropzoneRef}>
                 <SortableContext id={FORMULA_BOX_ID} items={itemIds}>
                     <DropZone
                         firstElementId={itemIds[0]}
@@ -66,7 +66,7 @@ FormulaField.propTypes = {
             value: PropTypes.string,
         })
     ),
-    selectedId: PropTypes.number,
+    selectedId: PropTypes.string,
 }
 
 export default FormulaField

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -5,7 +5,12 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../modules/dataTypes.js'
 import { getIcon } from '../../modules/dimensionListItem.js'
-import { TYPE_INPUT, TYPE_DATAITEM, LAST_DROPZONE_ID } from './constants.js'
+import {
+    TYPE_INPUT,
+    TYPE_DATAITEM,
+    TYPE_OPERATOR,
+    LAST_DROPZONE_ID,
+} from './constants.js'
 import DragHandleIcon from './DragHandleIcon.js'
 import styles from './styles/FormulaItem.style.js'
 
@@ -142,7 +147,12 @@ const FormulaItem = ({
                         tabIndex={isLast ? 0 : -1}
                         onClick={onClick}
                     >
-                        <div className="content dataitem">
+                        <div
+                            className={cx('content', {
+                                dataitem: type === TYPE_DATAITEM,
+                                operator: type === TYPE_OPERATOR,
+                            })}
+                        >
                             {type === TYPE_DATAITEM && (
                                 <span className="icon">
                                     {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -63,9 +63,9 @@ const FormulaItem = ({
     let insertPosition = undefined
     if (over?.id === id) {
         console.log('index, activeIndex', index, activeIndex)
-        // This formulaItem is being hovered over by a dragged item
+        // This item is being hovered over by a dragged item
         if (activeIndex === -1) {
-            //This item came from the dimensions panel
+            //This item came from the expression options
             insertPosition = AFTER
         } else {
             insertPosition = index > activeIndex ? AFTER : BEFORE
@@ -75,25 +75,6 @@ const FormulaItem = ({
 
     if (isLast && overLastDropZone) {
         insertPosition = AFTER
-    }
-
-    function onClick() {
-        if (type === 'input' && !isEditing) {
-            inputRef.current.style.display = 'inline'
-            inputRef.current.focus()
-            spanRef.current.style.display = 'none'
-            setIsEditing(true)
-        }
-    }
-
-    function onInputBlur() {
-        inputRef.current.style.display = 'none'
-        spanRef.current.style.display = 'inline'
-        setIsEditing(false)
-    }
-
-    function onInputChange(e) {
-        onChange({ index, value: e.target.value })
     }
 
     const getContent = () => {
@@ -120,10 +101,10 @@ const FormulaItem = ({
         }
     }
 
-    const contentClassName = cx(styles.content, {
-        [styles.active]: isDragging,
-        [styles.insertBefore]: insertPosition === BEFORE,
-        [styles.insertAfter]: insertPosition === AFTER,
+    const contentClassName = cx('content', {
+        active: isDragging,
+        insertBefore: insertPosition === BEFORE,
+        insertAfter: insertPosition === AFTER,
     })
 
     return (
@@ -131,7 +112,7 @@ const FormulaItem = ({
             ref={setNodeRef}
             {...attributes}
             {...listeners}
-            className={isLast ? styles.isLast : null}
+            className={cx('container', { isLast, highlighted })}
             style={style}
         >
             <div className="part">
@@ -140,17 +121,38 @@ const FormulaItem = ({
             <style jsx>{styles}</style>
         </div>
     )
+
+    function onClick() {
+        if (type === 'input' && !isEditing) {
+            inputRef.current.style.display = 'inline'
+            inputRef.current.focus()
+            spanRef.current.style.display = 'none'
+            setIsEditing(true)
+        }
+    }
+
+    function onInputBlur() {
+        inputRef.current.style.display = 'none'
+        spanRef.current.style.display = 'inline'
+        setIsEditing(false)
+    }
+
+    function onInputChange(e) {
+        onChange({ index, value: e.target.value })
+    }
 }
 
 export default FormulaItem
 
 FormulaItem.propTypes = {
+    highlighted: PropTypes.bool,
     id: PropTypes.string,
-    label: PropTypes.string,
-    value: PropTypes.string,
-    type: PropTypes.string,
-    onChange: PropTypes.func,
     isLast: PropTypes.bool,
+    label: PropTypes.string,
+    type: PropTypes.string,
+    value: PropTypes.string,
+    onChange: PropTypes.func,
+    onClickItem: PropTypes.func,
 }
 
 //<>

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -3,13 +3,45 @@ import { CSS } from '@dnd-kit/utilities'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useState, useRef } from 'react'
+import { DIMENSION_TYPE_DATA_ELEMENT } from '../../modules/dataTypes.js'
+import { getIcon } from '../../modules/dimensionListItem.js'
 import { LAST_DROPZONE_ID } from './CalculationModal.js'
+import { TYPE_INPUT } from './MathOperatorSelector.js'
 import styles from './styles/FormulaItem.style.js'
 
 const BEFORE = 'BEFORE'
 const AFTER = 'AFTER'
 
-const FormulaItem = ({
+const itemIsDimension = (item) => item.startsWith('#{') && item.endsWith('}')
+
+const FormulaItem = ({ value, children }) => {
+    return (
+        <>
+            <div
+                className={cx('part', {
+                    dimension: itemIsDimension(value),
+                })}
+            >
+                {itemIsDimension(value) && (
+                    <span className="icon">
+                        {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
+                    </span>
+                )}
+                {children}
+            </div>
+            <style jsx>{styles}</style>
+        </>
+    )
+}
+
+FormulaItem.propTypes = {
+    children: PropTypes.node,
+    value: PropTypes.string,
+}
+
+export { FormulaItem }
+
+const DraggableFormulaItem = ({
     id,
     label,
     type,
@@ -17,7 +49,7 @@ const FormulaItem = ({
     onChange,
     isLast,
     highlighted,
-    onClickItem,
+    // onClickItem,
 }) => {
     const [isEditing, setIsEditing] = useState(false)
     const inputRef = useRef(null)
@@ -33,9 +65,15 @@ const FormulaItem = ({
         setNodeRef,
         transform,
         transition,
+        isOver,
     } = useSortable({
         id,
+        data: { id, label, type, value },
     })
+
+    if (isOver) {
+        console.log(active?.id, 'is over', over?.id)
+    }
 
     // console.log("item:", name, "isDragging", isDragging, "over:", over);
     // console.log("active", active);
@@ -62,7 +100,7 @@ const FormulaItem = ({
 
     let insertPosition = undefined
     if (over?.id === id) {
-        console.log('index, activeIndex', index, activeIndex)
+        // console.log('index, activeIndex', index, activeIndex)
         // This item is being hovered over by a dragged item
         if (activeIndex === -1) {
             //This item came from the expression options
@@ -70,15 +108,15 @@ const FormulaItem = ({
         } else {
             insertPosition = index > activeIndex ? AFTER : BEFORE
         }
-        console.log('insertPosition', insertPosition)
     }
 
     if (isLast && overLastDropZone) {
         insertPosition = AFTER
     }
+    // console.log('insertPosition', insertPosition)
 
     const getContent = () => {
-        if (type === 'input') {
+        if (type === TYPE_INPUT) {
             return (
                 <>
                     <input
@@ -107,23 +145,29 @@ const FormulaItem = ({
         insertAfter: insertPosition === AFTER,
     })
 
+    // console.log('contentClassName', contentClassName)
+
     return (
-        <div
-            ref={setNodeRef}
-            {...attributes}
-            {...listeners}
-            className={cx('container', { isLast, highlighted })}
-            style={style}
-        >
-            <div className="part">
-                <div className={contentClassName}>{getContent()}</div>
+        <>
+            <div
+                ref={setNodeRef}
+                {...attributes}
+                {...listeners}
+                className={cx('container', { isLast, highlighted })}
+                style={style}
+            >
+                <div className={contentClassName}>
+                    <FormulaItem label={label} value={value}>
+                        {getContent()}
+                    </FormulaItem>
+                </div>
             </div>
             <style jsx>{styles}</style>
-        </div>
+        </>
     )
 
     function onClick() {
-        if (type === 'input' && !isEditing) {
+        if (type === TYPE_INPUT && !isEditing) {
             inputRef.current.style.display = 'inline'
             inputRef.current.focus()
             spanRef.current.style.display = 'none'
@@ -142,9 +186,7 @@ const FormulaItem = ({
     }
 }
 
-export default FormulaItem
-
-FormulaItem.propTypes = {
+DraggableFormulaItem.propTypes = {
     highlighted: PropTypes.bool,
     id: PropTypes.string,
     isLast: PropTypes.bool,
@@ -155,19 +197,4 @@ FormulaItem.propTypes = {
     onClickItem: PropTypes.func,
 }
 
-//<>
-//             <span
-//                 className={cx('part', {
-//                     dimension: partIsDimension(part.value),
-//                 })}
-//                 key={index}
-//             >
-//                 {partIsDimension(part.value) && (
-//                     <span className="icon">
-//                         {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
-//                     </span>
-//                 )}
-//                 {part.label}
-//             </span>
-//             <style jsx>{styles}</style>
-//         </>
+export default DraggableFormulaItem

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -6,7 +6,7 @@ import React, { useState, useRef } from 'react'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../modules/dataTypes.js'
 import { getIcon } from '../../modules/dimensionListItem.js'
 import { LAST_DROPZONE_ID } from './CalculationModal.js'
-import { TYPE_INPUT } from './MathOperatorSelector.js'
+import { TYPE_INPUT, TYPE_DATAITEM } from './MathOperatorSelector.js'
 import styles from './styles/FormulaItem.style.js'
 
 const BEFORE = 'BEFORE'
@@ -18,7 +18,7 @@ const FormulaItem = ({ value, children }) => {
     return (
         <>
             <div
-                className={cx('part', {
+                className={cx('chip', {
                     dimension: itemIsDimension(value),
                 })}
             >
@@ -65,24 +65,14 @@ const DraggableFormulaItem = ({
         setNodeRef,
         transform,
         transition,
-        isOver,
     } = useSortable({
         id,
         data: { id, label, type, value },
     })
 
-    if (isOver) {
-        console.log(active?.id, 'is over', over?.id)
-    }
-
-    // console.log("item:", name, "isDragging", isDragging, "over:", over);
-    // console.log("active", active);
-    // console.log("forumulaItemIndex", formulaItemIndex, "index", index);
-
     const activeIndex = active?.data.current.sortable.index || -1
 
     const overLastDropZone = over?.id === LAST_DROPZONE_ID
-    // console.log("overLastDropZone", overLastDropZone);
 
     const style = transform
         ? {
@@ -100,7 +90,6 @@ const DraggableFormulaItem = ({
 
     let insertPosition = undefined
     if (over?.id === id) {
-        // console.log('index, activeIndex', index, activeIndex)
         // This item is being hovered over by a dragged item
         if (activeIndex === -1) {
             //This item came from the expression options
@@ -113,7 +102,6 @@ const DraggableFormulaItem = ({
     if (isLast && overLastDropZone) {
         insertPosition = AFTER
     }
-    // console.log('insertPosition', insertPosition)
 
     const getContent = () => {
         if (type === TYPE_INPUT) {
@@ -134,18 +122,19 @@ const DraggableFormulaItem = ({
                     </span>
                 </>
             )
+        } else if (type === TYPE_DATAITEM) {
+            return (
+                <>
+                    <span className="icon">
+                        {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
+                    </span>
+                    <span onClick={onClick}>{value || label}</span>
+                </>
+            )
         } else {
             return <span onClick={onClick}>{value || label}</span>
         }
     }
-
-    const contentClassName = cx('content', {
-        active: isDragging,
-        insertBefore: insertPosition === BEFORE,
-        insertAfter: insertPosition === AFTER,
-    })
-
-    // console.log('contentClassName', contentClassName)
 
     return (
         <>
@@ -153,13 +142,24 @@ const DraggableFormulaItem = ({
                 ref={setNodeRef}
                 {...attributes}
                 {...listeners}
-                className={cx('container', { isLast, highlighted })}
+                className={cx('dnd', { isLast })}
                 style={style}
             >
-                <div className={contentClassName}>
-                    <FormulaItem label={label} value={value}>
+                <div
+                    className={cx('chip', {
+                        inactive: !isDragging,
+                        insertBefore: insertPosition === BEFORE,
+                        insertAfter: insertPosition === AFTER,
+                        highlighted,
+                    })}
+                >
+                    <div
+                        className={cx('content', {
+                            dimension: itemIsDimension(value),
+                        })}
+                    >
                         {getContent()}
-                    </FormulaItem>
+                    </div>
                 </div>
             </div>
             <style jsx>{styles}</style>

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -2,12 +2,11 @@ import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import React, { useState, useEffect, useRef } from 'react'
+import React from 'react'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../modules/dataTypes.js'
 import { getIcon } from '../../modules/dimensionListItem.js'
-import { LAST_DROPZONE_ID } from './CalculationModal.js'
+import { TYPE_INPUT, TYPE_DATAITEM, LAST_DROPZONE_ID } from './constants.js'
 import DragHandleIcon from './DragHandleIcon.js'
-import { TYPE_INPUT, TYPE_DATAITEM } from './MathOperatorSelector.js'
 import styles from './styles/FormulaItem.style.js'
 
 const BEFORE = 'BEFORE'
@@ -157,7 +156,7 @@ const DraggableFormulaItem = ({
                             <span className="icon">
                                 {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
                             </span>
-                            <span className="label">{value || label}</span>
+                            <span className="label">{label || value}</span>
                         </div>
                     </div>
                     <style jsx>{styles}</style>

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -20,7 +20,7 @@ const FormulaItem = ({
     onChange,
     isLast,
     highlighted,
-    // onClickItem,
+    onClickItem,
 }) => {
     const {
         attributes,
@@ -38,8 +38,6 @@ const FormulaItem = ({
         attributes: { tabIndex: isLast ? -1 : 0 },
         data: { id, label, type, value },
     })
-
-    console.log('attributes', attributes)
 
     const activeIndex = active?.data.current.sortable.index || -1
 
@@ -85,6 +83,12 @@ const FormulaItem = ({
         highlighted,
     })
 
+    const onClick = (e) => {
+        if (e.target.tagName !== 'INPUT') {
+            onClickItem()
+        }
+    }
+
     if (type === TYPE_INPUT) {
         return (
             <>
@@ -94,7 +98,11 @@ const FormulaItem = ({
                     {...listeners}
                     className={cx('inputwrapper', { isLast })}
                 >
-                    <div className={chipClasses} tabIndex={isLast ? 0 : -1}>
+                    <div
+                        className={chipClasses}
+                        tabIndex={isLast ? 0 : -1}
+                        onClick={onClick}
+                    >
                         <div className="content">
                             <div className="dndHandle">{DragHandleIcon}</div>
                             <span className="inputWrap">
@@ -119,28 +127,6 @@ const FormulaItem = ({
                 <style jsx>{styles}</style>
             </>
         )
-    } else if (type === TYPE_DATAITEM) {
-        return (
-            <>
-                <div
-                    ref={setNodeRef}
-                    {...attributes}
-                    {...listeners}
-                    className={cx('dnd', { isLast })}
-                    style={style}
-                >
-                    <div className={chipClasses} tabIndex={isLast ? 0 : -1}>
-                        <div className="content dataitem">
-                            <span className="icon">
-                                {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
-                            </span>
-                            <span className="label">{label || value}</span>
-                        </div>
-                    </div>
-                    <style jsx>{styles}</style>
-                </div>
-            </>
-        )
     } else {
         return (
             <>
@@ -151,13 +137,22 @@ const FormulaItem = ({
                     className={cx('dnd', { isLast })}
                     style={style}
                 >
-                    <div className={chipClasses} tabIndex={isLast ? 0 : -1}>
-                        <div className="content operator">
-                            <span className="label">{value || label}</span>
+                    <div
+                        className={chipClasses}
+                        tabIndex={isLast ? 0 : -1}
+                        onClick={onClick}
+                    >
+                        <div className="content dataitem">
+                            {type === TYPE_DATAITEM && (
+                                <span className="icon">
+                                    {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
+                                </span>
+                            )}
+                            <span className="label">{label || value}</span>
                         </div>
                     </div>
+                    <style jsx>{styles}</style>
                 </div>
-                <style jsx>{styles}</style>
             </>
         )
     }

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -117,22 +117,37 @@ const DraggableFormulaItem = ({
                         name={label}
                         value={value}
                     />
-                    <span ref={spanRef} onClick={onClick}>
+                    <span
+                        className="label input"
+                        ref={spanRef}
+                        onClick={onClick}
+                    >
                         {value || label}
                     </span>
+                    <style jsx>{styles}</style>
                 </>
             )
         } else if (type === TYPE_DATAITEM) {
             return (
                 <>
-                    <span className="icon">
+                    <span className="icon dataitem">
                         {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
                     </span>
-                    <span onClick={onClick}>{value || label}</span>
+                    <span className="label dataitem" onClick={onClick}>
+                        {value || label}
+                    </span>
+                    <style jsx>{styles}</style>
                 </>
             )
         } else {
-            return <span onClick={onClick}>{value || label}</span>
+            return (
+                <>
+                    <span className="label operator" onClick={onClick}>
+                        {value || label}
+                    </span>
+                    <style jsx>{styles}</style>
+                </>
+            )
         }
     }
 

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -12,30 +12,7 @@ import styles from './styles/FormulaItem.style.js'
 const BEFORE = 'BEFORE'
 const AFTER = 'AFTER'
 
-const FormulaItem = ({ type, children }) => {
-    return (
-        <>
-            <div className="chip">
-                {type === TYPE_DATAITEM && (
-                    <span className="icon">
-                        {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
-                    </span>
-                )}
-                {children}
-            </div>
-            <style jsx>{styles}</style>
-        </>
-    )
-}
-
-FormulaItem.propTypes = {
-    children: PropTypes.node,
-    type: PropTypes.string,
-}
-
-export { FormulaItem }
-
-const DraggableFormulaItem = ({
+const FormulaItem = ({
     id,
     label,
     type,
@@ -58,8 +35,11 @@ const DraggableFormulaItem = ({
         transition,
     } = useSortable({
         id,
+        attributes: { tabIndex: isLast ? -1 : 0 },
         data: { id, label, type, value },
     })
+
+    console.log('attributes', attributes)
 
     const activeIndex = active?.data.current.sortable.index || -1
 
@@ -108,17 +88,15 @@ const DraggableFormulaItem = ({
     if (type === TYPE_INPUT) {
         return (
             <>
-                <div className={cx('inputwrapper', { isLast })}>
-                    <div className={chipClasses}>
+                <div
+                    ref={setNodeRef}
+                    {...attributes}
+                    {...listeners}
+                    className={cx('inputwrapper', { isLast })}
+                >
+                    <div className={chipClasses} tabIndex={isLast ? 0 : -1}>
                         <div className="content">
-                            <div
-                                ref={setNodeRef}
-                                {...attributes}
-                                {...listeners}
-                                className="dndHandle"
-                            >
-                                {DragHandleIcon}
-                            </div>
+                            <div className="dndHandle">{DragHandleIcon}</div>
                             <span className="inputWrap">
                                 <span
                                     className="widthMachine"
@@ -148,10 +126,10 @@ const DraggableFormulaItem = ({
                     ref={setNodeRef}
                     {...attributes}
                     {...listeners}
-                    className="dnd"
+                    className={cx('dnd', { isLast })}
                     style={style}
                 >
-                    <div className={chipClasses}>
+                    <div className={chipClasses} tabIndex={isLast ? 0 : -1}>
                         <div className="content dataitem">
                             <span className="icon">
                                 {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
@@ -173,7 +151,7 @@ const DraggableFormulaItem = ({
                     className={cx('dnd', { isLast })}
                     style={style}
                 >
-                    <div className={chipClasses}>
+                    <div className={chipClasses} tabIndex={isLast ? 0 : -1}>
                         <div className="content operator">
                             <span className="label">{value || label}</span>
                         </div>
@@ -189,7 +167,7 @@ const DraggableFormulaItem = ({
     }
 }
 
-DraggableFormulaItem.propTypes = {
+FormulaItem.propTypes = {
     highlighted: PropTypes.bool,
     id: PropTypes.string,
     isLast: PropTypes.bool,
@@ -200,4 +178,4 @@ DraggableFormulaItem.propTypes = {
     onClickItem: PropTypes.func,
 }
 
-export default DraggableFormulaItem
+export default FormulaItem

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -2,27 +2,22 @@ import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import React, { useState, useRef } from 'react'
+import React, { useState, useEffect, useRef } from 'react'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../modules/dataTypes.js'
 import { getIcon } from '../../modules/dimensionListItem.js'
 import { LAST_DROPZONE_ID } from './CalculationModal.js'
+import DragHandleIcon from './DragHandleIcon.js'
 import { TYPE_INPUT, TYPE_DATAITEM } from './MathOperatorSelector.js'
 import styles from './styles/FormulaItem.style.js'
 
 const BEFORE = 'BEFORE'
 const AFTER = 'AFTER'
 
-const itemIsDimension = (item) => item.startsWith('#{') && item.endsWith('}')
-
-const FormulaItem = ({ value, children }) => {
+const FormulaItem = ({ type, children }) => {
     return (
         <>
-            <div
-                className={cx('chip', {
-                    dimension: itemIsDimension(value),
-                })}
-            >
-                {itemIsDimension(value) && (
+            <div className="chip">
+                {type === TYPE_DATAITEM && (
                     <span className="icon">
                         {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
                     </span>
@@ -36,7 +31,7 @@ const FormulaItem = ({ value, children }) => {
 
 FormulaItem.propTypes = {
     children: PropTypes.node,
-    value: PropTypes.string,
+    type: PropTypes.string,
 }
 
 export { FormulaItem }
@@ -51,9 +46,6 @@ const DraggableFormulaItem = ({
     highlighted,
     // onClickItem,
 }) => {
-    const [isEditing, setIsEditing] = useState(false)
-    const inputRef = useRef(null)
-    const spanRef = useRef(null)
     const {
         attributes,
         listeners,
@@ -90,11 +82,15 @@ const DraggableFormulaItem = ({
 
     let insertPosition = undefined
     if (over?.id === id) {
-        // This item is being hovered over by a dragged item
+        // This item is being hovered over by the item being dragged
         if (activeIndex === -1) {
-            //This item came from the expression options
+            //The item being dragged came from the expression options
+            // so we will insert after
             insertPosition = AFTER
         } else {
+            // The item being dragged is being moved from the formula
+            // so if the item is before the item being dragged, use the
+            // BEFORE position. Otherwise use the AFTER position
             insertPosition = index > activeIndex ? AFTER : BEFORE
         }
     }
@@ -103,97 +99,90 @@ const DraggableFormulaItem = ({
         insertPosition = AFTER
     }
 
-    const getContent = () => {
-        if (type === TYPE_INPUT) {
-            return (
-                <>
-                    <input
-                        ref={inputRef}
-                        style={{ display: 'none' }}
-                        onBlur={onInputBlur}
-                        onChange={onInputChange}
-                        type="text"
-                        id={id}
-                        name={label}
-                        value={value}
-                    />
-                    <span
-                        className="label input"
-                        ref={spanRef}
-                        onClick={onClick}
-                    >
-                        {value || label}
-                    </span>
-                    <style jsx>{styles}</style>
-                </>
-            )
-        } else if (type === TYPE_DATAITEM) {
-            return (
-                <>
-                    <span className="icon dataitem">
-                        {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
-                    </span>
-                    <span className="label dataitem" onClick={onClick}>
-                        {value || label}
-                    </span>
-                    <style jsx>{styles}</style>
-                </>
-            )
-        } else {
-            return (
-                <>
-                    <span className="label operator" onClick={onClick}>
-                        {value || label}
-                    </span>
-                    <style jsx>{styles}</style>
-                </>
-            )
-        }
-    }
+    const chipClasses = cx('chip', {
+        inactive: !isDragging,
+        insertBefore: insertPosition === BEFORE,
+        insertAfter: insertPosition === AFTER,
+        highlighted,
+    })
 
-    return (
-        <>
-            <div
-                ref={setNodeRef}
-                {...attributes}
-                {...listeners}
-                className={cx('dnd', { isLast })}
-                style={style}
-            >
-                <div
-                    className={cx('chip', {
-                        inactive: !isDragging,
-                        insertBefore: insertPosition === BEFORE,
-                        insertAfter: insertPosition === AFTER,
-                        highlighted,
-                    })}
-                >
-                    <div
-                        className={cx('content', {
-                            dimension: itemIsDimension(value),
-                        })}
-                    >
-                        {getContent()}
+    if (type === TYPE_INPUT) {
+        return (
+            <>
+                <div className={cx('inputwrapper', { isLast })}>
+                    <div className={chipClasses}>
+                        <div className="content">
+                            <div
+                                ref={setNodeRef}
+                                {...attributes}
+                                {...listeners}
+                                className="dndHandle"
+                            >
+                                {DragHandleIcon}
+                            </div>
+                            <span className="inputWrap">
+                                <span
+                                    className="widthMachine"
+                                    aria-hidden="true"
+                                >
+                                    {value}
+                                </span>
+                                <input
+                                    id={id}
+                                    name={label}
+                                    onChange={onInputChange}
+                                    className="input"
+                                    value={value}
+                                    type="number"
+                                />
+                            </span>
+                        </div>
                     </div>
                 </div>
-            </div>
-            <style jsx>{styles}</style>
-        </>
-    )
-
-    function onClick() {
-        if (type === TYPE_INPUT && !isEditing) {
-            inputRef.current.style.display = 'inline'
-            inputRef.current.focus()
-            spanRef.current.style.display = 'none'
-            setIsEditing(true)
-        }
-    }
-
-    function onInputBlur() {
-        inputRef.current.style.display = 'none'
-        spanRef.current.style.display = 'inline'
-        setIsEditing(false)
+                <style jsx>{styles}</style>
+            </>
+        )
+    } else if (type === TYPE_DATAITEM) {
+        return (
+            <>
+                <div
+                    ref={setNodeRef}
+                    {...attributes}
+                    {...listeners}
+                    className="dnd"
+                    style={style}
+                >
+                    <div className={chipClasses}>
+                        <div className="content dataitem">
+                            <span className="icon">
+                                {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
+                            </span>
+                            <span className="label">{value || label}</span>
+                        </div>
+                    </div>
+                    <style jsx>{styles}</style>
+                </div>
+            </>
+        )
+    } else {
+        return (
+            <>
+                <div
+                    ref={setNodeRef}
+                    {...attributes}
+                    {...listeners}
+                    className={cx('dnd', { isLast })}
+                    style={style}
+                >
+                    <div className={chipClasses}>
+                        <div className="content operator">
+                            <span className="label">{value || label}</span>
+                        </div>
+                    </div>
+                </div>
+                <style jsx>{styles}</style>
+            </>
+        )
     }
 
     function onInputChange(e) {

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -1,0 +1,162 @@
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import React, { useState, useRef } from 'react'
+import { LAST_DROPZONE_ID } from './CalculationModal.js'
+import styles from './styles/FormulaItem.style.js'
+
+const BEFORE = 'BEFORE'
+const AFTER = 'AFTER'
+
+const FormulaItem = ({ id, label, type, value = '', onChange, isLast }) => {
+    const [isEditing, setIsEditing] = useState(false)
+    const inputRef = useRef(null)
+    const spanRef = useRef(null)
+    const {
+        attributes,
+        listeners,
+        index,
+        isDragging,
+        isSorting,
+        over,
+        active,
+        setNodeRef,
+        transform,
+        transition,
+    } = useSortable({
+        id,
+    })
+
+    // console.log("item:", name, "isDragging", isDragging, "over:", over);
+    // console.log("active", active);
+    // console.log("forumulaItemIndex", formulaItemIndex, "index", index);
+
+    const activeIndex = active?.data.current.sortable.index || -1
+
+    const overLastDropZone = over?.id === LAST_DROPZONE_ID
+    // console.log("overLastDropZone", overLastDropZone);
+
+    const style = transform
+        ? {
+              transform: isSorting
+                  ? undefined
+                  : CSS.Translate.toString({
+                        x: transform.x,
+                        y: transform.y,
+                        scaleX: 1,
+                        scaleY: 1,
+                    }),
+              transition,
+          }
+        : undefined
+
+    let insertPosition = undefined
+    if (over?.id === id) {
+        console.log('index, activeIndex', index, activeIndex)
+        // This formulaItem is being hovered over by a dragged item
+        if (activeIndex === -1) {
+            //This item came from the dimensions panel
+            insertPosition = AFTER
+        } else {
+            insertPosition = index > activeIndex ? AFTER : BEFORE
+        }
+        console.log('insertPosition', insertPosition)
+    }
+
+    if (isLast && overLastDropZone) {
+        insertPosition = AFTER
+    }
+
+    const onClick = () => {
+        if (type === 'input' && !isEditing) {
+            inputRef.current.style.display = 'inline'
+            inputRef.current.focus()
+            spanRef.current.style.display = 'none'
+            setIsEditing(true)
+        }
+    }
+
+    const onInputBlur = () => {
+        inputRef.current.style.display = 'none'
+        spanRef.current.style.display = 'inline'
+        setIsEditing(false)
+    }
+
+    const onInputChange = (e) => {
+        onChange({ index, value: e.target.value })
+    }
+
+    const getContent = () => {
+        if (type === 'input') {
+            return (
+                <>
+                    <input
+                        ref={inputRef}
+                        style={{ display: 'none' }}
+                        onBlur={onInputBlur}
+                        onChange={onInputChange}
+                        type="text"
+                        id={id}
+                        name={label}
+                        value={value}
+                    />
+                    <span ref={spanRef} onClick={onClick}>
+                        {value || label}
+                    </span>
+                </>
+            )
+        } else {
+            return <span onClick={onClick}>{value || label}</span>
+        }
+    }
+
+    const contentClassName = cx(styles.content, {
+        [styles.active]: isDragging,
+        [styles.insertBefore]: insertPosition === BEFORE,
+        [styles.insertAfter]: insertPosition === AFTER,
+    })
+
+    return (
+        <div
+            ref={setNodeRef}
+            {...attributes}
+            {...listeners}
+            className={isLast ? styles.isLast : null}
+            style={style}
+        >
+            <div className="part">
+                <div className={contentClassName}>{getContent()}</div>
+            </div>
+            <style jsx>{styles}</style>
+        </div>
+    )
+}
+
+export default FormulaItem
+
+FormulaItem.propTypes = {
+    id: PropTypes.string,
+    label: PropTypes.string,
+    value: PropTypes.string,
+    type: PropTypes.string,
+    onChange: PropTypes.func,
+    isLast: PropTypes.bool,
+}
+
+//<>
+//             <span
+//                 className={cx('part', {
+//                     dimension: partIsDimension(part.value),
+//                 })}
+//                 key={index}
+//             >
+//                 {partIsDimension(part.value) && (
+//                     <span className="icon">
+//                         {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
+//                     </span>
+//                 )}
+//                 {part.label}
+//             </span>
+//             <style jsx>{styles}</style>
+//         </>

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -43,7 +43,7 @@ const FormulaItem = ({
     } = useSortable({
         id,
         attributes: { tabIndex: isLast ? -1 : 0 },
-        data: { label, type, value, index },
+        data: { label, type, value },
     })
 
     const inputRef = useRef(null)

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -5,11 +5,7 @@ import PropTypes from 'prop-types'
 import React, { useState, useRef, useEffect } from 'react'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../modules/dataTypes.js'
 import { getIcon } from '../../modules/dimensionListItem.js'
-import {
-    TYPE_NUMBER,
-    TYPE_DATA_ELEMENT,
-    LAST_DROPZONE_ID,
-} from './constants.js'
+import { TYPE_NUMBER, TYPE_DATA_ELEMENT } from '../../modules/expressions.js'
 import DragHandleIcon from './DragHandleIcon.js'
 import styles from './styles/FormulaItem.style.js'
 
@@ -21,10 +17,11 @@ const maxMsBetweenClicks = 300
 const FormulaItem = ({
     id,
     label,
+    value = '',
     type,
     isLast,
     isHighlighted,
-    value = '',
+    overLastDropZone,
     onChange,
     onClick,
     onDoubleClick,
@@ -90,7 +87,7 @@ const FormulaItem = ({
             // BEFORE position. Otherwise use the AFTER position
             insertPosition = index > activeIndex ? AFTER : BEFORE
         }
-    } else if (isLast && over?.id === LAST_DROPZONE_ID) {
+    } else if (isLast && overLastDropZone) {
         insertPosition = AFTER
     }
 
@@ -197,6 +194,7 @@ FormulaItem.propTypes = {
     hasFocus: PropTypes.bool,
     isHighlighted: PropTypes.bool,
     isLast: PropTypes.bool,
+    overLastDropZone: PropTypes.bool,
     value: PropTypes.string,
 }
 

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -5,7 +5,10 @@ import PropTypes from 'prop-types'
 import React, { useState, useRef, useEffect } from 'react'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../modules/dataTypes.js'
 import { getIcon } from '../../modules/dimensionListItem.js'
-import { TYPE_NUMBER, TYPE_DATA_ELEMENT } from '../../modules/expressions.js'
+import {
+    EXPRESSION_TYPE_NUMBER,
+    EXPRESSION_TYPE_DATA_ELEMENT,
+} from '../../modules/expressions.js'
 import DragHandleIcon from './DragHandleIcon.js'
 import styles from './styles/FormulaItem.style.js'
 
@@ -113,7 +116,7 @@ const FormulaItem = ({
     const handleChange = (e) => onChange({ itemId: id, value: e.target.value })
 
     const getContent = () => {
-        if (type === TYPE_NUMBER) {
+        if (type === EXPRESSION_TYPE_NUMBER) {
             return (
                 <>
                     {DragHandleIcon}
@@ -136,7 +139,7 @@ const FormulaItem = ({
             )
         }
 
-        if (type === TYPE_DATA_ELEMENT) {
+        if (type === EXPRESSION_TYPE_DATA_ELEMENT) {
             return (
                 <>
                     <span className="icon">

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types'
 import React, { useState, useRef, useEffect } from 'react'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../modules/dataTypes.js'
 import { getIcon } from '../../modules/dimensionListItem.js'
-import { TYPE_INPUT, TYPE_DATAITEM, LAST_DROPZONE_ID } from './constants.js'
+import { TYPE_INPUT, TYPE_DATAELEMENT, LAST_DROPZONE_ID } from './constants.js'
 import DragHandleIcon from './DragHandleIcon.js'
 import styles from './styles/FormulaItem.style.js'
 
@@ -116,9 +116,9 @@ const FormulaItem = ({
         if (type === TYPE_INPUT) {
             return (
                 <>
-                    <div className="dndHandle">{DragHandleIcon}</div>
-                    <span className="inputWidth">
-                        <span className="widthMachine" aria-hidden="true">
+                    <div className="dnd-handle">{DragHandleIcon}</div>
+                    <span className="input-width">
+                        <span className="width-machine" aria-hidden="true">
                             {value}
                         </span>
                         <input
@@ -135,13 +135,13 @@ const FormulaItem = ({
             )
         }
 
-        if (type === TYPE_DATAITEM) {
+        if (type === TYPE_DATAELEMENT) {
             return (
                 <>
                     <span className="icon">
                         {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
                     </span>
-                    <span className="dataitemLabel">{label}</span>
+                    <span className="data-element-label">{label}</span>
                     <style jsx>{styles}</style>
                 </>
             )
@@ -149,7 +149,7 @@ const FormulaItem = ({
 
         return (
             <>
-                <span className="operatorLabel">{label}</span>
+                <span className="operator-label">{label}</span>
                 <style jsx>{styles}</style>
             </>
         )
@@ -161,11 +161,11 @@ const FormulaItem = ({
                 ref={setNodeRef}
                 {...attributes}
                 {...listeners}
-                className={isLast && 'isLast'}
+                className={isLast && 'last-item'}
                 style={style}
             >
                 <div
-                    className={cx('formulaItem', {
+                    className={cx('formula-item', {
                         inactive: !isDragging,
                         insertBefore: insertPosition === BEFORE,
                         insertAfter: insertPosition === AFTER,

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -5,7 +5,7 @@ import PropTypes from 'prop-types'
 import React, { useState, useRef, useEffect } from 'react'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../modules/dataTypes.js'
 import { getIcon } from '../../modules/dimensionListItem.js'
-import { TYPE_INPUT, TYPE_DATAELEMENT, LAST_DROPZONE_ID } from './constants.js'
+import { TYPE_NUMBER, TYPE_DATAELEMENT, LAST_DROPZONE_ID } from './constants.js'
 import DragHandleIcon from './DragHandleIcon.js'
 import styles from './styles/FormulaItem.style.js'
 
@@ -31,7 +31,6 @@ const FormulaItem = ({
         listeners,
         index,
         isDragging,
-        isSorting,
         over,
         active,
         setNodeRef,
@@ -40,7 +39,7 @@ const FormulaItem = ({
     } = useSortable({
         id,
         attributes: { tabIndex: isLast ? -1 : 0 },
-        data: { id, label, type, value },
+        data: { label, type, value, index },
     })
 
     const inputRef = useRef(null)
@@ -56,13 +55,13 @@ const FormulaItem = ({
                 inputRef.current.focus()
             }, 50)
         }
-    }, [inputRef, hasFocus, id])
+    }, [inputRef, hasFocus])
 
     const activeIndex = active?.data.current.sortable.index || -1
 
     const style = transform
         ? {
-              transform: isSorting
+              transform: active
                   ? undefined
                   : CSS.Translate.toString({
                         x: transform.x,
@@ -96,7 +95,7 @@ const FormulaItem = ({
         clearTimeout(clickTimeoutId)
         const to = setTimeout(function () {
             if (tagname !== 'INPUT') {
-                onClick(id)
+                onClick(index)
             } else {
                 inputRef.current && inputRef.current.focus()
             }
@@ -107,13 +106,13 @@ const FormulaItem = ({
     const handleDoubleClick = () => {
         clearTimeout(clickTimeoutId)
         setClickTimeoutId(null)
-        onDoubleClick(id)
+        onDoubleClick(index)
     }
 
     const handleChange = (e) => onChange({ index, value: e.target.value })
 
     const getContent = () => {
-        if (type === TYPE_INPUT) {
+        if (type === TYPE_NUMBER) {
             return (
                 <>
                     {DragHandleIcon}
@@ -122,6 +121,7 @@ const FormulaItem = ({
                             {value}
                         </span>
                         <input
+                            className="input"
                             id={id}
                             name={label}
                             onChange={handleChange}
@@ -138,7 +138,9 @@ const FormulaItem = ({
         if (type === TYPE_DATAELEMENT) {
             return (
                 <>
-                    {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
+                    <span className="icon">
+                        {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
+                    </span>
                     <span className="data-element-label">{label}</span>
                     <style jsx>{styles}</style>
                 </>
@@ -187,6 +189,7 @@ FormulaItem.propTypes = {
     onDoubleClick: PropTypes.func.isRequired,
     hasFocus: PropTypes.bool,
     id: PropTypes.string,
+    index: PropTypes.number,
     isHighlighted: PropTypes.bool,
     isLast: PropTypes.bool,
     label: PropTypes.string,

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -121,7 +121,6 @@ const FormulaItem = ({
                                     id={id}
                                     name={label}
                                     onChange={onInputChange}
-                                    className="input"
                                     value={value}
                                     type="number"
                                 />

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -54,7 +54,7 @@ const FormulaItem = ({
             // even though the input still has the focus. Not sure why.
             setTimeout(() => {
                 inputRef.current.focus()
-            }, 0)
+            }, 50)
         }
     }, [inputRef, hasFocus, id])
 

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -5,7 +5,11 @@ import PropTypes from 'prop-types'
 import React, { useState, useRef, useEffect } from 'react'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../modules/dataTypes.js'
 import { getIcon } from '../../modules/dimensionListItem.js'
-import { TYPE_NUMBER, TYPE_DATAELEMENT, LAST_DROPZONE_ID } from './constants.js'
+import {
+    TYPE_NUMBER,
+    TYPE_DATA_ELEMENT,
+    LAST_DROPZONE_ID,
+} from './constants.js'
 import DragHandleIcon from './DragHandleIcon.js'
 import styles from './styles/FormulaItem.style.js'
 
@@ -18,10 +22,10 @@ const FormulaItem = ({
     id,
     label,
     type,
-    value = '',
-    onChange,
     isLast,
     isHighlighted,
+    value = '',
+    onChange,
     onClick,
     onDoubleClick,
     hasFocus,
@@ -135,7 +139,7 @@ const FormulaItem = ({
             )
         }
 
-        if (type === TYPE_DATAELEMENT) {
+        if (type === TYPE_DATA_ELEMENT) {
             return (
                 <>
                     <span className="icon">
@@ -161,7 +165,7 @@ const FormulaItem = ({
                 ref={setNodeRef}
                 {...attributes}
                 {...listeners}
-                className={isLast && 'last-item'}
+                className={cx({ 'last-item': isLast })}
                 style={style}
             >
                 <div
@@ -184,16 +188,15 @@ const FormulaItem = ({
 }
 
 FormulaItem.propTypes = {
+    id: PropTypes.string.isRequired,
+    label: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
     onClick: PropTypes.func.isRequired,
     onDoubleClick: PropTypes.func.isRequired,
     hasFocus: PropTypes.bool,
-    id: PropTypes.string,
-    index: PropTypes.number,
     isHighlighted: PropTypes.bool,
     isLast: PropTypes.bool,
-    label: PropTypes.string,
-    type: PropTypes.string,
     value: PropTypes.string,
 }
 

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -74,7 +74,7 @@ const FormulaItem = ({
           }
         : undefined
 
-    let insertPosition = undefined
+    let insertPosition
     if (over?.id === id) {
         // This item is being hovered over by the item being dragged
         if (activeIndex === -1) {

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -5,12 +5,7 @@ import PropTypes from 'prop-types'
 import React, { useState, useRef, useEffect } from 'react'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../modules/dataTypes.js'
 import { getIcon } from '../../modules/dimensionListItem.js'
-import {
-    TYPE_INPUT,
-    TYPE_DATAITEM,
-    TYPE_OPERATOR,
-    LAST_DROPZONE_ID,
-} from './constants.js'
+import { TYPE_INPUT, TYPE_DATAITEM, LAST_DROPZONE_ID } from './constants.js'
 import DragHandleIcon from './DragHandleIcon.js'
 import styles from './styles/FormulaItem.style.js'
 
@@ -112,92 +107,80 @@ const FormulaItem = ({
     const handleDoubleClick = () => {
         clearTimeout(clickTimeoutId)
         setClickTimeoutId(null)
-        onDoubleClick({ index })
+        onDoubleClick(id)
     }
 
     const handleChange = (e) => onChange({ index, value: e.target.value })
 
-    const itemClasses = cx('formulaItem', {
-        inactive: !isDragging,
-        insertBefore: insertPosition === BEFORE,
-        insertAfter: insertPosition === AFTER,
-        highlighted: isHighlighted,
-    })
+    const getContent = () => {
+        if (type === TYPE_INPUT) {
+            return (
+                <>
+                    <div className="dndHandle">{DragHandleIcon}</div>
+                    <span className="inputWidth">
+                        <span className="widthMachine" aria-hidden="true">
+                            {value}
+                        </span>
+                        <input
+                            id={id}
+                            name={label}
+                            onChange={handleChange}
+                            value={value}
+                            type="number"
+                            ref={inputRef}
+                        />
+                    </span>
+                    <style jsx>{styles}</style>
+                </>
+            )
+        }
 
-    if (type === TYPE_INPUT) {
+        if (type === TYPE_DATAITEM) {
+            return (
+                <>
+                    <span className="icon">
+                        {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
+                    </span>
+                    <span className="dataitemLabel">{label}</span>
+                    <style jsx>{styles}</style>
+                </>
+            )
+        }
+
         return (
             <>
-                <div
-                    ref={setNodeRef}
-                    {...attributes}
-                    {...listeners}
-                    className={isLast && 'isLast'}
-                >
-                    <div
-                        className={itemClasses}
-                        tabIndex={isLast ? 0 : -1}
-                        onClick={handleClick}
-                        onDoubleClick={handleDoubleClick}
-                    >
-                        <div className="content">
-                            <div className="dndHandle">{DragHandleIcon}</div>
-                            <span className="inputWidth">
-                                <span
-                                    className="widthMachine"
-                                    aria-hidden="true"
-                                >
-                                    {value}
-                                </span>
-                                <input
-                                    id={id}
-                                    name={label}
-                                    onChange={handleChange}
-                                    value={value}
-                                    type="number"
-                                    ref={inputRef}
-                                />
-                            </span>
-                        </div>
-                    </div>
-                </div>
+                <span className="operatorLabel">{label}</span>
                 <style jsx>{styles}</style>
             </>
         )
-    } else {
-        return (
-            <>
-                <div
-                    ref={setNodeRef}
-                    {...attributes}
-                    {...listeners}
-                    className={isLast && 'isLast'}
-                    style={style}
-                >
-                    <div
-                        className={itemClasses}
-                        tabIndex={isLast ? 0 : -1}
-                        onClick={handleClick}
-                        onDoubleClick={handleDoubleClick}
-                    >
-                        <div
-                            className={cx('content', {
-                                dataitem: type === TYPE_DATAITEM,
-                                operator: type === TYPE_OPERATOR,
-                            })}
-                        >
-                            {type === TYPE_DATAITEM && (
-                                <span className="icon">
-                                    {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
-                                </span>
-                            )}
-                            <span className="label">{label || value}</span>
-                        </div>
-                    </div>
-                    <style jsx>{styles}</style>
-                </div>
-            </>
-        )
     }
+
+    return (
+        <>
+            <div
+                ref={setNodeRef}
+                {...attributes}
+                {...listeners}
+                className={isLast && 'isLast'}
+                style={style}
+            >
+                <div
+                    className={cx('formulaItem', {
+                        inactive: !isDragging,
+                        insertBefore: insertPosition === BEFORE,
+                        insertAfter: insertPosition === AFTER,
+                        highlighted: isHighlighted,
+                    })}
+                    tabIndex={isLast ? 0 : -1}
+                    onClick={handleClick}
+                    onDoubleClick={handleDoubleClick}
+                >
+                    <div className="content">{getContent()}</div>
+                </div>
+            </div>
+            <style jsx>{styles}</style>
+        </>
+    )
 }
 
 FormulaItem.propTypes = {

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -101,7 +101,7 @@ const FormulaItem = ({
                     ref={setNodeRef}
                     {...attributes}
                     {...listeners}
-                    className={cx('inputwrapper', { isLast })}
+                    className={isLast && 'isLast'}
                 >
                     <div
                         className={chipClasses}
@@ -110,7 +110,7 @@ const FormulaItem = ({
                     >
                         <div className="content">
                             <div className="dndHandle">{DragHandleIcon}</div>
-                            <span className="inputWrap">
+                            <span className="inputWidth">
                                 <span
                                     className="widthMachine"
                                     aria-hidden="true"
@@ -138,7 +138,7 @@ const FormulaItem = ({
                     ref={setNodeRef}
                     {...attributes}
                     {...listeners}
-                    className={cx('dnd', { isLast })}
+                    className={isLast && 'isLast'}
                     style={style}
                 >
                     <div

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -26,9 +26,9 @@ const FormulaItem = ({
     value = '',
     onChange,
     isLast,
-    highlighted,
+    isHighlighted,
     onClick,
-    onDblClick,
+    onDoubleClick,
     hasFocus,
 }) => {
     const {
@@ -96,12 +96,12 @@ const FormulaItem = ({
         insertPosition = AFTER
     }
 
-    const handleSingleClick = (e) => {
+    const handleClick = (e) => {
         const tagname = e.target.tagName
         clearTimeout(clickTimeoutId)
         const to = setTimeout(function () {
             if (tagname !== 'INPUT') {
-                onClick(index)
+                onClick(id)
             } else {
                 inputRef.current && inputRef.current.focus()
             }
@@ -112,18 +112,16 @@ const FormulaItem = ({
     const handleDoubleClick = () => {
         clearTimeout(clickTimeoutId)
         setClickTimeoutId(null)
-        onDblClick({ index })
+        onDoubleClick({ index })
     }
 
-    const handleChange = (e) => {
-        onChange({ index, value: e.target.value })
-    }
+    const handleChange = (e) => onChange({ index, value: e.target.value })
 
-    const chipClasses = cx('chip', {
+    const itemClasses = cx('formulaItem', {
         inactive: !isDragging,
         insertBefore: insertPosition === BEFORE,
         insertAfter: insertPosition === AFTER,
-        highlighted,
+        highlighted: isHighlighted,
     })
 
     if (type === TYPE_INPUT) {
@@ -136,9 +134,9 @@ const FormulaItem = ({
                     className={isLast && 'isLast'}
                 >
                     <div
-                        className={chipClasses}
+                        className={itemClasses}
                         tabIndex={isLast ? 0 : -1}
-                        onClick={handleSingleClick}
+                        onClick={handleClick}
                         onDoubleClick={handleDoubleClick}
                     >
                         <div className="content">
@@ -154,7 +152,7 @@ const FormulaItem = ({
                                     id={id}
                                     name={label}
                                     onChange={handleChange}
-                                    value={value || ''}
+                                    value={value}
                                     type="number"
                                     ref={inputRef}
                                 />
@@ -176,9 +174,9 @@ const FormulaItem = ({
                     style={style}
                 >
                     <div
-                        className={chipClasses}
+                        className={itemClasses}
                         tabIndex={isLast ? 0 : -1}
-                        onClick={handleSingleClick}
+                        onClick={handleClick}
                         onDoubleClick={handleDoubleClick}
                     >
                         <div
@@ -203,16 +201,16 @@ const FormulaItem = ({
 }
 
 FormulaItem.propTypes = {
+    onChange: PropTypes.func.isRequired,
+    onClick: PropTypes.func.isRequired,
+    onDoubleClick: PropTypes.func.isRequired,
     hasFocus: PropTypes.bool,
-    highlighted: PropTypes.bool,
     id: PropTypes.string,
+    isHighlighted: PropTypes.bool,
     isLast: PropTypes.bool,
     label: PropTypes.string,
     type: PropTypes.string,
     value: PropTypes.string,
-    onChange: PropTypes.func,
-    onClick: PropTypes.func,
-    onDblClick: PropTypes.func,
 }
 
 export default FormulaItem

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -99,7 +99,7 @@ const FormulaItem = ({
         clearTimeout(clickTimeoutId)
         const to = setTimeout(function () {
             if (tagname !== 'INPUT') {
-                onClick(index)
+                onClick(id)
             } else {
                 inputRef.current && inputRef.current.focus()
             }
@@ -110,10 +110,10 @@ const FormulaItem = ({
     const handleDoubleClick = () => {
         clearTimeout(clickTimeoutId)
         setClickTimeoutId(null)
-        onDoubleClick(index)
+        onDoubleClick(id)
     }
 
-    const handleChange = (e) => onChange({ index, value: e.target.value })
+    const handleChange = (e) => onChange({ itemId: id, value: e.target.value })
 
     const getContent = () => {
         if (type === TYPE_NUMBER) {

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -116,8 +116,8 @@ const FormulaItem = ({
         if (type === TYPE_INPUT) {
             return (
                 <>
-                    <div className="dnd-handle">{DragHandleIcon}</div>
-                    <span className="input-width">
+                    {DragHandleIcon}
+                    <span className="input-positioner">
                         <span className="width-machine" aria-hidden="true">
                             {value}
                         </span>
@@ -138,9 +138,7 @@ const FormulaItem = ({
         if (type === TYPE_DATAELEMENT) {
             return (
                 <>
-                    <span className="icon">
-                        {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
-                    </span>
+                    {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
                     <span className="data-element-label">{label}</span>
                     <style jsx>{styles}</style>
                 </>

--- a/src/components/DataDimension/MathOperatorSelector.js
+++ b/src/components/DataDimension/MathOperatorSelector.js
@@ -5,18 +5,9 @@ import i18n from '../../locales/index.js'
 import Operator from './Operator.js'
 import styles from './styles/MathOperatorSelector.style.js'
 
-const TYPE_INPUT = 'input'
-const TYPE_OPERATOR = 'operator'
-
-// const itemTypes = [
-//     { id: 'plus', class: 'plus', name: '+', type: TYPE_OPERATOR },
-//     { id: 'minus', class: 'minus', name: '-', type: TYPE_OPERATOR },
-//     { id: 'div', class: 'div', name: '/', type: TYPE_OPERATOR },
-//     { id: 'mult', class: 'mult', name: '*', type: TYPE_OPERATOR },
-//     { id: 'openpar', class: 'openpar', name: '(', type: TYPE_OPERATOR },
-//     { id: 'closepar', class: 'closepar', name: ')', type: TYPE_OPERATOR },
-//     { id: 'num', class: 'num', name: '<number>', type: TYPE_INPUT },
-// ]
+export const TYPE_INPUT = 'input'
+export const TYPE_OPERATOR = 'operator'
+export const TYPE_DATAITEM = 'dataitem'
 
 export const getOperators = () => {
     return [

--- a/src/components/DataDimension/MathOperatorSelector.js
+++ b/src/components/DataDimension/MathOperatorSelector.js
@@ -2,7 +2,7 @@ import { useSortable } from '@dnd-kit/sortable'
 import PropTypes from 'prop-types'
 import React from 'react'
 import i18n from '../../locales/index.js'
-import Operator from './Operator.js'
+import DraggableOperator from './Operator.js'
 import styles from './styles/MathOperatorSelector.style.js'
 
 export const TYPE_INPUT = 'input'
@@ -34,23 +34,19 @@ const MathOperatorSelector = ({ onSelect }) => {
         opacity: isOver ? 1 : 0.5,
     }
 
-    const internalOnSelect = (val) => {
-        console.log('selected', val)
-        // onSelect()
-    }
-
     return (
         <>
             <div className="wrapper">
                 <h4 className="sub-header">{i18n.t('Math operators')}</h4>
                 <div className="operators" ref={setNodeRef} style={style}>
-                    {getOperators().map(({ id, value, label }) => (
-                        <Operator
+                    {getOperators().map(({ id, value, type, label }) => (
+                        <DraggableOperator
                             key={id}
                             id={id}
                             label={label}
+                            type={type}
                             value={value}
-                            onDblClick={internalOnSelect}
+                            onClick={onSelect}
                         />
                     ))}
                 </div>

--- a/src/components/DataDimension/MathOperatorSelector.js
+++ b/src/components/DataDimension/MathOperatorSelector.js
@@ -2,12 +2,9 @@ import { useSortable } from '@dnd-kit/sortable'
 import PropTypes from 'prop-types'
 import React from 'react'
 import i18n from '../../locales/index.js'
+import { TYPE_OPERATOR, TYPE_INPUT } from './constants.js'
 import DraggableOperator from './Operator.js'
 import styles from './styles/MathOperatorSelector.style.js'
-
-export const TYPE_INPUT = 'input'
-export const TYPE_OPERATOR = 'operator'
-export const TYPE_DATAITEM = 'dataitem'
 
 export const getOperators = () => {
     return [
@@ -27,18 +24,15 @@ export const getOperators = () => {
 }
 
 const MathOperatorSelector = ({ onSelect }) => {
-    const { isOver, setNodeRef } = useSortable({
+    const { setNodeRef } = useSortable({
         id: 'operators',
     })
-    const style = {
-        opacity: isOver ? 1 : 0.5,
-    }
 
     return (
         <>
             <div className="wrapper">
                 <h4 className="sub-header">{i18n.t('Math operators')}</h4>
-                <div className="operators" ref={setNodeRef} style={style}>
+                <div className="operators" ref={setNodeRef}>
                     {getOperators().map(({ id, value, type, label }) => (
                         <DraggableOperator
                             key={id}

--- a/src/components/DataDimension/MathOperatorSelector.js
+++ b/src/components/DataDimension/MathOperatorSelector.js
@@ -40,7 +40,7 @@ const MathOperatorSelector = ({ onSelect }) => {
                             label={label}
                             type={type}
                             value={value}
-                            onClick={onSelect}
+                            onDoubleClick={onSelect}
                         />
                     ))}
                 </div>

--- a/src/components/DataDimension/MathOperatorSelector.js
+++ b/src/components/DataDimension/MathOperatorSelector.js
@@ -1,44 +1,67 @@
+import { useSortable } from '@dnd-kit/sortable'
 import PropTypes from 'prop-types'
 import React from 'react'
 import i18n from '../../locales/index.js'
+import Operator from './Operator.js'
 import styles from './styles/MathOperatorSelector.style.js'
 
-const MathOperatorSelector = ({ onSelect }) => {
-    const operators = [
-        { value: '+', label: '+' },
-        { value: '-', label: '-' },
-        { value: '*', label: '×' },
-        { value: '/', label: '/' },
-        { value: '(', label: '(' },
-        { value: ')', label: ')' },
+const TYPE_INPUT = 'input'
+const TYPE_OPERATOR = 'operator'
+
+// const itemTypes = [
+//     { id: 'plus', class: 'plus', name: '+', type: TYPE_OPERATOR },
+//     { id: 'minus', class: 'minus', name: '-', type: TYPE_OPERATOR },
+//     { id: 'div', class: 'div', name: '/', type: TYPE_OPERATOR },
+//     { id: 'mult', class: 'mult', name: '*', type: TYPE_OPERATOR },
+//     { id: 'openpar', class: 'openpar', name: '(', type: TYPE_OPERATOR },
+//     { id: 'closepar', class: 'closepar', name: ')', type: TYPE_OPERATOR },
+//     { id: 'num', class: 'num', name: '<number>', type: TYPE_INPUT },
+// ]
+
+export const getOperators = () => {
+    return [
+        { id: 'plus', value: '+', label: '+', type: TYPE_OPERATOR },
+        { id: 'minus', value: '-', label: '-', type: TYPE_OPERATOR },
+        { id: 'multiply', value: 'x', label: 'x', type: TYPE_OPERATOR },
+        { id: 'divide', value: '/', label: '/', type: TYPE_OPERATOR },
+        { id: 'openpar', value: '(', label: '(', type: TYPE_OPERATOR },
+        { id: 'closepar', value: ')', label: ')', type: TYPE_OPERATOR },
+        {
+            id: 'number',
+            value: '',
+            label: i18n.t('<number>'),
+            type: TYPE_INPUT,
+        },
     ]
+}
+
+const MathOperatorSelector = ({ onSelect }) => {
+    const { isOver, setNodeRef } = useSortable({
+        id: 'operators',
+    })
+    const style = {
+        opacity: isOver ? 1 : 0.5,
+    }
+
+    const internalOnSelect = (val) => {
+        console.log('selected', val)
+        // onSelect()
+    }
 
     return (
         <>
             <div className="wrapper">
                 <h4 className="sub-header">{i18n.t('Math operators')}</h4>
-                <div className="operators">
-                    {operators.map(({ value, label }) => (
-                        <span
-                            key={value}
-                            className="operator"
-                            onDoubleClick={() => {
-                                onSelect({ value })
-                            }}
-                        >
-                            {label}
-                        </span>
+                <div className="operators" ref={setNodeRef} style={style}>
+                    {getOperators().map(({ id, value, label }) => (
+                        <Operator
+                            key={id}
+                            id={id}
+                            label={label}
+                            value={value}
+                            onDblClick={internalOnSelect}
+                        />
                     ))}
-                    <span
-                        className={'operator'}
-                        onDoubleClick={() => {
-                            onSelect({
-                                value: prompt('Please enter a number', 5),
-                            })
-                        }}
-                    >
-                        {i18n.t('<number>')}
-                    </span>
                 </div>
             </div>
             <style jsx>{styles}</style>

--- a/src/components/DataDimension/MathOperatorSelector.js
+++ b/src/components/DataDimension/MathOperatorSelector.js
@@ -2,25 +2,9 @@ import { useSortable } from '@dnd-kit/sortable'
 import PropTypes from 'prop-types'
 import React from 'react'
 import i18n from '../../locales/index.js'
-import { TYPE_OPERATOR, TYPE_NUMBER } from './constants.js'
+import { getOperators } from '../../modules/expressions.js'
 import DraggableOperator from './Operator.js'
 import styles from './styles/MathOperatorSelector.style.js'
-
-export const getOperators = () => {
-    return [
-        { value: '+', label: '+', type: TYPE_OPERATOR },
-        { value: '-', label: '-', type: TYPE_OPERATOR },
-        { value: '*', label: '×', type: TYPE_OPERATOR },
-        { value: '/', label: '/', type: TYPE_OPERATOR },
-        { value: '(', label: '(', type: TYPE_OPERATOR },
-        { value: ')', label: ')', type: TYPE_OPERATOR },
-        {
-            value: '',
-            label: i18n.t('<number>'),
-            type: TYPE_NUMBER,
-        },
-    ]
-}
 
 const MathOperatorSelector = ({ onDoubleClick }) => {
     const { setNodeRef } = useSortable({

--- a/src/components/DataDimension/MathOperatorSelector.js
+++ b/src/components/DataDimension/MathOperatorSelector.js
@@ -10,7 +10,7 @@ export const getOperators = () => {
     return [
         { id: 'plus', value: '+', label: '+', type: TYPE_OPERATOR },
         { id: 'minus', value: '-', label: '-', type: TYPE_OPERATOR },
-        { id: 'multiply', value: 'x', label: 'x', type: TYPE_OPERATOR },
+        { id: 'multiply', value: '×', label: '×', type: TYPE_OPERATOR },
         { id: 'divide', value: '/', label: '/', type: TYPE_OPERATOR },
         { id: 'openpar', value: '(', label: '(', type: TYPE_OPERATOR },
         { id: 'closepar', value: ')', label: ')', type: TYPE_OPERATOR },

--- a/src/components/DataDimension/MathOperatorSelector.js
+++ b/src/components/DataDimension/MathOperatorSelector.js
@@ -16,13 +16,13 @@ const MathOperatorSelector = ({ onDoubleClick }) => {
             <div className="wrapper">
                 <h4 className="sub-header">{i18n.t('Math operators')}</h4>
                 <div className="operators" ref={setNodeRef}>
-                    {getOperators().map(({ type, label, value }, index) => (
+                    {getOperators().map(({ label, value, type }, index) => (
                         <DraggableOperator
                             key={`${label}-${index}`}
-                            index={index}
                             label={label}
                             value={value}
                             type={type}
+                            index={index}
                             onDoubleClick={onDoubleClick}
                         />
                     ))}

--- a/src/components/DataDimension/MathOperatorSelector.js
+++ b/src/components/DataDimension/MathOperatorSelector.js
@@ -10,7 +10,7 @@ export const getOperators = () => {
     return [
         { id: 'plus', value: '+', label: '+', type: TYPE_OPERATOR },
         { id: 'minus', value: '-', label: '-', type: TYPE_OPERATOR },
-        { id: 'multiply', value: '×', label: '×', type: TYPE_OPERATOR },
+        { id: 'multiply', value: '*', label: '×', type: TYPE_OPERATOR },
         { id: 'divide', value: '/', label: '/', type: TYPE_OPERATOR },
         { id: 'openpar', value: '(', label: '(', type: TYPE_OPERATOR },
         { id: 'closepar', value: ')', label: ')', type: TYPE_OPERATOR },

--- a/src/components/DataDimension/MathOperatorSelector.js
+++ b/src/components/DataDimension/MathOperatorSelector.js
@@ -2,28 +2,27 @@ import { useSortable } from '@dnd-kit/sortable'
 import PropTypes from 'prop-types'
 import React from 'react'
 import i18n from '../../locales/index.js'
-import { TYPE_OPERATOR, TYPE_INPUT } from './constants.js'
+import { TYPE_OPERATOR, TYPE_NUMBER } from './constants.js'
 import DraggableOperator from './Operator.js'
 import styles from './styles/MathOperatorSelector.style.js'
 
 export const getOperators = () => {
     return [
-        { id: 'plus', value: '+', label: '+', type: TYPE_OPERATOR },
-        { id: 'minus', value: '-', label: '-', type: TYPE_OPERATOR },
-        { id: 'multiply', value: '*', label: '×', type: TYPE_OPERATOR },
-        { id: 'divide', value: '/', label: '/', type: TYPE_OPERATOR },
-        { id: 'openpar', value: '(', label: '(', type: TYPE_OPERATOR },
-        { id: 'closepar', value: ')', label: ')', type: TYPE_OPERATOR },
+        { value: '+', label: '+', type: TYPE_OPERATOR },
+        { value: '-', label: '-', type: TYPE_OPERATOR },
+        { value: '*', label: '×', type: TYPE_OPERATOR },
+        { value: '/', label: '/', type: TYPE_OPERATOR },
+        { value: '(', label: '(', type: TYPE_OPERATOR },
+        { value: ')', label: ')', type: TYPE_OPERATOR },
         {
-            id: 'number',
             value: '',
             label: i18n.t('<number>'),
-            type: TYPE_INPUT,
+            type: TYPE_NUMBER,
         },
     ]
 }
 
-const MathOperatorSelector = ({ onSelect }) => {
+const MathOperatorSelector = ({ onDoubleClick }) => {
     const { setNodeRef } = useSortable({
         id: 'operators',
     })
@@ -33,14 +32,14 @@ const MathOperatorSelector = ({ onSelect }) => {
             <div className="wrapper">
                 <h4 className="sub-header">{i18n.t('Math operators')}</h4>
                 <div className="operators" ref={setNodeRef}>
-                    {getOperators().map(({ id, value, type, label }) => (
+                    {getOperators().map(({ type, label, value }, index) => (
                         <DraggableOperator
-                            key={id}
-                            id={id}
+                            key={`${label}-${index}`}
+                            index={index}
                             label={label}
-                            type={type}
                             value={value}
-                            onDoubleClick={onSelect}
+                            type={type}
+                            onDoubleClick={onDoubleClick}
                         />
                     ))}
                 </div>
@@ -51,7 +50,7 @@ const MathOperatorSelector = ({ onSelect }) => {
 }
 
 MathOperatorSelector.propTypes = {
-    onSelect: PropTypes.func.isRequired,
+    onDoubleClick: PropTypes.func.isRequired,
 }
 
 export default MathOperatorSelector

--- a/src/components/DataDimension/Operator.js
+++ b/src/components/DataDimension/Operator.js
@@ -4,10 +4,10 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import styles from './styles/Operator.style.js'
 
-const Operator = ({ label, onClick }) => {
+const Operator = ({ label, onDoubleClick }) => {
     return (
         <>
-            <div className="operator" onClick={onClick}>
+            <div className="operator" onDoubleClick={onDoubleClick}>
                 <span>{label}</span>
             </div>
             <style jsx>{styles}</style>
@@ -17,16 +17,16 @@ const Operator = ({ label, onClick }) => {
 
 Operator.propTypes = {
     label: PropTypes.string,
-    onClick: PropTypes.func,
+    onDoubleClick: PropTypes.func,
 }
 
-Operator.defaultProps = {
-    onClick: Function.prototype,
+Operator.defaultValues = {
+    onDoubleClick: Function.prototype,
 }
 
 export { Operator }
 
-const DraggableOperator = ({ id, label, type, onClick }) => {
+const DraggableOperator = ({ id, label, type, onDoubleClick }) => {
     const { attributes, listeners, setNodeRef, transform } = useSortable({
         id,
         data: { id, label, type },
@@ -42,16 +42,20 @@ const DraggableOperator = ({ id, label, type, onClick }) => {
 
     return (
         <div {...attributes} {...listeners} ref={setNodeRef} style={style}>
-            <Operator label={label} onClick={() => onClick({ id, label })} />
+            <Operator
+                label={label}
+                id={id}
+                onDoubleClick={() => onDoubleClick({ id })}
+            />
         </div>
     )
 }
 
 DraggableOperator.propTypes = {
+    onDoubleClick: PropTypes.func.isRequired,
     id: PropTypes.string,
     label: PropTypes.string,
     type: PropTypes.string,
-    onClick: PropTypes.func,
 }
 
 export default DraggableOperator

--- a/src/components/DataDimension/Operator.js
+++ b/src/components/DataDimension/Operator.js
@@ -36,6 +36,10 @@ const DraggableOperator = ({ id, label, type, onClick }) => {
         transform: CSS.Translate.toString(transform),
     }
 
+    if (transform) {
+        console.log('operator transform', transform)
+    }
+
     return (
         <div {...attributes} {...listeners} ref={setNodeRef} style={style}>
             <Operator label={label} onClick={() => onClick({ id, label })} />

--- a/src/components/DataDimension/Operator.js
+++ b/src/components/DataDimension/Operator.js
@@ -1,0 +1,39 @@
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import PropTypes from 'prop-types'
+import React from 'react'
+import styles from './styles/Operator.style.js'
+
+const Operator = ({ id, label, onDblClick }) => {
+    const { attributes, listeners, setNodeRef, transform } = useSortable({
+        id,
+    })
+    const style = {
+        // Outputs `translate3d(x, y, 0)`
+        transform: CSS.Translate.toString(transform),
+    }
+
+    return (
+        <>
+            <div
+                className="operator"
+                {...attributes}
+                {...listeners}
+                ref={setNodeRef}
+                style={style}
+                onDoubleClick={onDblClick}
+            >
+                <span>{label}</span>
+            </div>
+            <style jsx>{styles}</style>
+        </>
+    )
+}
+
+Operator.propTypes = {
+    id: PropTypes.string,
+    label: PropTypes.string,
+    onDblClick: PropTypes.func,
+}
+
+export default Operator

--- a/src/components/DataDimension/Operator.js
+++ b/src/components/DataDimension/Operator.js
@@ -4,25 +4,10 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import styles from './styles/Operator.style.js'
 
-const Operator = ({ id, label, onDblClick }) => {
-    const { attributes, listeners, setNodeRef, transform } = useSortable({
-        id,
-    })
-    const style = {
-        // Outputs `translate3d(x, y, 0)`
-        transform: CSS.Translate.toString(transform),
-    }
-
+const Operator = ({ label, onClick }) => {
     return (
         <>
-            <div
-                className="operator"
-                {...attributes}
-                {...listeners}
-                ref={setNodeRef}
-                style={style}
-                onDoubleClick={onDblClick}
-            >
+            <div className="operator" onClick={onClick}>
                 <span>{label}</span>
             </div>
             <style jsx>{styles}</style>
@@ -31,9 +16,38 @@ const Operator = ({ id, label, onDblClick }) => {
 }
 
 Operator.propTypes = {
-    id: PropTypes.string,
     label: PropTypes.string,
-    onDblClick: PropTypes.func,
+    onClick: PropTypes.func,
 }
 
-export default Operator
+Operator.defaultProps = {
+    onClick: Function.prototype,
+}
+
+export { Operator }
+
+const DraggableOperator = ({ id, label, type, onClick }) => {
+    const { attributes, listeners, setNodeRef, transform } = useSortable({
+        id,
+        data: { id, label, type },
+    })
+    const style = {
+        // Outputs `translate3d(x, y, 0)`
+        transform: CSS.Translate.toString(transform),
+    }
+
+    return (
+        <div {...attributes} {...listeners} ref={setNodeRef} style={style}>
+            <Operator label={label} onClick={() => onClick({ id, label })} />
+        </div>
+    )
+}
+
+DraggableOperator.propTypes = {
+    id: PropTypes.string,
+    label: PropTypes.string,
+    type: PropTypes.string,
+    onClick: PropTypes.func,
+}
+
+export default DraggableOperator

--- a/src/components/DataDimension/Operator.js
+++ b/src/components/DataDimension/Operator.js
@@ -20,7 +20,7 @@ Operator.propTypes = {
     onDoubleClick: PropTypes.func,
 }
 
-Operator.defaultValues = {
+Operator.defaultProps = {
     onDoubleClick: Function.prototype,
 }
 
@@ -32,12 +32,7 @@ const DraggableOperator = ({ id, label, type, onDoubleClick }) => {
         data: { id, label, type },
     })
     const style = {
-        // Outputs `translate3d(x, y, 0)`
         transform: CSS.Translate.toString(transform),
-    }
-
-    if (transform) {
-        console.log('operator transform', transform)
     }
 
     return (

--- a/src/components/DataDimension/Operator.js
+++ b/src/components/DataDimension/Operator.js
@@ -4,10 +4,10 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import styles from './styles/Operator.style.js'
 
-const Operator = ({ label, value, index, type, onDoubleClick }) => {
+const Operator = ({ label, value, type, onDoubleClick }) => {
     const { attributes, listeners, setNodeRef, transform } = useSortable({
-        id: `operator-${index}`,
-        data: { index, value, label, type },
+        id: `operator-${label}`,
+        data: { label, value, type },
     })
     const style = {
         transform: CSS.Translate.toString(transform),
@@ -18,9 +18,7 @@ const Operator = ({ label, value, index, type, onDoubleClick }) => {
             <div
                 className="operator"
                 data-test="operator"
-                onDoubleClick={() =>
-                    onDoubleClick({ index, value, label, type })
-                }
+                onDoubleClick={() => onDoubleClick({ label, value, type })}
             >
                 <span>{label}</span>
             </div>
@@ -30,7 +28,6 @@ const Operator = ({ label, value, index, type, onDoubleClick }) => {
 }
 
 Operator.propTypes = {
-    index: PropTypes.number.isRequired,
     label: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
     value: PropTypes.string.isRequired,

--- a/src/components/DataDimension/Operator.js
+++ b/src/components/DataDimension/Operator.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import styles from './styles/Operator.style.js'
 
-const DraggableOperator = ({ label, value, index, type, onDoubleClick }) => {
+const Operator = ({ label, value, index, type, onDoubleClick }) => {
     const { attributes, listeners, setNodeRef, transform } = useSortable({
         id: `operator-${index}`,
         data: { index, value, label, type },
@@ -28,12 +28,12 @@ const DraggableOperator = ({ label, value, index, type, onDoubleClick }) => {
     )
 }
 
-DraggableOperator.propTypes = {
+Operator.propTypes = {
     index: PropTypes.number.isRequired,
+    label: PropTypes.string.isRequired,
+    type: PropTypes.string.isRequired,
+    value: PropTypes.string.isRequired,
     onDoubleClick: PropTypes.func.isRequired,
-    label: PropTypes.string,
-    type: PropTypes.string,
-    value: PropTypes.string,
 }
 
-export default DraggableOperator
+export default Operator

--- a/src/components/DataDimension/Operator.js
+++ b/src/components/DataDimension/Operator.js
@@ -4,10 +4,10 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import styles from './styles/Operator.style.js'
 
-const DraggableOperator = ({ id, label, type, onDoubleClick }) => {
+const DraggableOperator = ({ label, value, index, type, onDoubleClick }) => {
     const { attributes, listeners, setNodeRef, transform } = useSortable({
-        id,
-        data: { id, label, type },
+        id: `operator-${index}`,
+        data: { index, value, label, type },
     })
     const style = {
         transform: CSS.Translate.toString(transform),
@@ -17,7 +17,9 @@ const DraggableOperator = ({ id, label, type, onDoubleClick }) => {
         <div {...attributes} {...listeners} ref={setNodeRef} style={style}>
             <div
                 className="operator"
-                onDoubleClick={() => onDoubleClick({ id })}
+                onDoubleClick={() =>
+                    onDoubleClick({ index, value, label, type })
+                }
             >
                 <span>{label}</span>
             </div>
@@ -27,10 +29,11 @@ const DraggableOperator = ({ id, label, type, onDoubleClick }) => {
 }
 
 DraggableOperator.propTypes = {
+    index: PropTypes.number.isRequired,
     onDoubleClick: PropTypes.func.isRequired,
-    id: PropTypes.string,
     label: PropTypes.string,
     type: PropTypes.string,
+    value: PropTypes.string,
 }
 
 export default DraggableOperator

--- a/src/components/DataDimension/Operator.js
+++ b/src/components/DataDimension/Operator.js
@@ -4,28 +4,6 @@ import PropTypes from 'prop-types'
 import React from 'react'
 import styles from './styles/Operator.style.js'
 
-const Operator = ({ label, onDoubleClick }) => {
-    return (
-        <>
-            <div className="operator" onDoubleClick={onDoubleClick}>
-                <span>{label}</span>
-            </div>
-            <style jsx>{styles}</style>
-        </>
-    )
-}
-
-Operator.propTypes = {
-    label: PropTypes.string,
-    onDoubleClick: PropTypes.func,
-}
-
-Operator.defaultProps = {
-    onDoubleClick: Function.prototype,
-}
-
-export { Operator }
-
 const DraggableOperator = ({ id, label, type, onDoubleClick }) => {
     const { attributes, listeners, setNodeRef, transform } = useSortable({
         id,
@@ -37,11 +15,13 @@ const DraggableOperator = ({ id, label, type, onDoubleClick }) => {
 
     return (
         <div {...attributes} {...listeners} ref={setNodeRef} style={style}>
-            <Operator
-                label={label}
-                id={id}
+            <div
+                className="operator"
                 onDoubleClick={() => onDoubleClick({ id })}
-            />
+            >
+                <span>{label}</span>
+            </div>
+            <style jsx>{styles}</style>
         </div>
     )
 }

--- a/src/components/DataDimension/constants.js
+++ b/src/components/DataDimension/constants.js
@@ -1,0 +1,7 @@
+export const TYPE_INPUT = 'input'
+export const TYPE_OPERATOR = 'operator'
+export const TYPE_DATAITEM = 'DATA_ELEMENT'
+
+export const FIRST_DROPZONE_ID = 'firstdropzone'
+export const LAST_DROPZONE_ID = 'lastdropzone'
+export const FORMULA_BOX_ID = 'formulabox'

--- a/src/components/DataDimension/constants.js
+++ b/src/components/DataDimension/constants.js
@@ -1,4 +1,4 @@
-export const TYPE_INPUT = 'input'
+export const TYPE_NUMBER = 'input'
 export const TYPE_OPERATOR = 'operator'
 export const TYPE_DATAELEMENT = 'DATA_ELEMENT'
 

--- a/src/components/DataDimension/constants.js
+++ b/src/components/DataDimension/constants.js
@@ -1,6 +1,6 @@
 export const TYPE_INPUT = 'input'
 export const TYPE_OPERATOR = 'operator'
-export const TYPE_DATAITEM = 'DATA_ELEMENT'
+export const TYPE_DATAELEMENT = 'DATA_ELEMENT'
 
 export const FIRST_DROPZONE_ID = 'firstdropzone'
 export const LAST_DROPZONE_ID = 'lastdropzone'

--- a/src/components/DataDimension/constants.js
+++ b/src/components/DataDimension/constants.js
@@ -1,7 +1,0 @@
-export const TYPE_NUMBER = 'input'
-export const TYPE_OPERATOR = 'operator'
-export const TYPE_DATA_ELEMENT = 'DATA_ELEMENT'
-
-export const FIRST_DROPZONE_ID = 'firstdropzone'
-export const LAST_DROPZONE_ID = 'lastdropzone'
-export const FORMULA_BOX_ID = 'formulabox'

--- a/src/components/DataDimension/constants.js
+++ b/src/components/DataDimension/constants.js
@@ -1,6 +1,6 @@
 export const TYPE_NUMBER = 'input'
 export const TYPE_OPERATOR = 'operator'
-export const TYPE_DATAELEMENT = 'DATA_ELEMENT'
+export const TYPE_DATA_ELEMENT = 'DATA_ELEMENT'
 
 export const FIRST_DROPZONE_ID = 'firstdropzone'
 export const LAST_DROPZONE_ID = 'lastdropzone'

--- a/src/components/DataDimension/styles/CalculationModal.style.js
+++ b/src/components/DataDimension/styles/CalculationModal.style.js
@@ -54,4 +54,9 @@ export default css`
         margin-bottom: ${spacers.dp8};
         max-width: 75%;
     }
+
+    .dragOverlay {
+        background-color: #a0adba;
+        padding: 4px;
+    }
 `

--- a/src/components/DataDimension/styles/CalculationModal.style.js
+++ b/src/components/DataDimension/styles/CalculationModal.style.js
@@ -61,7 +61,6 @@ export default css`
     }
 
     .dragOverlay {
-        background-color: #a0adba;
         padding: 4px;
     }
 `

--- a/src/components/DataDimension/styles/CalculationModal.style.js
+++ b/src/components/DataDimension/styles/CalculationModal.style.js
@@ -30,6 +30,7 @@ export default css`
 
     .content {
         display: flex;
+        justify-content: space-between;
     }
 
     .left-section {
@@ -37,10 +38,13 @@ export default css`
     }
 
     .right-section {
-        width: 55%;
-        padding-left: ${spacers.dp8};
+        width: 53%;
         font-size: 14px;
         line-height: 24px;
+    }
+
+    .leftpad {
+        padding-left: ${spacers.dp4};
     }
 
     .validation-message {

--- a/src/components/DataDimension/styles/CalculationModal.style.js
+++ b/src/components/DataDimension/styles/CalculationModal.style.js
@@ -30,7 +30,6 @@ export default css`
 
     .content {
         display: flex;
-        justify-content: space-between;
     }
 
     .left-section {
@@ -38,7 +37,8 @@ export default css`
     }
 
     .right-section {
-        width: 53%;
+        width: 55%;
+        padding-left: ${spacers.dp8};
         font-size: 14px;
         line-height: 24px;
     }
@@ -62,9 +62,5 @@ export default css`
     .name-input {
         margin-bottom: ${spacers.dp8};
         max-width: 75%;
-    }
-
-    .dragOverlay {
-        padding: 4px;
     }
 `

--- a/src/components/DataDimension/styles/CalculationModal.style.js
+++ b/src/components/DataDimension/styles/CalculationModal.style.js
@@ -43,7 +43,7 @@ export default css`
         line-height: 24px;
     }
 
-    .leftpad {
+    .formula-actions {
         padding-left: ${spacers.dp4};
     }
 

--- a/src/components/DataDimension/styles/CalculationModal.style.js
+++ b/src/components/DataDimension/styles/CalculationModal.style.js
@@ -17,6 +17,7 @@ export default css`
     .actions-wrapper {
         margin-top: ${spacers.dp16};
         margin-bottom: ${spacers.dp16};
+        margin-left: ${spacers.dp4};
     }
 
     .remove-button {
@@ -25,7 +26,7 @@ export default css`
     }
 
     .delete-button {
-        margin-top: ${spacers.dp8};
+        margin-top: ${spacers.dp16};
     }
 
     .content {
@@ -41,10 +42,6 @@ export default css`
         padding-left: ${spacers.dp8};
         font-size: 14px;
         line-height: 24px;
-    }
-
-    .formula-actions {
-        padding-left: ${spacers.dp4};
     }
 
     .validation-message {

--- a/src/components/DataDimension/styles/DraggableTransferOption.style.js
+++ b/src/components/DataDimension/styles/DraggableTransferOption.style.js
@@ -1,0 +1,7 @@
+import css from 'styled-jsx/css'
+
+export default css`
+    .draggabledataitem {
+        cursor: pointer;
+    }
+`

--- a/src/components/DataDimension/styles/DraggableTransferOption.style.js
+++ b/src/components/DataDimension/styles/DraggableTransferOption.style.js
@@ -1,7 +1,7 @@
 import css from 'styled-jsx/css'
 
 export default css`
-    .draggabledataitem {
+    .draggable-item {
         cursor: pointer;
     }
 `

--- a/src/components/DataDimension/styles/DraggingItem.style.js
+++ b/src/components/DataDimension/styles/DraggingItem.style.js
@@ -3,19 +3,23 @@ import css from 'styled-jsx/css'
 
 export default css`
     .draggingItem {
-        display: inline-block;
+        display: inline-flex;
         background: ${colors.grey200};
-        padding: ${spacers.dp4};
         border-radius: 3px;
         font-size: 14px;
         line-height: 16px;
         cursor: default;
         user-select: none;
+        align-items: center;
     }
 
-    .iconAndLabelWrapper {
-        display: inline-flex;
-        align-items: center;
+    .operator,
+    .number {
+        padding: ${spacers.dp4} ${spacers.dp8};
+    }
+
+    .dataelement {
+        padding: ${spacers.dp4};
     }
 
     .icon {
@@ -23,9 +27,5 @@ export default css`
         width: 16px;
         height: 16px;
         margin-right: 4px;
-    }
-
-    .label {
-        flex: 0 1 auto;
     }
 `

--- a/src/components/DataDimension/styles/DraggingItem.style.js
+++ b/src/components/DataDimension/styles/DraggingItem.style.js
@@ -2,14 +2,30 @@ import { colors, spacers } from '@dhis2/ui'
 import css from 'styled-jsx/css'
 
 export default css`
-    .operator {
+    .draggingItem {
         display: inline-block;
         background: ${colors.grey200};
         padding: ${spacers.dp4} ${spacers.dp8};
         border-radius: 3px;
         font-size: 14px;
         line-height: 16px;
-        cursor: pointer;
+        cursor: default;
         user-select: none;
+    }
+
+    .iconAndLabelWrapper {
+        display: flex;
+        align-items: center;
+    }
+
+    .icon {
+        flex: 0 0 auto;
+        width: 16px;
+        height: 16px;
+        margin-right: 6px;
+    }
+
+    .label {
+        flex: 0 1 auto;
     }
 `

--- a/src/components/DataDimension/styles/DraggingItem.style.js
+++ b/src/components/DataDimension/styles/DraggingItem.style.js
@@ -5,7 +5,7 @@ export default css`
     .draggingItem {
         display: inline-block;
         background: ${colors.grey200};
-        padding: ${spacers.dp4} ${spacers.dp8};
+        padding: ${spacers.dp4};
         border-radius: 3px;
         font-size: 14px;
         line-height: 16px;
@@ -14,7 +14,7 @@ export default css`
     }
 
     .iconAndLabelWrapper {
-        display: flex;
+        display: inline-flex;
         align-items: center;
     }
 
@@ -22,7 +22,7 @@ export default css`
         flex: 0 0 auto;
         width: 16px;
         height: 16px;
-        margin-right: 6px;
+        margin-right: 4px;
     }
 
     .label {

--- a/src/components/DataDimension/styles/DraggingItem.style.js
+++ b/src/components/DataDimension/styles/DraggingItem.style.js
@@ -19,7 +19,7 @@ export default css`
         padding: ${spacers.dp4} ${spacers.dp8};
     }
 
-    .dataelement {
+    .data-element {
         padding: ${spacers.dp4};
     }
 

--- a/src/components/DataDimension/styles/DraggingItem.style.js
+++ b/src/components/DataDimension/styles/DraggingItem.style.js
@@ -2,13 +2,13 @@ import { colors, spacers } from '@dhis2/ui'
 import css from 'styled-jsx/css'
 
 export default css`
-    .draggingItem {
+    .dragging-item {
         display: inline-flex;
         background: ${colors.grey200};
         border-radius: 3px;
         font-size: 14px;
         line-height: 16px;
-        cursor: default;
+        cursor: pointer;
         user-select: none;
         align-items: center;
         opacity: 0.7;

--- a/src/components/DataDimension/styles/DraggingItem.style.js
+++ b/src/components/DataDimension/styles/DraggingItem.style.js
@@ -11,6 +11,7 @@ export default css`
         cursor: default;
         user-select: none;
         align-items: center;
+        opacity: 0.7;
     }
 
     .operator,

--- a/src/components/DataDimension/styles/DraggingItem.style.js
+++ b/src/components/DataDimension/styles/DraggingItem.style.js
@@ -27,6 +27,6 @@ export default css`
         flex: 0 0 auto;
         width: 16px;
         height: 16px;
-        margin-right: 4px;
+        margin-right: ${spacers.dp4};
     }
 `

--- a/src/components/DataDimension/styles/DropZone.style.js
+++ b/src/components/DataDimension/styles/DropZone.style.js
@@ -1,0 +1,51 @@
+// import { colors, spacers } from '@dhis2/ui'
+import css from 'styled-jsx/css'
+
+export default css`
+    .dropZone {
+        position: absolute;
+        top: 0;
+        left: 0;
+        z-index: -1;
+        width: 32px;
+        height: 26px;
+        margin: var(--spacers-dp4);
+        background-color: transparent;
+    }
+
+    .isOver {
+        z-index: 100;
+    }
+
+    .isEmpty {
+        position: relative;
+        flex-grow: 1;
+        z-index: 100;
+    }
+
+    .isOver::before,
+    .isOver::after {
+        content: '';
+        position: absolute;
+    }
+
+    /* the vertical line */
+    .isOver::before {
+        top: 8px;
+        width: 4px;
+        left: -6px;
+        height: 18px;
+        background-color: #4c9ffe;
+    }
+
+    /* the circle */
+    .isOver::after {
+        top: -4px;
+        left: -10px;
+        width: 12px;
+        height: 12px;
+        border: 4px solid #4c9ffe;
+        background: transparent;
+        border-radius: 12px;
+    }
+`

--- a/src/components/DataDimension/styles/DropZone.style.js
+++ b/src/components/DataDimension/styles/DropZone.style.js
@@ -5,7 +5,7 @@ export default css`
     .firstDropZone {
         position: absolute;
         top: 0;
-        left: 0;
+        left: 4px;
         z-index: -1;
         width: 32px;
         height: 26px;

--- a/src/components/DataDimension/styles/DropZone.style.js
+++ b/src/components/DataDimension/styles/DropZone.style.js
@@ -2,7 +2,7 @@
 import css from 'styled-jsx/css'
 
 export default css`
-    .dropZone {
+    .firstDropZone {
         position: absolute;
         top: 0;
         left: 0;

--- a/src/components/DataDimension/styles/DropZone.style.js
+++ b/src/components/DataDimension/styles/DropZone.style.js
@@ -2,7 +2,7 @@
 import css from 'styled-jsx/css'
 
 export default css`
-    .firstDropZone {
+    .first-dropzone {
         position: absolute;
         top: 0;
         left: 0;
@@ -13,11 +13,11 @@ export default css`
         background-color: transparent;
     }
 
-    .isOver {
+    .over {
         z-index: 100;
     }
 
-    .isEmpty {
+    .empty {
         position: relative;
         flex-grow: 1;
         z-index: 100;
@@ -25,14 +25,14 @@ export default css`
         margin-top: -4px;
     }
 
-    .isOver::before,
-    .isOver::after {
+    .over::before,
+    .over::after {
         content: '';
         position: absolute;
     }
 
     /* the vertical line */
-    .isOver::before {
+    .over::before {
         top: 10px;
         width: 4px;
         left: 4px;
@@ -41,7 +41,7 @@ export default css`
     }
 
     /* the circle */
-    .isOver::after {
+    .over::after {
         top: 0;
         left: 0;
         width: 12px;

--- a/src/components/DataDimension/styles/DropZone.style.js
+++ b/src/components/DataDimension/styles/DropZone.style.js
@@ -5,10 +5,10 @@ export default css`
     .firstDropZone {
         position: absolute;
         top: 0;
-        left: 4px;
+        left: 0;
         z-index: -1;
-        width: 32px;
-        height: 26px;
+        width: 24px;
+        height: 28px;
         margin: var(--spacers-dp4);
         background-color: transparent;
     }
@@ -21,6 +21,8 @@ export default css`
         position: relative;
         flex-grow: 1;
         z-index: 100;
+        margin-left: -10px;
+        margin-top: -4px;
     }
 
     .isOver::before,
@@ -31,17 +33,17 @@ export default css`
 
     /* the vertical line */
     .isOver::before {
-        top: 8px;
+        top: 10px;
         width: 4px;
-        left: -6px;
+        left: 4px;
         height: 18px;
         background-color: #4c9ffe;
     }
 
     /* the circle */
     .isOver::after {
-        top: -4px;
-        left: -10px;
+        top: 0;
+        left: 0;
         width: 12px;
         height: 12px;
         border: 4px solid #4c9ffe;

--- a/src/components/DataDimension/styles/DropZone.style.js
+++ b/src/components/DataDimension/styles/DropZone.style.js
@@ -11,7 +11,7 @@ export default css`
         background-color: transparent;
     }
 
-    .over {
+    .dragging-over {
         z-index: 100;
     }
 
@@ -23,14 +23,14 @@ export default css`
         margin-top: -4px;
     }
 
-    .over::before,
-    .over::after {
+    .dragging-over::before,
+    .dragging-over::after {
         content: '';
         position: absolute;
     }
 
     /* the vertical line */
-    .over::before {
+    .dragging-over::before {
         top: 10px;
         width: 4px;
         left: 4px;
@@ -39,7 +39,7 @@ export default css`
     }
 
     /* the circle */
-    .over::after {
+    .dragging-over::after {
         top: 0;
         left: 0;
         width: 12px;

--- a/src/components/DataDimension/styles/DropZone.style.js
+++ b/src/components/DataDimension/styles/DropZone.style.js
@@ -1,3 +1,4 @@
+import { colors } from '@dhis2/ui'
 import css from 'styled-jsx/css'
 
 export default css`
@@ -35,7 +36,7 @@ export default css`
         width: 4px;
         left: 4px;
         height: 18px;
-        background-color: #4c9ffe;
+        background-color: ${colors.blue500};
     }
 
     /* the circle */
@@ -44,7 +45,7 @@ export default css`
         left: 0;
         width: 12px;
         height: 12px;
-        border: 4px solid #4c9ffe;
+        border: 4px solid ${colors.blue500};
         background: transparent;
         border-radius: 12px;
     }

--- a/src/components/DataDimension/styles/DropZone.style.js
+++ b/src/components/DataDimension/styles/DropZone.style.js
@@ -1,4 +1,3 @@
-// import { colors, spacers } from '@dhis2/ui'
 import css from 'styled-jsx/css'
 
 export default css`
@@ -9,7 +8,6 @@ export default css`
         z-index: -1;
         width: 24px;
         height: 28px;
-        margin: var(--spacers-dp4);
         background-color: transparent;
     }
 

--- a/src/components/DataDimension/styles/FormulaField.style.js
+++ b/src/components/DataDimension/styles/FormulaField.style.js
@@ -3,6 +3,7 @@ import css from 'styled-jsx/css'
 
 export default css`
     .wrapper {
+        position: relative;
         display: flex;
         align-items: flex-start;
         align-content: flex-start;

--- a/src/components/DataDimension/styles/FormulaField.style.js
+++ b/src/components/DataDimension/styles/FormulaField.style.js
@@ -1,4 +1,4 @@
-import { colors, spacers, elevations, theme } from '@dhis2/ui'
+import { colors, spacers } from '@dhis2/ui'
 import css from 'styled-jsx/css'
 
 export default css`
@@ -11,46 +11,5 @@ export default css`
         height: 120px;
         border: 2px solid ${colors.grey200};
         padding: ${spacers.dp4};
-    }
-
-    .operators {
-        display: flex;
-        flex-wrap: wrap;
-        gap: ${spacers.dp4};
-        padding: ${spacers.dp4};
-        border-top: 1px solid ${colors.grey400};
-    }
-
-    .operator {
-        display: inline-block;
-        background: ${colors.grey200};
-        padding: ${spacers.dp4} ${spacers.dp8};
-        border-radius: 3px;
-        font-size: 14px;
-        line-height: 16px;
-    }
-
-    .part {
-        display: inline-block;
-        height: 21px;
-        background: ${colors.grey200};
-        font-size: 14px;
-        line-height: 16px;
-        padding: 2px ${spacers.dp4};
-        margin: ${spacers.dp4} 0 0 0;
-        border-radius: 3px;
-        user-select: none;
-        box-shadow: ${elevations.e100};
-    }
-
-    .dimension {
-        padding: 2px ${spacers.dp8} 2px ${spacers.dp4};
-    }
-
-    .icon {
-        margin-right: ${spacers.dp4};
-        display: inline-flex;
-        vertical-align: text-bottom;
-        padding-top: 1px;
     }
 `

--- a/src/components/DataDimension/styles/FormulaField.style.js
+++ b/src/components/DataDimension/styles/FormulaField.style.js
@@ -2,14 +2,16 @@ import { colors, spacers } from '@dhis2/ui'
 import css from 'styled-jsx/css'
 
 export default css`
-    .wrapper {
+    .formulaField {
         position: relative;
         display: flex;
         align-items: flex-start;
         align-content: flex-start;
         flex-wrap: wrap;
         gap: ${spacers.dp4} ${spacers.dp8};
-        height: 120px;
+        min-height: 120px;
+        max-height: 200px;
+        overflow: auto;
         border: 2px solid ${colors.grey200};
         padding: ${spacers.dp4};
     }

--- a/src/components/DataDimension/styles/FormulaField.style.js
+++ b/src/components/DataDimension/styles/FormulaField.style.js
@@ -53,13 +53,4 @@ export default css`
         vertical-align: text-bottom;
         padding-top: 1px;
     }
-
-    .highlighted {
-        background: ${theme.secondary800};
-        color: ${colors.white};
-    }
-
-    .highlighted :global(.icon path) {
-        fill: ${colors.white};
-    }
 `

--- a/src/components/DataDimension/styles/FormulaField.style.js
+++ b/src/components/DataDimension/styles/FormulaField.style.js
@@ -3,16 +3,31 @@ import css from 'styled-jsx/css'
 
 export default css`
     .formulaField {
+        border-right: 2px solid ${colors.grey200};
+        height: 200px;
+        overflow: auto;
+        padding: 4px 4px 4px 10px;
         position: relative;
         display: flex;
         align-items: flex-start;
         align-content: flex-start;
         flex-wrap: wrap;
         gap: ${spacers.dp4} ${spacers.dp8};
-        min-height: 120px;
-        max-height: 200px;
-        overflow: auto;
-        border: 2px solid ${colors.grey200};
-        padding: ${spacers.dp4};
+        width: 100%;
+    }
+
+    .container {
+        position: relative;
+    }
+
+    .border {
+        position: absolute;
+        top: 0;
+        left: 4px;
+        height: 200px;
+        width: 99%;
+        border-left: 2px solid ${colors.grey200};
+        border-top: 2px solid ${colors.grey200};
+        border-bottom: 2px solid ${colors.grey200};
     }
 `

--- a/src/components/DataDimension/styles/FormulaField.style.js
+++ b/src/components/DataDimension/styles/FormulaField.style.js
@@ -6,7 +6,7 @@ export default css`
         border-right: 2px solid ${colors.grey200};
         height: 200px;
         overflow: auto;
-        padding: 4px 4px 4px 10px;
+        padding: 4px 10px;
         position: relative;
         display: flex;
         align-items: flex-start;

--- a/src/components/DataDimension/styles/FormulaField.style.js
+++ b/src/components/DataDimension/styles/FormulaField.style.js
@@ -4,9 +4,9 @@ import css from 'styled-jsx/css'
 export default css`
     .formula-field {
         border-right: 2px solid ${colors.grey200};
-        height: 200px;
+        height: 180px;
         overflow: auto;
-        padding: 4px 10px;
+        padding: 6px 12px;
         position: relative;
         display: flex;
         align-items: flex-start;
@@ -23,9 +23,9 @@ export default css`
     .border {
         position: absolute;
         top: 0;
-        left: 4px;
-        height: 200px;
-        width: 99%;
+        left: 6px;
+        height: 180px;
+        width: calc(100% - 6px);
         border-left: 2px solid ${colors.grey200};
         border-top: 2px solid ${colors.grey200};
         border-bottom: 2px solid ${colors.grey200};

--- a/src/components/DataDimension/styles/FormulaField.style.js
+++ b/src/components/DataDimension/styles/FormulaField.style.js
@@ -2,7 +2,7 @@ import { colors, spacers } from '@dhis2/ui'
 import css from 'styled-jsx/css'
 
 export default css`
-    .formulaField {
+    .formula-field {
         border-right: 2px solid ${colors.grey200};
         height: 200px;
         overflow: auto;

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -1,4 +1,4 @@
-import { colors, spacers, elevations } from '@dhis2/ui'
+import { colors, spacers, elevations, theme } from '@dhis2/ui'
 import css from 'styled-jsx/css'
 
 export default css`
@@ -52,5 +52,14 @@ export default css`
         display: inline-flex;
         vertical-align: text-bottom;
         padding-top: 1px;
+    }
+
+    .highlighted {
+        background: ${theme.secondary800};
+        color: ${colors.white};
+    }
+
+    .highlighted :global(.icon path) {
+        fill: ${colors.white};
     }
 `

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -2,7 +2,8 @@ import { colors, spacers, elevations, theme } from '@dhis2/ui'
 import css from 'styled-jsx/css'
 
 export default css`
-    .part {
+    .chip {
+        position: relative;
         display: inline-block;
         height: 21px;
         background: ${colors.grey200};
@@ -35,43 +36,58 @@ export default css`
         fill: ${colors.white};
     }
 
-    .isLast {
-        flex: 1;
+    .content {
+        display: inline-flex;
+        cursor: pointer;
+        min-height: 24px;
+        user-select: none;
+        width: fit-content;
+        align-items: center;
+        padding-right: 2px;
     }
 
-    .isOver {
-        z-index: 100;
-    }
-
-    .isEmpty {
-        position: relative;
-        flex-grow: 1;
-        z-index: 100;
-    }
-
-    .isOver::before,
-    .isOver::after {
+    .inactive.insertBefore .content::before,
+    .inactive.insertAfter .content::before,
+    .inactive.insertBefore .content::after,
+    .inactive.insertAfter .content::after {
         content: '';
         position: absolute;
+        z-index: 100;
     }
 
     /* the vertical line */
-    .isOver::before {
-        top: 8px;
+    .content::before {
+        top: 6px;
+        bottom: 0;
         width: 4px;
-        left: -6px;
-        height: 18px;
         background-color: #4c9ffe;
     }
 
     /* the circle */
-    .isOver::after {
+    .content::after {
         top: -4px;
-        left: -10px;
         width: 12px;
         height: 12px;
         border: 4px solid #4c9ffe;
         background: transparent;
         border-radius: 12px;
+    }
+
+    .isLast {
+        flex: 1;
+    }
+
+    .insertBefore .content::before {
+        left: -6px;
+    }
+    .insertBefore .content::after {
+        left: -10px;
+    }
+
+    .insertAfter .content::before {
+        right: -6px;
+    }
+    .insertAfter .content::after {
+        right: -10px;
     }
 `

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -6,7 +6,7 @@ export default css`
         position: relative;
         display: flex;
         width: fit-content;
-        background: ${colors.grey500};
+        background: ${colors.grey200};
         font-size: 14px;
         line-height: 16px;
         border-radius: 3px;
@@ -21,7 +21,7 @@ export default css`
         user-select: none;
         width: fit-content;
         align-items: center;
-        padding: 4px;
+        padding: 2px;
     }
 
     .icon {
@@ -31,6 +31,48 @@ export default css`
         padding-top: 1px;
     }
 
+    .inputwrapper input {
+        background-color: transparent;
+        border: 1px dashed #a0adba;
+        padding: 0 0 0 2px;
+    }
+
+    .inputwrapper input:hover,
+    .inputwrapper input:focus {
+        background: white;
+        border: 1px solid rgba(0, 0, 0, 0.2);
+    }
+
+    .inputWrap {
+        position: relative;
+    }
+    .inputWrap .input {
+        position: absolute;
+        width: 100%;
+        left: 0;
+    }
+    .widthMachine {
+        /* Add extra space for number spinner */
+        padding: 0 1rem;
+        visibility: hidden;
+    }
+
+    .dndHandle {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        background: none;
+        border: none;
+        padding: 0;
+        vertical-align: middle;
+        width: 20px;
+        height: 20px;
+    }
+
+    .dndHandle:hover {
+        cursor: grab;
+    }
+
     .highlighted {
         background: ${theme.secondary800};
         color: ${colors.white};
@@ -38,6 +80,14 @@ export default css`
 
     .highlighted :global(.icon path) {
         fill: ${colors.white};
+    }
+
+    .operator .label {
+        padding: 0 6px;
+    }
+
+    .content.operator {
+        cursor: grab;
     }
 
     .inactive.insertBefore .content::before,

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -78,7 +78,8 @@ export default css`
         fill: ${colors.white};
     }
 
-    .operator .label {
+    .operator .label,
+    .dataitem .label {
         padding: 0 6px;
     }
 

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -4,20 +4,24 @@ import css from 'styled-jsx/css'
 export default css`
     .chip {
         position: relative;
-        display: inline-block;
-        height: 21px;
-        background: ${colors.grey200};
+        display: flex;
+        width: fit-content;
+        background: ${colors.grey500};
         font-size: 14px;
         line-height: 16px;
-        padding: 2px ${spacers.dp4};
-        margin: ${spacers.dp4} 0 0 0;
         border-radius: 3px;
         user-select: none;
         box-shadow: ${elevations.e100};
     }
 
-    .dimension {
-        padding: 2px ${spacers.dp8} 2px ${spacers.dp4};
+    .content {
+        display: inline-flex;
+        cursor: pointer;
+        min-height: 24px;
+        user-select: none;
+        width: fit-content;
+        align-items: center;
+        padding: 4px;
     }
 
     .icon {
@@ -34,16 +38,6 @@ export default css`
 
     .highlighted :global(.icon path) {
         fill: ${colors.white};
-    }
-
-    .content {
-        display: inline-flex;
-        cursor: pointer;
-        min-height: 24px;
-        user-select: none;
-        width: fit-content;
-        align-items: center;
-        padding-right: 2px;
     }
 
     .inactive.insertBefore .content::before,

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -69,10 +69,6 @@ export default css`
         height: 20px;
     }
 
-    .dndHandle:hover {
-        cursor: grab;
-    }
-
     .highlighted {
         background: ${theme.secondary800};
         color: ${colors.white};
@@ -84,10 +80,6 @@ export default css`
 
     .operator .label {
         padding: 0 6px;
-    }
-
-    .content.operator {
-        cursor: grab;
     }
 
     .inactive.insertBefore .content::before,

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -78,9 +78,16 @@ export default css`
         fill: ${colors.white};
     }
 
-    .operator .label,
-    .dataitem .label {
+    .operator .label {
         padding: 0 6px;
+    }
+
+    .dataitem .label {
+        padding-right: 6px;
+        max-width: 280px;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
     }
 
     .inactive.insertBefore .content::before,

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -1,0 +1,56 @@
+import { colors, spacers, elevations } from '@dhis2/ui'
+import css from 'styled-jsx/css'
+
+export default css`
+    .wrapper {
+        display: flex;
+        align-items: flex-start;
+        align-content: flex-start;
+        flex-wrap: wrap;
+        gap: ${spacers.dp4} ${spacers.dp8};
+        height: 120px;
+        border: 2px solid ${colors.grey200};
+        padding: ${spacers.dp4};
+    }
+
+    .operators {
+        display: flex;
+        flex-wrap: wrap;
+        gap: ${spacers.dp4};
+        padding: ${spacers.dp4};
+        border-top: 1px solid ${colors.grey400};
+    }
+
+    .operator {
+        display: inline-block;
+        background: ${colors.grey200};
+        padding: ${spacers.dp4} ${spacers.dp8};
+        border-radius: 3px;
+        font-size: 14px;
+        line-height: 16px;
+    }
+
+    .part {
+        display: inline-block;
+        height: 21px;
+        background: ${colors.grey200};
+        font-size: 14px;
+        line-height: 16px;
+        padding: 2px ${spacers.dp4};
+        margin: ${spacers.dp4} 0 0 0;
+        border-radius: 3px;
+        user-select: none;
+        box-shadow: ${elevations.e100};
+    }
+
+    .dimension {
+        padding: 2px ${spacers.dp8} 2px ${spacers.dp4};
+    }
+
+    .icon {
+        margin-right: ${spacers.dp4};
+        display: inline-flex;
+        vertical-align: text-bottom;
+        padding-top: 1px;
+    }
+`

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -2,34 +2,6 @@ import { colors, spacers, elevations, theme } from '@dhis2/ui'
 import css from 'styled-jsx/css'
 
 export default css`
-    .wrapper {
-        display: flex;
-        align-items: flex-start;
-        align-content: flex-start;
-        flex-wrap: wrap;
-        gap: ${spacers.dp4} ${spacers.dp8};
-        height: 120px;
-        border: 2px solid ${colors.grey200};
-        padding: ${spacers.dp4};
-    }
-
-    .operators {
-        display: flex;
-        flex-wrap: wrap;
-        gap: ${spacers.dp4};
-        padding: ${spacers.dp4};
-        border-top: 1px solid ${colors.grey400};
-    }
-
-    .operator {
-        display: inline-block;
-        background: ${colors.grey200};
-        padding: ${spacers.dp4} ${spacers.dp8};
-        border-radius: 3px;
-        font-size: 14px;
-        line-height: 16px;
-    }
-
     .part {
         display: inline-block;
         height: 21px;
@@ -61,5 +33,45 @@ export default css`
 
     .highlighted :global(.icon path) {
         fill: ${colors.white};
+    }
+
+    .isLast {
+        flex: 1;
+    }
+
+    .isOver {
+        z-index: 100;
+    }
+
+    .isEmpty {
+        position: relative;
+        flex-grow: 1;
+        z-index: 100;
+    }
+
+    .isOver::before,
+    .isOver::after {
+        content: '';
+        position: absolute;
+    }
+
+    /* the vertical line */
+    .isOver::before {
+        top: 8px;
+        width: 4px;
+        left: -6px;
+        height: 18px;
+        background-color: #4c9ffe;
+    }
+
+    /* the circle */
+    .isOver::after {
+        top: -4px;
+        left: -10px;
+        width: 12px;
+        height: 12px;
+        border: 4px solid #4c9ffe;
+        background: transparent;
+        border-radius: 12px;
     }
 `

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -45,7 +45,7 @@ export default css`
 
     .width-machine {
         /* Add extra space for number spinner */
-        padding: 0 1rem;
+        padding: 0 14px;
         visibility: hidden;
     }
 
@@ -63,11 +63,15 @@ export default css`
 
     .highlighted {
         background: ${theme.secondary800};
+    }
+
+    .highlighted input {
         color: ${colors.white};
     }
 
-    .highlighted input:not(:focus) {
-        color: ${colors.white};
+    .highlighted input:hover,
+    .highlighted input:active {
+        color: ${colors.grey900};
     }
 
     .highlighted :global(.icon path) {

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -46,7 +46,7 @@ export default css`
     .inputWrap {
         position: relative;
     }
-    .inputWrap .input {
+    .inputWrap input {
         position: absolute;
         width: 100%;
         left: 0;

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -8,7 +8,7 @@ export default css`
         width: fit-content;
         background: ${colors.grey200};
         font-size: 14px;
-        line-height: 16px;
+        height: 24px;
         border-radius: 3px;
         user-select: none;
         box-shadow: ${elevations.e100};
@@ -17,15 +17,16 @@ export default css`
     .content {
         display: inline-flex;
         cursor: pointer;
-        min-height: 24px;
         user-select: none;
         width: fit-content;
         align-items: center;
         padding: 2px;
     }
 
-    .input-width {
+    .input-positioner {
         position: relative;
+        line-height: 18px;
+        margin-right: 1px;
     }
 
     input {
@@ -49,17 +50,25 @@ export default css`
         visibility: hidden;
     }
 
-    .dnd-handle {
+    .icon {
+        margin-right: ${spacers.dp4};
         display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        background: none;
-        border: none;
-        padding: 0;
-        vertical-align: middle;
-        width: 20px;
-        height: 20px;
+        vertical-align: text-bottom;
     }
+
+    .operator-label {
+        padding: 0 6px;
+    }
+
+    .data-element-label {
+        padding: 0 4px;
+        max-width: 280px;
+        text-overflow: ellipsis;
+        overflow: hidden;
+        white-space: nowrap;
+    }
+
+    /* highlighted items */
 
     .highlighted {
         background: ${theme.secondary800};
@@ -76,25 +85,6 @@ export default css`
 
     .highlighted :global(.icon path) {
         fill: ${colors.white};
-    }
-
-    .operator-label {
-        padding: 0 6px;
-    }
-
-    .icon {
-        margin-right: ${spacers.dp4};
-        display: inline-flex;
-        vertical-align: text-bottom;
-        padding-top: 1px;
-    }
-
-    .data-element-label {
-        padding-right: 6px;
-        max-width: 280px;
-        text-overflow: ellipsis;
-        overflow: hidden;
-        white-space: nowrap;
     }
 
     /* DND markers */

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -2,7 +2,7 @@ import { colors, spacers, elevations, theme } from '@dhis2/ui'
 import css from 'styled-jsx/css'
 
 export default css`
-    .chip {
+    .formulaItem {
         position: relative;
         display: flex;
         width: fit-content;
@@ -31,14 +31,14 @@ export default css`
         padding-top: 1px;
     }
 
-    .chip input {
+    .formulaItem input {
         background-color: transparent;
         border: 1px dashed #a0adba;
         padding: 0 0 0 2px;
     }
 
-    .chip input:hover,
-    .chip input:focus {
+    .formulaItem input:hover,
+    .formulaItem input:focus {
         background: white;
         border: 1px solid rgba(0, 0, 0, 0.2);
     }

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -53,7 +53,7 @@ export default css`
     }
     .widthMachine {
         /* Add extra space for number spinner */
-        padding: 0 0.8rem;
+        padding: 0 1rem;
         visibility: hidden;
     }
 
@@ -74,7 +74,7 @@ export default css`
         color: ${colors.white};
     }
 
-    .highlighted input {
+    .highlighted input:not(:focus) {
         color: ${colors.white};
     }
 

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -53,7 +53,7 @@ export default css`
     }
     .widthMachine {
         /* Add extra space for number spinner */
-        padding: 0 1rem;
+        padding: 0 0.8rem;
         visibility: hidden;
     }
 

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -24,33 +24,25 @@ export default css`
         padding: 2px;
     }
 
-    .icon {
-        margin-right: ${spacers.dp4};
-        display: inline-flex;
-        vertical-align: text-bottom;
-        padding-top: 1px;
+    .inputWidth {
+        position: relative;
     }
 
-    .formulaItem input {
+    input {
+        position: absolute;
+        width: 100%;
+        left: 0;
         background-color: transparent;
         border: 1px dashed #a0adba;
         padding: 0 0 0 2px;
     }
 
-    .formulaItem input:hover,
-    .formulaItem input:focus {
+    input:hover,
+    input:focus {
         background: white;
         border: 1px solid rgba(0, 0, 0, 0.2);
     }
 
-    .inputWidth {
-        position: relative;
-    }
-    .inputWidth input {
-        position: absolute;
-        width: 100%;
-        left: 0;
-    }
     .widthMachine {
         /* Add extra space for number spinner */
         padding: 0 1rem;
@@ -82,17 +74,26 @@ export default css`
         fill: ${colors.white};
     }
 
-    .operator .label {
+    .operatorLabel {
         padding: 0 6px;
     }
 
-    .dataitem .label {
+    .icon {
+        margin-right: ${spacers.dp4};
+        display: inline-flex;
+        vertical-align: text-bottom;
+        padding-top: 1px;
+    }
+
+    .dataitemLabel {
         padding-right: 6px;
         max-width: 280px;
         text-overflow: ellipsis;
         overflow: hidden;
         white-space: nowrap;
     }
+
+    /* DND markers */
 
     .inactive.insertBefore .content::before,
     .inactive.insertAfter .content::before,

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -29,7 +29,7 @@ export default css`
         margin-right: 1px;
     }
 
-    input {
+    .input {
         position: absolute;
         width: 100%;
         left: 0;
@@ -38,8 +38,8 @@ export default css`
         padding: 0 0 0 2px;
     }
 
-    input:hover,
-    input:focus {
+    .input:hover,
+    .input:focus {
         background: white;
         border: 1px solid rgba(0, 0, 0, 0.2);
     }

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -74,6 +74,10 @@ export default css`
         color: ${colors.white};
     }
 
+    .highlighted input {
+        color: ${colors.white};
+    }
+
     .highlighted :global(.icon path) {
         fill: ${colors.white};
     }

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -45,7 +45,7 @@ export default css`
 
     .width-machine {
         /* Add extra space for number spinner */
-        padding: 0 14px;
+        padding: 0 24px 0 0;
         visibility: hidden;
     }
 

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -1,4 +1,4 @@
-import { colors, spacers, elevations, theme } from '@dhis2/ui'
+import { colors, elevations, theme } from '@dhis2/ui'
 import css from 'styled-jsx/css'
 
 export default css`
@@ -51,9 +51,7 @@ export default css`
     }
 
     .icon {
-        margin-right: ${spacers.dp4};
         display: inline-flex;
-        vertical-align: text-bottom;
     }
 
     .operator-label {
@@ -72,14 +70,16 @@ export default css`
 
     .highlighted {
         background: ${theme.secondary800};
-    }
-
-    .highlighted input {
         color: ${colors.white};
     }
 
-    .highlighted input:hover,
-    .highlighted input:active {
+    .highlighted .input {
+        color: ${colors.white};
+    }
+
+    .highlighted .input:hover,
+    .highlighted .input:active,
+    .highlighted .input:focus {
         color: ${colors.grey900};
     }
 

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -2,7 +2,7 @@ import { colors, spacers, elevations, theme } from '@dhis2/ui'
 import css from 'styled-jsx/css'
 
 export default css`
-    .formulaItem {
+    .formula-item {
         position: relative;
         display: flex;
         width: fit-content;
@@ -24,7 +24,7 @@ export default css`
         padding: 2px;
     }
 
-    .inputWidth {
+    .input-width {
         position: relative;
     }
 
@@ -43,13 +43,13 @@ export default css`
         border: 1px solid rgba(0, 0, 0, 0.2);
     }
 
-    .widthMachine {
+    .width-machine {
         /* Add extra space for number spinner */
         padding: 0 1rem;
         visibility: hidden;
     }
 
-    .dndHandle {
+    .dnd-handle {
         display: inline-flex;
         align-items: center;
         justify-content: center;
@@ -74,7 +74,7 @@ export default css`
         fill: ${colors.white};
     }
 
-    .operatorLabel {
+    .operator-label {
         padding: 0 6px;
     }
 
@@ -85,7 +85,7 @@ export default css`
         padding-top: 1px;
     }
 
-    .dataitemLabel {
+    .data-element-label {
         padding-right: 6px;
         max-width: 280px;
         text-overflow: ellipsis;
@@ -122,7 +122,7 @@ export default css`
         border-radius: 12px;
     }
 
-    .isLast {
+    .last-item {
         flex: 1;
     }
 

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -31,22 +31,22 @@ export default css`
         padding-top: 1px;
     }
 
-    .inputwrapper input {
+    .chip input {
         background-color: transparent;
         border: 1px dashed #a0adba;
         padding: 0 0 0 2px;
     }
 
-    .inputwrapper input:hover,
-    .inputwrapper input:focus {
+    .chip input:hover,
+    .chip input:focus {
         background: white;
         border: 1px solid rgba(0, 0, 0, 0.2);
     }
 
-    .inputWrap {
+    .inputWidth {
         position: relative;
     }
-    .inputWrap input {
+    .inputWidth input {
         position: absolute;
         width: 100%;
         left: 0;

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -103,7 +103,7 @@ export default css`
         top: 6px;
         bottom: 0;
         width: 4px;
-        background-color: #4c9ffe;
+        background-color: ${colors.blue500};
     }
 
     /* the circle */
@@ -111,7 +111,7 @@ export default css`
         top: -4px;
         width: 12px;
         height: 12px;
-        border: 4px solid #4c9ffe;
+        border: 4px solid ${colors.blue500};
         background: transparent;
         border-radius: 12px;
     }

--- a/src/components/DataDimension/styles/MathOperatorSelector.style.js
+++ b/src/components/DataDimension/styles/MathOperatorSelector.style.js
@@ -20,15 +20,4 @@ export default css`
         font-weight: normal;
         margin: ${spacers.dp4} ${spacers.dp8};
     }
-
-    .operator {
-        display: inline-block;
-        background: ${colors.grey200};
-        padding: ${spacers.dp4} ${spacers.dp8};
-        border-radius: 3px;
-        font-size: 14px;
-        line-height: 16px;
-        cursor: default;
-        user-select: none;
-    }
 `

--- a/src/components/DataDimension/styles/Operator.style.js
+++ b/src/components/DataDimension/styles/Operator.style.js
@@ -2,25 +2,6 @@ import { colors, spacers } from '@dhis2/ui'
 import css from 'styled-jsx/css'
 
 export default css`
-    .wrapper {
-        border: 1px solid ${colors.grey400};
-        margin-top: ${spacers.dp8};
-    }
-
-    .operators {
-        display: flex;
-        flex-wrap: wrap;
-        gap: ${spacers.dp4};
-        padding: ${spacers.dp4};
-        border-top: 1px solid ${colors.grey400};
-    }
-
-    .sub-header {
-        font-size: 14px;
-        font-weight: normal;
-        margin: ${spacers.dp4} ${spacers.dp8};
-    }
-
     .operator {
         display: inline-block;
         background: ${colors.grey200};

--- a/src/components/DataDimension/styles/Operator.style.js
+++ b/src/components/DataDimension/styles/Operator.style.js
@@ -3,7 +3,7 @@ import css from 'styled-jsx/css'
 
 export default css`
     .operator {
-        display: inline-block;
+        display: inline-flex;
         background: ${colors.grey200};
         padding: ${spacers.dp4} ${spacers.dp8};
         border-radius: 3px;
@@ -11,5 +11,6 @@ export default css`
         line-height: 16px;
         cursor: pointer;
         user-select: none;
+        align-items: center;
     }
 `

--- a/src/components/DataDimension/styles/Operator.style.js
+++ b/src/components/DataDimension/styles/Operator.style.js
@@ -1,0 +1,34 @@
+import { colors, spacers } from '@dhis2/ui'
+import css from 'styled-jsx/css'
+
+export default css`
+    .wrapper {
+        border: 1px solid ${colors.grey400};
+        margin-top: ${spacers.dp8};
+    }
+
+    .operators {
+        display: flex;
+        flex-wrap: wrap;
+        gap: ${spacers.dp4};
+        padding: ${spacers.dp4};
+        border-top: 1px solid ${colors.grey400};
+    }
+
+    .sub-header {
+        font-size: 14px;
+        font-weight: normal;
+        margin: ${spacers.dp4} ${spacers.dp8};
+    }
+
+    .operator {
+        display: inline-block;
+        background: ${colors.grey200};
+        padding: ${spacers.dp4} ${spacers.dp8};
+        border-radius: 3px;
+        font-size: 14px;
+        line-height: 16px;
+        cursor: default;
+        user-select: none;
+    }
+`

--- a/src/modules/__tests__/expressions.spec.js
+++ b/src/modules/__tests__/expressions.spec.js
@@ -2,9 +2,9 @@ import {
     validateExpression,
     parseArrayToExpression,
     parseExpressionToArray,
-    TYPE_DATA_ELEMENT,
-    TYPE_NUMBER,
-    TYPE_OPERATOR,
+    EXPRESSION_TYPE_DATA_ELEMENT,
+    EXPRESSION_TYPE_NUMBER,
+    EXPRESSION_TYPE_OPERATOR,
     INVALID_EXPRESSION,
 } from '../expressions.js'
 
@@ -59,9 +59,13 @@ describe('validateExpression', () => {
 describe('parseArrayToExpression', () => {
     test('expression 1', () => {
         const expressionArray = [
-            { label: 'abc123', value: '#{abc123}', type: TYPE_DATA_ELEMENT },
-            { label: '/', value: '/', type: TYPE_OPERATOR },
-            { label: '10', value: '10', type: TYPE_NUMBER },
+            {
+                label: 'abc123',
+                value: '#{abc123}',
+                type: EXPRESSION_TYPE_DATA_ELEMENT,
+            },
+            { label: '/', value: '/', type: EXPRESSION_TYPE_OPERATOR },
+            { label: '10', value: '10', type: EXPRESSION_TYPE_NUMBER },
         ]
         const expected = '#{abc123}/10'
 
@@ -73,11 +77,15 @@ describe('parseExpressionToArray', () => {
     test('exp 1', () => {
         const expression = '#{abc123}/10*99'
         const expected = [
-            { label: 'abc123', value: '#{abc123}', type: TYPE_DATA_ELEMENT },
-            { label: '/', value: '/', type: TYPE_OPERATOR },
-            { label: '10', value: '10', type: TYPE_NUMBER },
-            { label: '×', value: '*', type: TYPE_OPERATOR },
-            { label: '99', value: '99', type: TYPE_NUMBER },
+            {
+                label: 'abc123',
+                value: '#{abc123}',
+                type: EXPRESSION_TYPE_DATA_ELEMENT,
+            },
+            { label: '/', value: '/', type: EXPRESSION_TYPE_OPERATOR },
+            { label: '10', value: '10', type: EXPRESSION_TYPE_NUMBER },
+            { label: '×', value: '*', type: EXPRESSION_TYPE_OPERATOR },
+            { label: '99', value: '99', type: EXPRESSION_TYPE_NUMBER },
         ]
 
         expect(parseExpressionToArray(expression)).toEqual(expected)

--- a/src/modules/__tests__/expressions.spec.js
+++ b/src/modules/__tests__/expressions.spec.js
@@ -1,5 +1,5 @@
 import {
-    TYPE_DATAELEMENT,
+    TYPE_DATA_ELEMENT,
     TYPE_NUMBER,
     TYPE_OPERATOR,
 } from '../../components/DataDimension/constants.js'
@@ -61,7 +61,7 @@ describe('validateExpression', () => {
 describe('parseArrayToExpression', () => {
     test('expression 1', () => {
         const expressionArray = [
-            { label: 'abc123', value: '#{abc123}', type: TYPE_DATAELEMENT },
+            { label: 'abc123', value: '#{abc123}', type: TYPE_DATA_ELEMENT },
             { label: '/', value: '/', type: TYPE_OPERATOR },
             { label: '10', value: '10', type: TYPE_NUMBER },
         ]
@@ -75,7 +75,7 @@ describe('parseExpressionToArray', () => {
     test('exp 1', () => {
         const expression = '#{abc123}/10*99'
         const expected = [
-            { label: 'abc123', value: '#{abc123}', type: TYPE_DATAELEMENT },
+            { label: 'abc123', value: '#{abc123}', type: TYPE_DATA_ELEMENT },
             { label: '/', value: '/', type: TYPE_OPERATOR },
             { label: '10', value: '10', type: TYPE_NUMBER },
             { label: '×', value: '*', type: TYPE_OPERATOR },

--- a/src/modules/__tests__/expressions.spec.js
+++ b/src/modules/__tests__/expressions.spec.js
@@ -51,7 +51,7 @@ describe('validateExpression', () => {
 
     validTestExpressions.forEach((exp) => {
         test(`Passes validation: ${exp}`, () => {
-            expect(validateExpression(exp)).toEqual('')
+            expect(validateExpression(exp)).toEqual(undefined)
         })
     })
 })

--- a/src/modules/__tests__/expressions.spec.js
+++ b/src/modules/__tests__/expressions.spec.js
@@ -1,12 +1,10 @@
 import {
-    TYPE_DATA_ELEMENT,
-    TYPE_NUMBER,
-    TYPE_OPERATOR,
-} from '../../components/DataDimension/constants.js'
-import {
     validateExpression,
     parseArrayToExpression,
     parseExpressionToArray,
+    TYPE_DATA_ELEMENT,
+    TYPE_NUMBER,
+    TYPE_OPERATOR,
     INVALID_EXPRESSION,
 } from '../expressions.js'
 

--- a/src/modules/__tests__/expressions.spec.js
+++ b/src/modules/__tests__/expressions.spec.js
@@ -1,4 +1,9 @@
 import {
+    TYPE_DATAELEMENT,
+    TYPE_NUMBER,
+    TYPE_OPERATOR,
+} from '../../components/DataDimension/constants.js'
+import {
     validateExpression,
     parseArrayToExpression,
     parseExpressionToArray,
@@ -56,9 +61,9 @@ describe('validateExpression', () => {
 describe('parseArrayToExpression', () => {
     test('expression 1', () => {
         const expressionArray = [
-            { label: 'abc123', value: '#{abc123}' },
-            { label: '/', value: '/' },
-            { label: '10', value: '10' },
+            { label: 'abc123', value: '#{abc123}', type: TYPE_DATAELEMENT },
+            { label: '/', value: '/', type: TYPE_OPERATOR },
+            { label: '10', value: '10', type: TYPE_NUMBER },
         ]
         const expected = '#{abc123}/10'
 
@@ -68,11 +73,13 @@ describe('parseArrayToExpression', () => {
 
 describe('parseExpressionToArray', () => {
     test('exp 1', () => {
-        const expression = '#{abc123}/10'
+        const expression = '#{abc123}/10*99'
         const expected = [
-            { label: 'abc123', value: '#{abc123}' },
-            { label: '/', value: '/' },
-            { label: '10', value: '10' },
+            { label: 'abc123', value: '#{abc123}', type: TYPE_DATAELEMENT },
+            { label: '/', value: '/', type: TYPE_OPERATOR },
+            { label: '10', value: '10', type: TYPE_NUMBER },
+            { label: '×', value: '*', type: TYPE_OPERATOR },
+            { label: '99', value: '99', type: TYPE_NUMBER },
         ]
 
         expect(parseExpressionToArray(expression)).toEqual(expected)

--- a/src/modules/__tests__/expressions.spec.js
+++ b/src/modules/__tests__/expressions.spec.js
@@ -1,0 +1,49 @@
+import { validateExpression, INVALID_EXPRESSION } from '../expressions.js'
+
+const invalidTestExpressions = [
+    { message: 'Empty formula', expressions: [''] },
+    {
+        message: 'Consecutive math operators',
+        expressions: ['5+-', '5+++', '4+9-*'],
+    },
+    {
+        message: 'Consecutive data elements',
+        expressions: ['#{cYeuwXTCPkU}#{Jtf34kNZhzP}'],
+    },
+    {
+        message: 'Starts or ends with a math operator',
+        expressions: ['*((#{cYeuwXTCPkU}*#{Jtf34kNZhzP})))'],
+    },
+    {
+        message: 'Missing left parenthesis (',
+        expressions: ['((#{cYeuwXTCPkU}*#{Jtf34kNZhzP})))'],
+    },
+    {
+        message: 'Missing right parenthesis )',
+        expressions: ['((#{cYeuwXTCPkU}*#{Jtf34kNZhzP})'],
+    },
+]
+
+const validTestExpressions = [
+    '5+9',
+    '((#{cYeuwXTCPkU}*#{Jtf34kNZhzP}))#{iKGjnOOaPlE}',
+]
+
+describe('validateExpression', () => {
+    invalidTestExpressions.forEach(({ expressions, message }) => {
+        expressions.forEach((exp) => {
+            test(`Fails: ${message}`, () => {
+                expect(validateExpression(exp)).toEqual({
+                    status: INVALID_EXPRESSION,
+                    message,
+                })
+            })
+        })
+    })
+
+    validTestExpressions.forEach((exp) => {
+        test(`Passes validation: ${exp}`, () => {
+            expect(validateExpression(exp)).toEqual('')
+        })
+    })
+})

--- a/src/modules/__tests__/expressions.spec.js
+++ b/src/modules/__tests__/expressions.spec.js
@@ -1,4 +1,9 @@
-import { validateExpression, INVALID_EXPRESSION } from '../expressions.js'
+import {
+    validateExpression,
+    parseArrayToExpression,
+    parseExpressionToArray,
+    INVALID_EXPRESSION,
+} from '../expressions.js'
 
 const invalidTestExpressions = [
     { message: 'Empty formula', expressions: [''] },
@@ -45,5 +50,31 @@ describe('validateExpression', () => {
         test(`Passes validation: ${exp}`, () => {
             expect(validateExpression(exp)).toEqual('')
         })
+    })
+})
+
+describe('parseArrayToExpression', () => {
+    test('expression 1', () => {
+        const expressionArray = [
+            { label: 'abc123', value: '#{abc123}' },
+            { label: '/', value: '/' },
+            { label: '10', value: '10' },
+        ]
+        const expected = '#{abc123}/10'
+
+        expect(parseArrayToExpression(expressionArray)).toEqual(expected)
+    })
+})
+
+describe('parseExpressionToArray', () => {
+    test('exp 1', () => {
+        const expression = '#{abc123}/10'
+        const expected = [
+            { label: 'abc123', value: '#{abc123}' },
+            { label: '/', value: '/' },
+            { label: '10', value: '10' },
+        ]
+
+        expect(parseExpressionToArray(expression)).toEqual(expected)
     })
 })

--- a/src/modules/__tests__/expressions.spec.js
+++ b/src/modules/__tests__/expressions.spec.js
@@ -1,0 +1,44 @@
+import { validateExpression, INVALID_EXPRESSION } from '../expressions.js'
+
+const invalidTestExpressions = [
+    { exp: '', message: 'Empty formula' },
+    { exp: '5+-', message: 'Consecutive math operators' },
+    {
+        exp: '#{cYeuwXTCPkU}#{Jtf34kNZhzP}',
+        message: 'Consecutive data elements',
+    },
+    {
+        exp: '*((#{cYeuwXTCPkU}*#{Jtf34kNZhzP})))',
+        message: 'Starts or ends with a math operator',
+    },
+    {
+        exp: '((#{cYeuwXTCPkU}*#{Jtf34kNZhzP})))',
+        message: 'Missing left parenthesis (',
+    },
+    {
+        exp: '((#{cYeuwXTCPkU}*#{Jtf34kNZhzP})',
+        message: 'Missing right parenthesis )',
+    },
+]
+
+const validTestExpressions = [
+    { exp: '5+9' },
+    { exp: '((#{cYeuwXTCPkU}*#{Jtf34kNZhzP}))#{iKGjnOOaPlE}' },
+]
+
+describe('expressions', () => {
+    invalidTestExpressions.forEach(({ exp, message }) => {
+        test(`Fails: ${message}`, () => {
+            expect(validateExpression(exp)).toEqual({
+                status: INVALID_EXPRESSION,
+                message,
+            })
+        })
+    })
+
+    validTestExpressions.forEach(({ exp }) => {
+        test(`Passes validation: ${exp}`, () => {
+            expect(validateExpression(exp)).toEqual('')
+        })
+    })
+})

--- a/src/modules/expressions.js
+++ b/src/modules/expressions.js
@@ -1,5 +1,5 @@
 import {
-    TYPE_DATAELEMENT,
+    TYPE_DATA_ELEMENT,
     TYPE_NUMBER,
     TYPE_OPERATOR,
 } from '../components/DataDimension/constants.js'
@@ -8,21 +8,19 @@ import i18n from '../locales/index.js'
 export const VALID_EXPRESSION = 'OK'
 export const INVALID_EXPRESSION = 'ERROR'
 
-export const getOperators = () => {
-    return [
-        { value: '+', label: '+', type: TYPE_OPERATOR },
-        { value: '-', label: '-', type: TYPE_OPERATOR },
-        { value: '*', label: '×', type: TYPE_OPERATOR },
-        { value: '/', label: '/', type: TYPE_OPERATOR },
-        { value: '(', label: '(', type: TYPE_OPERATOR },
-        { value: ')', label: ')', type: TYPE_OPERATOR },
-        {
-            value: '',
-            label: i18n.t('<number>'),
-            type: TYPE_NUMBER,
-        },
-    ]
-}
+export const getOperators = () => [
+    { value: '+', label: '+', type: TYPE_OPERATOR },
+    { value: '-', label: '-', type: TYPE_OPERATOR },
+    { value: '*', label: '×', type: TYPE_OPERATOR },
+    { value: '/', label: '/', type: TYPE_OPERATOR },
+    { value: '(', label: '(', type: TYPE_OPERATOR },
+    { value: ')', label: ')', type: TYPE_OPERATOR },
+    {
+        value: '',
+        label: i18n.t('<number>'),
+        type: TYPE_NUMBER,
+    },
+]
 
 export const parseExpression = (input) => {
     const regex = /(#{[a-zA-Z0-9#]+.*?}|[+\-*/()])|(\d+)/g
@@ -34,7 +32,7 @@ export const parseExpressionToArray = (expression = '') => {
         parseExpression(expression).map((value) => {
             if (value.startsWith('#{') && value.endsWith('}')) {
                 const label = value.slice(2, -1)
-                return { value, label, type: TYPE_DATAELEMENT }
+                return { value, label, type: TYPE_DATA_ELEMENT }
             }
 
             if (isNaN(value)) {

--- a/src/modules/expressions.js
+++ b/src/modules/expressions.js
@@ -1,24 +1,24 @@
 import i18n from '../locales/index.js'
 import { DIMENSION_TYPE_DATA_ELEMENT } from './dataTypes.js'
 
-export const TYPE_NUMBER = 'NUMBER'
-export const TYPE_OPERATOR = 'OPERATOR'
-export const TYPE_DATA_ELEMENT = DIMENSION_TYPE_DATA_ELEMENT
+export const EXPRESSION_TYPE_NUMBER = 'EXPRESSION_TYPE_NUMBER'
+export const EXPRESSION_TYPE_OPERATOR = 'EXPRESSION_TYPE_OPERATOR'
+export const EXPRESSION_TYPE_DATA_ELEMENT = DIMENSION_TYPE_DATA_ELEMENT
 
 export const VALID_EXPRESSION = 'OK'
 export const INVALID_EXPRESSION = 'ERROR'
 
 export const getOperators = () => [
-    { value: '+', label: '+', type: TYPE_OPERATOR },
-    { value: '-', label: '-', type: TYPE_OPERATOR },
-    { value: '*', label: '×', type: TYPE_OPERATOR },
-    { value: '/', label: '/', type: TYPE_OPERATOR },
-    { value: '(', label: '(', type: TYPE_OPERATOR },
-    { value: ')', label: ')', type: TYPE_OPERATOR },
+    { value: '+', label: '+', type: EXPRESSION_TYPE_OPERATOR },
+    { value: '-', label: '-', type: EXPRESSION_TYPE_OPERATOR },
+    { value: '*', label: '×', type: EXPRESSION_TYPE_OPERATOR },
+    { value: '/', label: '/', type: EXPRESSION_TYPE_OPERATOR },
+    { value: '(', label: '(', type: EXPRESSION_TYPE_OPERATOR },
+    { value: ')', label: ')', type: EXPRESSION_TYPE_OPERATOR },
     {
         value: '',
         label: i18n.t('<number>'),
-        type: TYPE_NUMBER,
+        type: EXPRESSION_TYPE_NUMBER,
     },
 ]
 
@@ -32,7 +32,7 @@ export const parseExpressionToArray = (expression = '') => {
         parseExpression(expression).map((value) => {
             if (value.startsWith('#{') && value.endsWith('}')) {
                 const label = value.slice(2, -1)
-                return { value, label, type: TYPE_DATA_ELEMENT }
+                return { value, label, type: EXPRESSION_TYPE_DATA_ELEMENT }
             }
 
             if (isNaN(value)) {
@@ -40,14 +40,14 @@ export const parseExpressionToArray = (expression = '') => {
                     value,
                     label: getOperators().find((op) => op.value === value)
                         .label,
-                    type: TYPE_OPERATOR,
+                    type: EXPRESSION_TYPE_OPERATOR,
                 }
             }
 
             return {
                 value,
                 label: value,
-                type: TYPE_NUMBER,
+                type: EXPRESSION_TYPE_NUMBER,
             }
         }) || []
     )

--- a/src/modules/expressions.js
+++ b/src/modules/expressions.js
@@ -1,8 +1,9 @@
 import i18n from '../locales/index.js'
+import { DIMENSION_TYPE_DATA_ELEMENT } from './dataTypes.js'
 
 export const TYPE_NUMBER = 'NUMBER'
 export const TYPE_OPERATOR = 'OPERATOR'
-export const TYPE_DATA_ELEMENT = 'DATA_ELEMENT'
+export const TYPE_DATA_ELEMENT = DIMENSION_TYPE_DATA_ELEMENT
 
 export const VALID_EXPRESSION = 'OK'
 export const INVALID_EXPRESSION = 'ERROR'

--- a/src/modules/expressions.js
+++ b/src/modules/expressions.js
@@ -1,3 +1,8 @@
+import i18n from '../locales/index.js'
+
+export const VALID_EXPRESSION = 'OK'
+export const INVALID_EXPRESSION = 'ERROR'
+
 export const parseExpression = (input) => {
     const regex = /(#{[a-zA-Z0-9#]+.*?}|[+\-*/()])|(\d+)/g
     return input.match(regex) || []
@@ -21,3 +26,51 @@ export const parseExpressionToArray = (input = '') => {
 // output: '#{abc123}/10'
 export const parseArrayToExpression = (input = []) =>
     input.map((item) => item.value).join('')
+
+export const validateExpression = async (expression) => {
+    let result = ''
+    // TODO: two numbers next to each other
+
+    const leftParenthesisCount = expression.split('(').length - 1
+    const rightParenthesisCount = expression.split(')').length - 1
+
+    if (!expression) {
+        // empty formula
+        result = {
+            status: INVALID_EXPRESSION,
+            message: i18n.t('Empty formula'),
+        }
+    } else if (/[-+/*]{2,}/.test(expression)) {
+        // two math operators next to each other
+        result = {
+            status: INVALID_EXPRESSION,
+            message: i18n.t('Consecutive math operators'),
+        }
+    } else if (/}#/.test(expression)) {
+        // two data elements next to each other
+        result = {
+            status: INVALID_EXPRESSION,
+            message: i18n.t('Consecutive data elements'),
+        }
+    } else if (/^[+\-*/]|[+\-*/]$/.test(expression)) {
+        // starting or ending with a math operator
+        result = {
+            status: INVALID_EXPRESSION,
+            message: i18n.t('Starts or ends with a math operator'),
+        }
+    } else if (leftParenthesisCount > rightParenthesisCount) {
+        // ( but no )
+        result = {
+            status: INVALID_EXPRESSION,
+            message: i18n.t('Missing right parenthesis )'),
+        }
+    } else if (rightParenthesisCount > leftParenthesisCount) {
+        // ) but no (
+        result = {
+            status: INVALID_EXPRESSION,
+            message: i18n.t('Missing left parenthesis ('),
+        }
+    }
+
+    return result
+}

--- a/src/modules/expressions.js
+++ b/src/modules/expressions.js
@@ -8,8 +8,6 @@ export const parseExpression = (input) => {
     return input.match(regex) || []
 }
 
-// input: '#{abc123}/10'
-// output: [{label:'abc123', value:'#{abc123}'},{label:'/', value:'/'},{label:'10', value:'10'}]
 export const parseExpressionToArray = (input = '') => {
     return (
         parseExpression(input).map((part) => {
@@ -22,8 +20,6 @@ export const parseExpressionToArray = (input = '') => {
     )
 }
 
-// input: [{label:'abc123', value:'#{abc123}'},{label:'/', value:'/'},{label:'10', value:'10'}]
-// output: '#{abc123}/10'
 export const parseArrayToExpression = (input = []) =>
     input.map((item) => item.value).join('')
 

--- a/src/modules/expressions.js
+++ b/src/modules/expressions.js
@@ -27,7 +27,7 @@ export const parseExpressionToArray = (input = '') => {
 export const parseArrayToExpression = (input = []) =>
     input.map((item) => item.value).join('')
 
-export const validateExpression = async (expression) => {
+export const validateExpression = (expression) => {
     let result = ''
     // TODO: two numbers next to each other
 

--- a/src/modules/expressions.js
+++ b/src/modules/expressions.js
@@ -1,21 +1,56 @@
+import {
+    TYPE_DATAELEMENT,
+    TYPE_NUMBER,
+    TYPE_OPERATOR,
+} from '../components/DataDimension/constants.js'
 import i18n from '../locales/index.js'
 
 export const VALID_EXPRESSION = 'OK'
 export const INVALID_EXPRESSION = 'ERROR'
+
+export const getOperators = () => {
+    return [
+        { value: '+', label: '+', type: TYPE_OPERATOR },
+        { value: '-', label: '-', type: TYPE_OPERATOR },
+        { value: '*', label: '×', type: TYPE_OPERATOR },
+        { value: '/', label: '/', type: TYPE_OPERATOR },
+        { value: '(', label: '(', type: TYPE_OPERATOR },
+        { value: ')', label: ')', type: TYPE_OPERATOR },
+        {
+            value: '',
+            label: i18n.t('<number>'),
+            type: TYPE_NUMBER,
+        },
+    ]
+}
 
 export const parseExpression = (input) => {
     const regex = /(#{[a-zA-Z0-9#]+.*?}|[+\-*/()])|(\d+)/g
     return input.match(regex) || []
 }
 
-export const parseExpressionToArray = (input = '') => {
+export const parseExpressionToArray = (expression = '') => {
     return (
-        parseExpression(input).map((part) => {
-            if (part.startsWith('#{') && part.endsWith('}')) {
-                const id = part.slice(2, -1)
-                return { value: part, label: id }
+        parseExpression(expression).map((value) => {
+            if (value.startsWith('#{') && value.endsWith('}')) {
+                const label = value.slice(2, -1)
+                return { value, label, type: TYPE_DATAELEMENT }
             }
-            return { value: part, label: part }
+
+            if (isNaN(value)) {
+                return {
+                    value,
+                    label: getOperators().find((op) => op.value === value)
+                        .label,
+                    type: TYPE_OPERATOR,
+                }
+            }
+
+            return {
+                value,
+                label: value,
+                type: TYPE_NUMBER,
+            }
         }) || []
     )
 }

--- a/src/modules/expressions.js
+++ b/src/modules/expressions.js
@@ -1,7 +1,7 @@
 import i18n from '../locales/index.js'
 
-export const TYPE_NUMBER = 'input'
-export const TYPE_OPERATOR = 'operator'
+export const TYPE_NUMBER = 'NUMBER'
+export const TYPE_OPERATOR = 'OPERATOR'
 export const TYPE_DATA_ELEMENT = 'DATA_ELEMENT'
 
 export const VALID_EXPRESSION = 'OK'

--- a/src/modules/expressions.js
+++ b/src/modules/expressions.js
@@ -1,9 +1,8 @@
-import {
-    TYPE_DATA_ELEMENT,
-    TYPE_NUMBER,
-    TYPE_OPERATOR,
-} from '../components/DataDimension/constants.js'
 import i18n from '../locales/index.js'
+
+export const TYPE_NUMBER = 'input'
+export const TYPE_OPERATOR = 'operator'
+export const TYPE_DATA_ELEMENT = 'DATA_ELEMENT'
 
 export const VALID_EXPRESSION = 'OK'
 export const INVALID_EXPRESSION = 'ERROR'

--- a/src/modules/expressions.js
+++ b/src/modules/expressions.js
@@ -56,7 +56,7 @@ export const parseArrayToExpression = (input = []) =>
     input.map((item) => item.value).join('')
 
 export const validateExpression = (expression) => {
-    let result = ''
+    let result
     // TODO: two numbers next to each other
 
     const leftParenthesisCount = expression.split('(').length - 1

--- a/yarn.lock
+++ b/yarn.lock
@@ -2304,6 +2304,37 @@
     "@dhis2/ui-icons" "8.4.11"
     prop-types "^15.7.2"
 
+"@dnd-kit/accessibility@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/accessibility/-/accessibility-3.0.1.tgz#3ccbefdfca595b0a23a5dc57d3de96bc6935641c"
+  integrity sha512-HXRrwS9YUYQO9lFRc/49uO/VICbM+O+ZRpFDe9Pd1rwVv2PCNkRiTZRdxrDgng/UkvdC3Re9r2vwPpXXrWeFzg==
+  dependencies:
+    tslib "^2.0.0"
+
+"@dnd-kit/core@^6.0.7":
+  version "6.0.7"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/core/-/core-6.0.7.tgz#eb9bcb2ab5cfba3c5e8d5dc64b61e5e9cc5567dc"
+  integrity sha512-qcLBTVTjmLuLqC0RHQ+dFKN5neWmAI56H9xZ+he9WEJEkAvR76YAcz7DSWDJfjErepfG2H3Fkb9lYiX7cPR62g==
+  dependencies:
+    "@dnd-kit/accessibility" "^3.0.0"
+    "@dnd-kit/utilities" "^3.2.1"
+    tslib "^2.0.0"
+
+"@dnd-kit/sortable@^7.0.2":
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/sortable/-/sortable-7.0.2.tgz#791d550872457f3f3c843e00d159b640f982011c"
+  integrity sha512-wDkBHHf9iCi1veM834Gbk1429bd4lHX4RpAwT0y2cHLf246GAvU2sVw/oxWNpPKQNQRQaeGXhAVgrOl1IT+iyA==
+  dependencies:
+    "@dnd-kit/utilities" "^3.2.0"
+    tslib "^2.0.0"
+
+"@dnd-kit/utilities@^3.2.0", "@dnd-kit/utilities@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@dnd-kit/utilities/-/utilities-3.2.1.tgz#53f9e2016fd2506ec49e404c289392cfff30332a"
+  integrity sha512-OOXqISfvBw/1REtkSK2N3Fi2EQiLMlWUlqnOK/UpOISqBZPWpE6TqL+jcPtMOkE8TqYGiURvRdPSI9hltNUjEA==
+  dependencies:
+    tslib "^2.0.0"
+
 "@emotion/cache@^10.0.27":
   version "10.0.29"
   resolved "https://registry.yarnpkg.com/@emotion/cache/-/cache-10.0.29.tgz#87e7e64f412c060102d589fe7c6dc042e6f9d1e0"


### PR DESCRIPTION
dnd for calculations

Some technical notes:
* DndContext is mostly copied from Line-list. The only thing that has really changed is the handleDragEnd function.
* When an item is added to the formula, it is assigned an id based on the id or label of the item and a counter. Dnd requires that each draggable item have an id.
* In the INPUT formula item, there is a setTimeout that was needed in order to get the cursor to stay in the input element once it was added to the formula.
* In the FormulaField, there is a special, invisible drop zone always present in the formula field. It makes it possible to drop an item before the first item.  This is the DropZone component. This is almost identical to what we have in LL
* Also in FormulaField, there is a little trickery that makes it possible to show the full drop indicator on top of the border.  This is using the <div className="border> element. The problem was that with `overflow` set on the formula field, the drop indicator is getting cut off. An alternative to the current solution would be to increase the padding inside FormulaField to leave enough space for the full drop indicator to show, but that means a padding of 12px, which looked strange to me. But it's worth discussing.


Give it a try by doing this: 
1. pull this branch
2. yarn install && yarn start
3. go to localhost:5000 (storybook) and try the CalculationsModal component
