### PR TITLE
feat: new props for customising OrgUnitDimension DHIS2-14744

### DIFF
--- a/src/__demo__/OrgUnitDimension.stories.js
+++ b/src/__demo__/OrgUnitDimension.stories.js
@@ -4,7 +4,10 @@ import React, { useState } from 'react'
 import OrgUnitDimension from '../components/OrgUnitDimension/OrgUnitDimension.js'
 
 const Wrapper = (story) => (
-    <DataProvider baseUrl="http://localhost:8080/" apiVersion="">
+    <DataProvider
+        baseUrl="https://debug.dhis2.org/analytics-dev/"
+        apiVersion=""
+    >
         {story()}
     </DataProvider>
 )
@@ -131,6 +134,69 @@ storiesOf('OrgUnitDimension', module)
                 selected={selected}
                 onSelect={(response) => setSelected(response.items)}
                 roots={['O6uvpzGd5pu', 'fdc6uOvgoji']} // Bo + Bombali
+            />
+        )
+    })
+
+storiesOf('OrgUnitDimension', module)
+    .addDecorator(Wrapper)
+    .add('Without level selector', () => {
+        const [selected, setSelected] = useState([])
+
+        return (
+            <OrgUnitDimension
+                hideLevelSelect={true}
+                selected={selected}
+                onSelect={(response) => setSelected(response.items)}
+                roots={defaultRootOrgUnits}
+            />
+        )
+    })
+
+storiesOf('OrgUnitDimension', module)
+    .addDecorator(Wrapper)
+    .add('Without group selector', () => {
+        const [selected, setSelected] = useState([])
+
+        return (
+            <OrgUnitDimension
+                hideGroupSelect={true}
+                selected={selected}
+                onSelect={(response) => setSelected(response.items)}
+                roots={defaultRootOrgUnits}
+            />
+        )
+    })
+
+storiesOf('OrgUnitDimension', module)
+    .addDecorator(Wrapper)
+    .add('Without level and group selector', () => {
+        const [selected, setSelected] = useState([])
+
+        return (
+            <OrgUnitDimension
+                hideLevelSelect={true}
+                hideGroupSelect={true}
+                selected={selected}
+                onSelect={(response) => setSelected(response.items)}
+                roots={defaultRootOrgUnits}
+            />
+        )
+    })
+
+storiesOf('OrgUnitDimension', module)
+    .addDecorator(Wrapper)
+    .add('Without level and group selector, with warning text', () => {
+        const [selected, setSelected] = useState([])
+
+        return (
+            <OrgUnitDimension
+                hideLevelSelect={true}
+                hideGroupSelect={true}
+                selected={selected}
+                onSelect={(response) => setSelected(response.items)}
+                roots={defaultRootOrgUnits}
+                warning={'No org. units selected'}
             />
         )
     })

--- a/src/components/OrgUnitDimension/OrgUnitDimension.js
+++ b/src/components/OrgUnitDimension/OrgUnitDimension.js
@@ -5,6 +5,8 @@ import {
     MultiSelect,
     MultiSelectOption,
     Button,
+    IconWarningFilled16,
+    colors,
 } from '@dhis2/ui'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
@@ -30,7 +32,14 @@ const DYNAMIC_ORG_UNITS = [
     USER_ORG_UNIT_GRANDCHILDREN,
 ]
 
-const OrgUnitDimension = ({ roots, selected, onSelect }) => {
+const OrgUnitDimension = ({
+    roots,
+    selected,
+    onSelect,
+    hideGroupSelect,
+    hideLevelSelect,
+    warning,
+}) => {
     const [ouLevels, setOuLevels] = useState([])
     const [ouGroups, setOuGroups] = useState([])
     const dataEngine = useDataEngine()
@@ -73,9 +82,9 @@ const OrgUnitDimension = ({ roots, selected, onSelect }) => {
             setOuGroups(result)
         }
 
-        doFetchOuLevels()
-        doFetchOuGroups()
-    }, [dataEngine])
+        !hideLevelSelect && doFetchOuLevels()
+        !hideGroupSelect && doFetchOuGroups()
+    }, [dataEngine, hideLevelSelect, hideGroupSelect])
 
     const onLevelChange = (ids) => {
         const items = ids.map((id) => ({
@@ -261,65 +270,77 @@ const OrgUnitDimension = ({ roots, selected, onSelect }) => {
                     disabled: selected.some((item) =>
                         DYNAMIC_ORG_UNITS.includes(item.id)
                     ),
+                    hidden: hideLevelSelect && hideGroupSelect,
                 })}
             >
-                <MultiSelect
-                    selected={
-                        ouLevels.length
-                            ? selected
-                                  .filter((item) =>
-                                      ouIdHelper.hasLevelPrefix(item.id)
-                                  )
-                                  .map((item) =>
-                                      ouIdHelper.removePrefix(item.id)
-                                  )
-                            : []
-                    }
-                    onChange={({ selected }) => onLevelChange(selected)}
-                    placeholder={i18n.t('Select a level')}
-                    loading={!ouLevels.length}
-                    dense
-                    dataTest={'org-unit-level-select'}
-                >
-                    {ouLevels.map((level) => (
-                        <MultiSelectOption
-                            key={level.id}
-                            value={level.id}
-                            label={level.displayName}
-                            dataTest={`org-unit-level-select-option-${level.id}`}
-                        />
-                    ))}
-                </MultiSelect>
-                <MultiSelect
-                    selected={
-                        ouGroups.length
-                            ? selected
-                                  .filter((item) =>
-                                      ouIdHelper.hasGroupPrefix(item.id)
-                                  )
-                                  .map((item) =>
-                                      ouIdHelper.removePrefix(item.id)
-                                  )
-                            : []
-                    }
-                    onChange={({ selected }) => onGroupChange(selected)}
-                    placeholder={i18n.t('Select a group')}
-                    loading={!ouGroups.length}
-                    dense
-                    dataTest={'org-unit-group-select'}
-                >
-                    {ouGroups.map((group) => (
-                        <MultiSelectOption
-                            key={group.id}
-                            value={group.id}
-                            label={group.displayName}
-                            dataTest={`org-unit-group-select-option-${group.id}`}
-                        />
-                    ))}
-                </MultiSelect>
+                {!hideLevelSelect && (
+                    <MultiSelect
+                        selected={
+                            ouLevels.length
+                                ? selected
+                                      .filter((item) =>
+                                          ouIdHelper.hasLevelPrefix(item.id)
+                                      )
+                                      .map((item) =>
+                                          ouIdHelper.removePrefix(item.id)
+                                      )
+                                : []
+                        }
+                        onChange={({ selected }) => onLevelChange(selected)}
+                        placeholder={i18n.t('Select a level')}
+                        loading={!ouLevels.length}
+                        dense
+                        dataTest={'org-unit-level-select'}
+                    >
+                        {ouLevels.map((level) => (
+                            <MultiSelectOption
+                                key={level.id}
+                                value={level.id}
+                                label={level.displayName}
+                                dataTest={`org-unit-level-select-option-${level.id}`}
+                            />
+                        ))}
+                    </MultiSelect>
+                )}
+                {!hideGroupSelect && (
+                    <MultiSelect
+                        selected={
+                            ouGroups.length
+                                ? selected
+                                      .filter((item) =>
+                                          ouIdHelper.hasGroupPrefix(item.id)
+                                      )
+                                      .map((item) =>
+                                          ouIdHelper.removePrefix(item.id)
+                                      )
+                                : []
+                        }
+                        onChange={({ selected }) => onGroupChange(selected)}
+                        placeholder={i18n.t('Select a group')}
+                        loading={!ouGroups.length}
+                        dense
+                        dataTest={'org-unit-group-select'}
+                    >
+                        {ouGroups.map((group) => (
+                            <MultiSelectOption
+                                key={group.id}
+                                value={group.id}
+                                label={group.displayName}
+                                dataTest={`org-unit-group-select-option-${group.id}`}
+                            />
+                        ))}
+                    </MultiSelect>
+                )}
             </div>
             <div className="summaryWrapper">
-                <span className="summaryText">{getSummary()}</span>
+                {warning ? (
+                    <div className="warningWrapper">
+                        <IconWarningFilled16 color={colors.red500} />
+                        <span className="warningText">{warning}</span>
+                    </div>
+                ) : (
+                    <span className="summaryText">{getSummary()}</span>
+                )}
                 <div className="deselectButton">
                     <Button
                         secondary
@@ -335,7 +356,15 @@ const OrgUnitDimension = ({ roots, selected, onSelect }) => {
         </div>
     )
 }
+
+OrgUnitDimension.defaultProps = {
+    hideGroupSelect: false,
+    hideLevelSelect: false,
+}
+
 OrgUnitDimension.propTypes = {
+    hideGroupSelect: PropTypes.bool,
+    hideLevelSelect: PropTypes.bool,
     roots: PropTypes.arrayOf(PropTypes.string),
     selected: PropTypes.arrayOf(
         PropTypes.shape({
@@ -344,6 +373,7 @@ OrgUnitDimension.propTypes = {
             path: PropTypes.string,
         })
     ),
+    warning: PropTypes.string,
     onSelect: PropTypes.func,
 }
 

--- a/src/components/OrgUnitDimension/styles/OrgUnitDimension.style.js
+++ b/src/components/OrgUnitDimension/styles/OrgUnitDimension.style.js
@@ -45,12 +45,30 @@ export default css`
         margin-top: ${spacers.dp12};
     }
 
+    .selectsWrapper.hidden {
+        display: none;
+    }
+
     .selectsWrapper > :global(*) {
         width: 50%;
     }
 
     .summaryWrapper {
+        display: inline-flex;
+        align-items: center;
         margin-top: ${spacers.dp8};
+    }
+
+    .warningWrapper {
+        display: inline-flex;
+        align-items: center;
+    }
+
+    .warningText {
+        margin-left: ${spacers.dp8};
+        font-size: 14px;
+        line-height: 18px;
+        color: ${colors.red600};
     }
 
     .summaryText {


### PR DESCRIPTION
Implements [DHIS2-14744](https://dhis2.atlassian.net/browse/DHIS2-14744)

---

### Key features

1. add `hideLevelSelect` prop
2. add `hideGroupSelect` prop
3. add `warning` prop
4. added new Storybook stories to demonstrate the features

---

### Description

With these 3 new optional props the `OrgUnitDimension` component can be customised to accommodate the needs of Maps app.
Defaults are `false` for 1 and 2 and `empty` for 3.

1 and 2 simply hide the respective dropdown select and also avoid fetching levels/groups.
3 can be passed with a translated string to inform the user of some error/warning.

---

### Screenshots

`hideLevelSelect` enabled:
<img width="732" alt="Screenshot 2023-02-14 at 15 37 38" src="https://user-images.githubusercontent.com/150978/218769621-4dab1ed6-7ede-410f-9794-c5b9b780c5c6.png">

`hideGroupSelect` enabled:
<img width="732" alt="Screenshot 2023-02-14 at 15 37 50" src="https://user-images.githubusercontent.com/150978/218769652-83578e6f-c64e-4d1a-b975-8bff49e5d395.png">

Both `hideLevelSelect` and `hideGroupSelect` enabled:
<img width="736" alt="Screenshot 2023-02-14 at 15 38 02" src="https://user-images.githubusercontent.com/150978/218769782-84fecbdb-284c-449b-914a-7bc99a8a631a.png">

Custom `warning` text:
<img width="735" alt="Screenshot 2023-02-14 at 15 38 09" src="https://user-images.githubusercontent.com/150978/218769819-ad2a68da-869a-4e2a-9641-e50c9f9410c2.png">


[DHIS2-14744]: https://dhis2.atlassian.net/browse/DHIS2-14744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ