### PR TITLE
feat: add prop for controlling user org unit selector DHIS2-14744

### DIFF
--- a/src/__demo__/OrgUnitDimension.stories.js
+++ b/src/__demo__/OrgUnitDimension.stories.js
@@ -140,6 +140,21 @@ storiesOf('OrgUnitDimension', module)
 
 storiesOf('OrgUnitDimension', module)
     .addDecorator(Wrapper)
+    .add('Without user org units selection', () => {
+        const [selected, setSelected] = useState([])
+
+        return (
+            <OrgUnitDimension
+                hideUserOrgUnits={true}
+                selected={selected}
+                onSelect={(response) => setSelected(response.items)}
+                roots={defaultRootOrgUnits}
+            />
+        )
+    })
+
+storiesOf('OrgUnitDimension', module)
+    .addDecorator(Wrapper)
     .add('Without level selector', () => {
         const [selected, setSelected] = useState([])
 

--- a/src/components/OrgUnitDimension/OrgUnitDimension.js
+++ b/src/components/OrgUnitDimension/OrgUnitDimension.js
@@ -38,6 +38,7 @@ const OrgUnitDimension = ({
     onSelect,
     hideGroupSelect,
     hideLevelSelect,
+    hideUserOrgUnits,
     warning,
 }) => {
     const [ouLevels, setOuLevels] = useState([])
@@ -185,48 +186,52 @@ const OrgUnitDimension = ({
 
     return (
         <div className="container">
-            <div className="userOrgUnitsWrapper">
-                <Checkbox
-                    label={i18n.t('User organisation unit')}
-                    checked={selected.some((item) => item.id === USER_ORG_UNIT)}
-                    onChange={({ checked }) =>
-                        onSelectItems({
-                            id: USER_ORG_UNIT,
-                            checked,
-                            displayName: i18n.t('User organisation unit'),
-                        })
-                    }
-                    dense
-                />
-                <Checkbox
-                    label={i18n.t('User sub-units')}
-                    checked={selected.some(
-                        (item) => item.id === USER_ORG_UNIT_CHILDREN
-                    )}
-                    onChange={({ checked }) =>
-                        onSelectItems({
-                            id: USER_ORG_UNIT_CHILDREN,
-                            checked,
-                            displayName: i18n.t('User sub-units'),
-                        })
-                    }
-                    dense
-                />
-                <Checkbox
-                    label={i18n.t('User sub-x2-units')}
-                    checked={selected.some(
-                        (item) => item.id === USER_ORG_UNIT_GRANDCHILDREN
-                    )}
-                    onChange={({ checked }) =>
-                        onSelectItems({
-                            id: USER_ORG_UNIT_GRANDCHILDREN,
-                            checked,
-                            displayName: i18n.t('User sub-x2-units'),
-                        })
-                    }
-                    dense
-                />
-            </div>
+            {!hideUserOrgUnits && (
+                <div className="userOrgUnitsWrapper">
+                    <Checkbox
+                        label={i18n.t('User organisation unit')}
+                        checked={selected.some(
+                            (item) => item.id === USER_ORG_UNIT
+                        )}
+                        onChange={({ checked }) =>
+                            onSelectItems({
+                                id: USER_ORG_UNIT,
+                                checked,
+                                displayName: i18n.t('User organisation unit'),
+                            })
+                        }
+                        dense
+                    />
+                    <Checkbox
+                        label={i18n.t('User sub-units')}
+                        checked={selected.some(
+                            (item) => item.id === USER_ORG_UNIT_CHILDREN
+                        )}
+                        onChange={({ checked }) =>
+                            onSelectItems({
+                                id: USER_ORG_UNIT_CHILDREN,
+                                checked,
+                                displayName: i18n.t('User sub-units'),
+                            })
+                        }
+                        dense
+                    />
+                    <Checkbox
+                        label={i18n.t('User sub-x2-units')}
+                        checked={selected.some(
+                            (item) => item.id === USER_ORG_UNIT_GRANDCHILDREN
+                        )}
+                        onChange={({ checked }) =>
+                            onSelectItems({
+                                id: USER_ORG_UNIT_GRANDCHILDREN,
+                                checked,
+                                displayName: i18n.t('User sub-x2-units'),
+                            })
+                        }
+                        dense
+                    />
+                </div>
+            )}
             <div
                 className={cx('orgUnitTreeWrapper', {
                     disabled: selected.some((item) =>
@@ -360,11 +365,13 @@ const OrgUnitDimension = ({
 OrgUnitDimension.defaultProps = {
     hideGroupSelect: false,
     hideLevelSelect: false,
+    hideUserOrgUnits: false,
 }
 
 OrgUnitDimension.propTypes = {
     hideGroupSelect: PropTypes.bool,
     hideLevelSelect: PropTypes.bool,
+    hideUserOrgUnits: PropTypes.bool,
     roots: PropTypes.arrayOf(PropTypes.string),
     selected: PropTypes.arrayOf(
         PropTypes.shape({


### PR DESCRIPTION
Implements [DHIS2-14744](https://dhis2.atlassian.net/browse/DHIS2-14744)

---

### Key features

1. add `hideUserOrgUnits` prop

---

### Description

Maps needs to hide the user org units selector in some cases.

---

### Screenshots

Example of component without the user org unit section at the top:

<img width="512" alt="Screenshot 2023-02-16 at 14 44 40" src="https://user-images.githubusercontent.com/150978/219381710-bb988703-c456-4fc7-b245-35dc81d5944f.png">


[DHIS2-14744]: https://dhis2.atlassian.net/browse/DHIS2-14744?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ