### PR TITLE
feat: localise multi-calendar fixed periods according to user locale

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     },
     "dependencies": {
         "@dhis2/d2-ui-rich-text": "^7.4.0",
-        "@dhis2/multi-calendar-dates": "1.0.0-beta.24",
+        "@dhis2/multi-calendar-dates": "1.0.0",
         "classnames": "^2.3.1",
         "d2-utilizr": "^0.2.16",
         "d3-color": "^1.2.3",

--- a/package.json
+++ b/package.json
@@ -48,11 +48,6 @@
         "styled-jsx": "^4.0.1",
         "typeface-roboto": "^0.0.75"
     },
-    "jest": {
-        "transformIgnorePatterns": [
-            "/!node_modules\\/multi-calendar-dates/"
-        ]
-    },
     "peerDependencies": {
         "@dhis2/app-runtime": "^3",
         "@dhis2/d2-i18n": "^1.1",
@@ -64,7 +59,7 @@
     },
     "dependencies": {
         "@dhis2/d2-ui-rich-text": "^7.4.0",
-        "@dhis2/multi-calendar-dates": "1.0.0-alpha.18",
+        "@dhis2/multi-calendar-dates": "1.0.0-beta.24",
         "classnames": "^2.3.1",
         "d2-utilizr": "^0.2.16",
         "d3-color": "^1.2.3",

--- a/src/components/PeriodDimension/__tests__/PeriodSelector.spec.js
+++ b/src/components/PeriodDimension/__tests__/PeriodSelector.spec.js
@@ -4,7 +4,10 @@ import PeriodTransfer from '../PeriodTransfer.js'
 
 jest.mock('@dhis2/app-runtime', () => ({
     useConfig: () => ({ systemInfo: {} }),
+    useDataQuery: () => ({ data: { userSettings: { keyUiLocale: 'en' } } }),
 }))
+
+afterEach(jest.clearAllMocks)
 
 describe('The Period Selector component', () => {
     let props

--- a/src/components/PeriodDimension/utils/fixedPeriods.js
+++ b/src/components/PeriodDimension/utils/fixedPeriods.js
@@ -44,13 +44,14 @@ const PERIOD_TYPE_REGEX = {
     [FYAPR]: /^([0-9]{4})April$/, // YYYY"April"
 }
 
-const getPeriods = ({ periodType, config, fnFilter, calendar }) => {
+const getPeriods = ({ periodType, config, fnFilter, periodSettings = {} }) => {
     const offset = parseInt(config.offset, 10)
     const isFilter = config.filterFuturePeriods
     const isReverse = periodType.match(/^FY|YEARLY/)
         ? true
         : config.reversePeriods
 
+    const { calendar = 'gregory', locale = 'en' } = periodSettings
     const now = getNowInCalendar(calendar)
     const year = (now.eraYear || now.year) + offset
 
@@ -58,7 +59,7 @@ const getPeriods = ({ periodType, config, fnFilter, calendar }) => {
         periodType,
         year,
         calendar,
-        locale: 'en',
+        locale,
         startingDay: config.startDay,
     }
 
@@ -70,18 +71,18 @@ const getPeriods = ({ periodType, config, fnFilter, calendar }) => {
     return periods
 }
 
-const getDailyPeriodType = (fnFilter, calendar) => {
+const getDailyPeriodType = (fnFilter, periodSettings) => {
     return (config) => {
         return getPeriods({
             periodType: 'DAILY',
             config,
             fnFilter,
-            calendar,
+            periodSettings,
         })
     }
 }
 
-const getWeeklyPeriodType = (weekObj, fnFilter, calendar) => {
+const getWeeklyPeriodType = (weekObj, fnFilter, periodSettings) => {
     return (config) => {
         return getPeriods({
             periodType: 'WEEKLY',
@@ -90,123 +91,128 @@ const getWeeklyPeriodType = (weekObj, fnFilter, calendar) => {
                 startDay: weekObj.startDay,
             },
             fnFilter,
-            calendar,
+            periodSettings,
         })
     }
 }
 
-const getBiWeeklyPeriodType = (fnFilter, calendar) => {
+const getBiWeeklyPeriodType = (fnFilter, periodSettings) => {
     return (config) => {
         return getPeriods({
             periodType: 'BIWEEKLY',
             config,
             fnFilter,
-            calendar,
+            periodSettings,
         })
     }
 }
 
-const getMonthlyPeriodType = (fnFilter, calendar) => {
+const getMonthlyPeriodType = (fnFilter, periodSettings) => {
     return (config) => {
-        return getPeriods({ periodType: 'MONTHLY', config, fnFilter, calendar })
+        return getPeriods({
+            periodType: 'MONTHLY',
+            config,
+            fnFilter,
+            periodSettings,
+        })
     }
 }
 
-const getBiMonthlyPeriodType = (fnFilter, calendar) => {
+const getBiMonthlyPeriodType = (fnFilter, periodSettings) => {
     return (config) => {
         return getPeriods({
             periodType: 'BIMONTHLY',
             config,
             fnFilter,
-            calendar,
+            periodSettings,
         })
     }
 }
 
-const getQuarterlyPeriodType = (fnFilter, calendar) => {
+const getQuarterlyPeriodType = (fnFilter, periodSettings) => {
     return (config) => {
         return getPeriods({
             periodType: 'QUARTERLY',
             config,
             fnFilter,
-            calendar,
+            periodSettings,
         })
     }
 }
 
-const getSixMonthlyPeriodType = (fnFilter, calendar) => {
+const getSixMonthlyPeriodType = (fnFilter, periodSettings) => {
     return (config) => {
         return getPeriods({
             periodType: 'SIXMONTHLY',
             config,
             fnFilter,
-            calendar,
+            periodSettings,
         })
     }
 }
 
-const getSixMonthlyAprilPeriodType = (fnFilter, calendar) => {
+const getSixMonthlyAprilPeriodType = (fnFilter, periodSettings) => {
     return (config) => {
         return getPeriods({
             periodType: 'SIXMONTHLYAPR',
             config,
             fnFilter,
-            calendar,
+            periodSettings,
         })
     }
 }
 
-const getYearlyPeriodType = (fnFilter, calendar) => {
+const getYearlyPeriodType = (fnFilter, periodSettings) => {
     return (config) => {
         return getPeriods({
             periodType: 'YEARLY',
             config,
             fnFilter,
-            calendar,
+            periodSettings,
         })
     }
 }
 
-const getFinancialOctoberPeriodType = (fnFilter, calendar) => {
+const getFinancialOctoberPeriodType = (fnFilter, periodSettings) => {
     return (config) => {
         return getPeriods({
             periodType: 'FYOCT',
             config,
             fnFilter,
-            calendar,
+            periodSettings,
         })
     }
 }
 
-const getFinancialNovemberPeriodType = (fnFilter, calendar) => {
+const getFinancialNovemberPeriodType = (fnFilter, periodSettings) => {
     return (config) => {
         return getPeriods({
             periodType: 'FYNOV',
             config,
             fnFilter,
-            calendar,
+            periodSettings,
         })
     }
 }
 
-const getFinancialJulyPeriodType = (fnFilter, calendar) => {
+const getFinancialJulyPeriodType = (fnFilter, periodSettings) => {
     return (config) => {
         return getPeriods({
             periodType: 'FYJUL',
             config,
             fnFilter,
-            calendar,
+            periodSettings,
         })
     }
 }
 
-const getFinancialAprilPeriodType = (fnFilter, calendar) => {
+const getFinancialAprilPeriodType = (fnFilter, periodSettings) => {
     return (config) => {
         return getPeriods({
             periodType: 'FYAPR',
             config,
             fnFilter,
-            calendar,
+            periodSettings,
         })
     }
 }
@@ -224,11 +230,11 @@ const filterFuturePeriods = (periods) => {
     return array
 }
 
-const getOptions = (calendar = 'gregory') => {
+const getOptions = (periodSettings) => {
     return [
         {
             id: DAILY,
-            getPeriods: getDailyPeriodType(filterFuturePeriods, calendar),
+            getPeriods: getDailyPeriodType(filterFuturePeriods, periodSettings),
             name: i18n.t('Daily'),
         },
         {
@@ -236,7 +242,7 @@ const getOptions = (calendar = 'gregory') => {
             getPeriods: getWeeklyPeriodType(
                 { startDay: 1 },
                 filterFuturePeriods,
-                calendar
+                periodSettings
             ),
             name: i18n.t('Weekly'),
         },
@@ -245,7 +251,7 @@ const getOptions = (calendar = 'gregory') => {
             getPeriods: getWeeklyPeriodType(
                 { startDay: 3 },
                 filterFuturePeriods,
-                calendar
+                periodSettings
             ),
             name: i18n.t('Weekly (Start Wednesday)'),
         },
@@ -254,7 +260,7 @@ const getOptions = (calendar = 'gregory') => {
             getPeriods: getWeeklyPeriodType(
                 { startDay: 4 },
                 filterFuturePeriods,
-                calendar
+                periodSettings
             ),
             name: i18n.t('Weekly (Start Thursday)'),
         },
@@ -263,7 +269,7 @@ const getOptions = (calendar = 'gregory') => {
             getPeriods: getWeeklyPeriodType(
                 { startDay: 6 },
                 filterFuturePeriods,
-                calendar
+                periodSettings
             ),
             name: i18n.t('Weekly (Start Saturday)'),
         },
@@ -272,53 +278,71 @@ const getOptions = (calendar = 'gregory') => {
             getPeriods: getWeeklyPeriodType(
                 { startDay: 7 },
                 filterFuturePeriods,
-                calendar
+                periodSettings
             ),
             name: i18n.t('Weekly (Start Sunday)'),
         },
         {
             id: BIWEEKLY,
-            getPeriods: getBiWeeklyPeriodType(filterFuturePeriods, calendar),
+            getPeriods: getBiWeeklyPeriodType(
+                filterFuturePeriods,
+                periodSettings
+            ),
             name: i18n.t('Bi-weekly'),
         },
         {
             id: MONTHLY,
-            getPeriods: getMonthlyPeriodType(filterFuturePeriods, calendar),
+            getPeriods: getMonthlyPeriodType(
+                filterFuturePeriods,
+                periodSettings
+            ),
             name: i18n.t('Monthly'),
         },
         {
             id: BIMONTHLY,
-            getPeriods: getBiMonthlyPeriodType(filterFuturePeriods, calendar),
+            getPeriods: getBiMonthlyPeriodType(
+                filterFuturePeriods,
+                periodSettings
+            ),
             name: i18n.t('Bi-monthly'),
         },
         {
             id: QUARTERLY,
-            getPeriods: getQuarterlyPeriodType(filterFuturePeriods, calendar),
+            getPeriods: getQuarterlyPeriodType(
+                filterFuturePeriods,
+                periodSettings
+            ),
             name: i18n.t('Quarterly'),
         },
         {
             id: SIXMONTHLY,
-            getPeriods: getSixMonthlyPeriodType(filterFuturePeriods, calendar),
+            getPeriods: getSixMonthlyPeriodType(
+                filterFuturePeriods,
+                periodSettings
+            ),
             name: i18n.t('Six-monthly'),
         },
         {
             id: SIXMONTHLYAPR,
             getPeriods: getSixMonthlyAprilPeriodType(
                 filterFuturePeriods,
-                calendar
+                periodSettings
             ),
             name: i18n.t('Six-monthly April'),
         },
         {
             id: YEARLY,
-            getPeriods: getYearlyPeriodType(filterFuturePeriods, calendar),
+            getPeriods: getYearlyPeriodType(
+                filterFuturePeriods,
+                periodSettings
+            ),
             name: i18n.t('Yearly'),
         },
         {
             id: FYNOV,
             getPeriods: getFinancialNovemberPeriodType(
                 filterFuturePeriods,
-                calendar
+                periodSettings
             ),
             name: i18n.t('Financial year (Start November)'),
         },
@@ -326,7 +350,7 @@ const getOptions = (calendar = 'gregory') => {
             id: FYOCT,
             getPeriods: getFinancialOctoberPeriodType(
                 filterFuturePeriods,
-                calendar
+                periodSettings
             ),
             name: i18n.t('Financial year (Start October)'),
         },
@@ -334,7 +358,7 @@ const getOptions = (calendar = 'gregory') => {
             id: FYJUL,
             getPeriods: getFinancialJulyPeriodType(
                 filterFuturePeriods,
-                calendar
+                periodSettings
             ),
             name: i18n.t('Financial year (Start July)'),
         },
@@ -342,15 +366,15 @@ const getOptions = (calendar = 'gregory') => {
             id: FYAPR,
             getPeriods: getFinancialAprilPeriodType(
                 filterFuturePeriods,
-                calendar
+                periodSettings
             ),
             name: i18n.t('Financial year (Start April)'),
         },
     ]
 }
 
-export const getFixedPeriodsOptionsById = (id, calendar = 'gregory') => {
-    return getOptions(calendar).find((option) => option.id === id)
+export const getFixedPeriodsOptionsById = (id, periodSettings) => {
+    return getOptions(periodSettings).find((option) => option.id === id)
 }
 
 export const getFixedPeriodsOptions = () => getOptions()

--- a/yarn.lock
+++ b/yarn.lock
@@ -2202,10 +2202,10 @@
     markdown-it "^8.4.2"
     prop-types "^15.6.2"
 
-"@dhis2/multi-calendar-dates@1.0.0-beta.24":
-  version "1.0.0-beta.24"
-  resolved "https://registry.yarnpkg.com/@dhis2/multi-calendar-dates/-/multi-calendar-dates-1.0.0-beta.24.tgz#9a0edb059f8b2430f14aeb98a492f966c26aa548"
-  integrity sha512-PEy0DtIuMSpsdyZLy4QGiELpRgnz2GFJGd2UJXmpcvA/J3yAXEjmxaZID51buCA6xcAvb63MseoBpaNle2H/SQ==
+"@dhis2/multi-calendar-dates@1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@dhis2/multi-calendar-dates/-/multi-calendar-dates-1.0.0.tgz#bf7f49aecdffa9781837a5d60d56a094b74ab4df"
+  integrity sha512-IB9a+feuS6yE4lpZj/eZ9uBmpYI7Hxitl2Op0JjoRL4tP+p6uw4ns9cjoSdUeIU9sOAxVZV7oQqSyIw+9P6YjQ==
   dependencies:
     "@js-temporal/polyfill" "^0.4.2"
     classnames "^2.3.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2202,10 +2202,10 @@
     markdown-it "^8.4.2"
     prop-types "^15.6.2"
 
-"@dhis2/multi-calendar-dates@1.0.0-alpha.18":
-  version "1.0.0-alpha.18"
-  resolved "https://registry.yarnpkg.com/@dhis2/multi-calendar-dates/-/multi-calendar-dates-1.0.0-alpha.18.tgz#341176f1ffb0a4663dd5b882e587403d6dc7fbda"
-  integrity sha512-0m8HcH3j7/FRXdZ+tgnnFjDdoC05JEKsm6XH7m+JZOJlfWshNTrYU5l1JzFumiNO3teFkBS/uFgSZHu7UbKeng==
+"@dhis2/multi-calendar-dates@1.0.0-beta.24":
+  version "1.0.0-beta.24"
+  resolved "https://registry.yarnpkg.com/@dhis2/multi-calendar-dates/-/multi-calendar-dates-1.0.0-beta.24.tgz#9a0edb059f8b2430f14aeb98a492f966c26aa548"
+  integrity sha512-PEy0DtIuMSpsdyZLy4QGiELpRgnz2GFJGd2UJXmpcvA/J3yAXEjmxaZID51buCA6xcAvb63MseoBpaNle2H/SQ==
   dependencies:
     "@js-temporal/polyfill" "^0.4.2"
     classnames "^2.3.2"


### PR DESCRIPTION
Implements [DHIS2-14678](https://dhis2.atlassian.net/browse/DHIS2-14678)

**https://github.com/dhis2/data-visualizer-app/pull/2233**

---

### Key features

1. localise generated fixed periods

---

### Description

This PR changes period generation logic to pass the locale along the calendar type to allow localise the generated fixed periods in the requested calendar, as well as the locale

---

### BREAKING CHANGE

no breaking change


---

### Screenshots

<img width="825" alt="image" src="https://user-images.githubusercontent.com/1014725/220712483-06644a53-384a-445e-82f4-8e745d7ba469.png">

<img width="816" alt="image" src="https://user-images.githubusercontent.com/1014725/219787683-48030df6-efc8-4fb2-a1f9-3e8296d029b9.png">

<img width="823" alt="image" src="https://user-images.githubusercontent.com/1014725/219787880-12b4dc93-4aa0-4ab7-bad4-98d83817c938.png">



[DHIS2-14678]: https://dhis2.atlassian.net/browse/DHIS2-14678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ