### PR TITLE
fix: bump multi-calendar-dates to avoid jest config change

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     },
     "dependencies": {
         "@dhis2/d2-ui-rich-text": "^7.4.0",
-        "@dhis2/multi-calendar-dates": "1.0.0-beta.21",
+        "@dhis2/multi-calendar-dates": "1.0.0-alpha.18",
         "classnames": "^2.3.1",
         "d2-utilizr": "^0.2.16",
         "d3-color": "^1.2.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2202,10 +2202,10 @@
     markdown-it "^8.4.2"
     prop-types "^15.6.2"
 
-"@dhis2/multi-calendar-dates@1.0.0-beta.21":
-  version "1.0.0-beta.21"
-  resolved "https://registry.yarnpkg.com/@dhis2/multi-calendar-dates/-/multi-calendar-dates-1.0.0-beta.21.tgz#389c7bc2e707214255ae92adacb3194fec8428ed"
-  integrity sha512-3ck+r4u+xgUgZOnt9CvUJZ9HoxO01PFBwsJhycCJu/sNJB7frLol+GywLWW0pRZkJiNuTbLyqGmzI3byuJwCXA==
+"@dhis2/multi-calendar-dates@1.0.0-alpha.18":
+  version "1.0.0-alpha.18"
+  resolved "https://registry.yarnpkg.com/@dhis2/multi-calendar-dates/-/multi-calendar-dates-1.0.0-alpha.18.tgz#341176f1ffb0a4663dd5b882e587403d6dc7fbda"
+  integrity sha512-0m8HcH3j7/FRXdZ+tgnnFjDdoC05JEKsm6XH7m+JZOJlfWshNTrYU5l1JzFumiNO3teFkBS/uFgSZHu7UbKeng==
   dependencies:
     "@js-temporal/polyfill" "^0.4.2"
     classnames "^2.3.2"


### PR DESCRIPTION
bumps `multi-calendar-dates` to a version that emits both `cjs` and `es` modules to support cjs generally, to avoid having to add `transformIgnorePatterns` to the `jest` configuration of libraries that consume multi-calendar-dates through the analytics library.

related to https://github.com/dhis2/multi-calendar-dates/pull/10
