### PR TITLE
feat: icon in SV visualization DHIS2-10496

### DIFF
--- a/src/visualizations/config/adapters/dhis_dhis/index.js
+++ b/src/visualizations/config/adapters/dhis_dhis/index.js
@@ -34,5 +34,13 @@ export default function ({ store, layout, extraOptions }) {
         config.subText = indicatorType?.displayName
     }
 
+    // DHIS2-10496: show icon on the side of the value if an icon is assigned in Maintenance app and the option is set in DV options
+    const showIcon = Boolean(layout.icons?.length)
+    const icon = metaData.items[metaData.dimensions.dx[0]].style?.icon
+
+    if (showIcon && icon) {
+        config.icon = icon
+    }
+
     return config
 }

--- a/src/visualizations/config/adapters/dhis_dhis/index.js
+++ b/src/visualizations/config/adapters/dhis_dhis/index.js
@@ -34,13 +34,5 @@ export default function ({ store, layout, extraOptions }) {
         config.subText = indicatorType?.displayName
     }
 
-    // DHIS2-10496: show icon on the side of the value if an icon is assigned in Maintenance app and the option is set in DV options
-    const showIcon = Boolean(layout.icons?.length)
-    const icon = metaData.items[metaData.dimensions.dx[0]].style?.icon
-
-    if (showIcon && icon) {
-        config.icon = icon
-    }
-
     return config
 }

--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -150,10 +150,12 @@ const generateDashboardItem = (
     const container = document.createElement('div')
     container.setAttribute(
         'style',
-        `display: flex; flex-direction: column; align-items: center; justify-content: center; width: 100%; height: 100%; padding-top: 6px; background-color:${backgroundColor};`
+        `display: flex; flex-direction: column; align-items: center; justify-content: center; width: 100%; height: 100%; background-color:${backgroundColor};`
     )
 
-    const titleStyle = `font-size: 12px; color: ${titleColor || '#666'};`
+    const titleStyle = `padding: 0 8px; text-align: center; font-size: 12px; color: ${
+        titleColor || '#666'
+    };`
 
     const title = document.createElement('span')
     title.setAttribute('style', titleStyle)
@@ -165,10 +167,7 @@ const generateDashboardItem = (
 
     if (config.subtitle) {
         const subtitle = document.createElement('span')
-        subtitle.setAttribute(
-            'style',
-            titleStyle + ' margin-top: 4px; padding: 0 8px; text-align: center'
-        )
+        subtitle.setAttribute('style', titleStyle + ' margin-top: 4px;')
 
         subtitle.appendChild(document.createTextNode(config.subtitle))
 

--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -396,32 +396,7 @@ export default function (
     parentEl.style.overflow = 'hidden'
     parentEl.style.display = 'flex'
     parentEl.style.justifyContent = 'center'
-    /*
-    if (dashboard) {
-        parentEl.style.borderRadius = spacers.dp8
-        return generateDashboardItem(config, {
-            valueColor,
-            backgroundColor,
-            noData,
-            ...(shouldUseContrastColor(legendColor)
-                ? { titleColor: colors.white }
-                : {}),
-        })
-    } else {
-        parentEl.style.height = `100%`
-        return generateDVItem(config, {
-            valueColor,
-            backgroundColor,
-            titleColor,
-            parentEl,
-            fontStyle,
-            noData,
-        })
-    }
-*/
-    parentEl.style.borderRadius = spacers.dp8
     parentEl.style.margin = spacers.dp8
-    parentEl.style.height = `calc(100% - (${spacers.dp8} * 2))`
 
     const parentElBBox = parentEl.getBoundingClientRect()
     const width = parentElBBox.width
@@ -433,21 +408,32 @@ export default function (
     svgContainer.setAttribute('height', '100%')
     svgContainer.setAttribute('data-test', 'visualization-container')
 
-    return dashboard
-        ? generateDashboardItem(config, {
-              svgContainer,
-              width,
-              height,
-              valueColor,
-              noData,
-          })
-        : generateDVItem(config, {
-              svgContainer,
-              width,
-              height,
-              valueColor,
-              noData,
-              titleColor,
-              fontStyle,
-          })
+    if (dashboard) {
+        parentEl.style.borderRadius = spacers.dp8
+
+        return generateDashboardItem(config, {
+            svgContainer,
+            width,
+            height,
+            valueColor,
+            backgroundColor,
+            noData,
+            ...(shouldUseContrastColor(legendColor)
+                ? { titleColor: colors.white }
+                : {}),
+        })
+    } else {
+        parentEl.style.height = `100%`
+
+        return generateDVItem(config, {
+            svgContainer,
+            width,
+            height,
+            valueColor,
+            backgroundColor,
+            titleColor,
+            noData,
+            fontStyle,
+        })
+    }
 }

--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -356,7 +356,7 @@ const generateDVItem = (
     return svgContainer
 }
 
-const shouldUseContrastColor = (inputColor) => {
+const shouldUseContrastColor = (inputColor = '') => {
     // based on https://stackoverflow.com/questions/3942878/how-to-decide-font-color-in-white-or-black-depending-on-background-color
     var color =
         inputColor.charAt(0) === '#' ? inputColor.substring(1, 7) : inputColor
@@ -418,7 +418,7 @@ export default function (
             valueColor,
             backgroundColor,
             noData,
-            ...(shouldUseContrastColor(legendColor)
+            ...(legendColor && shouldUseContrastColor(legendColor)
                 ? { titleColor: colors.white }
                 : {}),
         })

--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -395,7 +395,6 @@ export default function (
     parentEl.style.overflow = 'hidden'
     parentEl.style.display = 'flex'
     parentEl.style.justifyContent = 'center'
-    parentEl.style.margin = spacers.dp8
 
     const parentElBBox = parentEl.getBoundingClientRect()
     const width = parentElBBox.width

--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -167,7 +167,7 @@ const generateDashboardItem = (
         const subtitle = document.createElement('span')
         subtitle.setAttribute(
             'style',
-            titleStyle + ' margin-top: 4px; padding: 0 8px'
+            titleStyle + ' margin-top: 4px; padding: 0 8px; text-align: center'
         )
 
         subtitle.appendChild(document.createTextNode(config.subtitle))

--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -403,6 +403,7 @@ export default function (
     const height = parentElBBox.height
 
     const svgContainer = document.createElementNS(svgNS, 'svg')
+    svgContainer.setAttribute('xmlns', svgNS)
     svgContainer.setAttribute('viewBox', `0 0 ${width} ${height}`)
     svgContainer.setAttribute('width', '100%')
     svgContainer.setAttribute('height', '100%')

--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -31,6 +31,7 @@ const generateValueSVG = ({
 }) => {
     const ratio = containerHeight / containerWidth
     const iconSize = 300
+    const iconPadding = 50
     const textSize = iconSize * 0.85
     const textWidth = textSize * 0.75 * formattedValue.length
 
@@ -39,7 +40,7 @@ const generateValueSVG = ({
     let viewBoxWidth = textWidth
 
     if (showIcon) {
-        viewBoxWidth += iconSize
+        viewBoxWidth += iconSize + iconPadding
     }
 
     const viewBoxHeight = viewBoxWidth * ratio
@@ -67,7 +68,7 @@ const generateValueSVG = ({
         iconSvgNode.setAttribute('height', iconSize)
         iconSvgNode.setAttribute('viewBox', '0 0 48 48')
         iconSvgNode.setAttribute('y', `-${iconSize / 2}`)
-        iconSvgNode.setAttribute('x', `-${textWidth / 2}`)
+        iconSvgNode.setAttribute('x', `-${(textWidth + iconPadding) / 2}`)
         iconSvgNode.setAttribute('style', `color: ${fillColor}`)
 
         // embed icon to allow changing color
@@ -85,7 +86,10 @@ const generateValueSVG = ({
     textNode.setAttribute('font-size', textSize)
     textNode.setAttribute('font-weight', '300')
     textNode.setAttribute('letter-spacing', '-5')
-    textNode.setAttribute('x', showIcon ? `-${textWidth / 2 - iconSize}` : 0)
+    textNode.setAttribute(
+        'x',
+        showIcon ? `-${(textWidth - iconPadding) / 2 - iconSize}` : 0
+    )
     textNode.setAttribute('y', 0)
     textNode.setAttribute('fill', fillColor)
     textNode.setAttribute('alignment-baseline', 'central')

--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -75,6 +75,9 @@ const generateValueSVG = ({
         // (elements with fill need to use "currentColor" for this to work)
         fetch(icon)
             .then((res) => res.text())
+            .then((originalSvgIcon) =>
+                originalSvgIcon.replaceAll('#333333', 'currentColor')
+            )
             .then((svgIcon) => {
                 iconSvgNode.insertAdjacentHTML('beforeend', svgIcon)
             })

--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -24,23 +24,32 @@ const generateValueSVG = ({
     formattedValue,
     subText,
     valueColor,
+    icon,
     noData,
-    y,
+    containerWidth,
+    containerHeight,
 }) => {
-    const textSize = 300
+    const ratio = containerHeight / containerWidth
+    const iconSize = 300
+    const textSize = iconSize * 0.85
+    const textWidth = textSize * 0.75 * formattedValue.length
+
+    let viewBoxWidth = textWidth
+
+    if (icon) {
+        viewBoxWidth += iconSize
+    }
+
+    const viewBoxHeight = viewBoxWidth * ratio
 
     const svgValue = document.createElementNS(svgNS, 'svg')
     svgValue.setAttribute('xmlns', svgNS)
-    svgValue.setAttribute(
-        'viewBox',
-        `0 -${textSize + 50} ${textSize * 0.75 * formattedValue.length} ${
-            textSize + 200
-        }`
-    )
-
-    if (y) {
-        svgValue.setAttribute('y', y)
-    }
+    svgValue.setAttribute('viewBox', `0 0 ${viewBoxWidth} ${viewBoxHeight}`)
+    svgValue.setAttribute('width', containerWidth * 0.95)
+    svgValue.setAttribute('height', containerHeight * 0.95)
+    svgValue.setAttribute('x', '50%')
+    svgValue.setAttribute('y', '50%')
+    svgValue.setAttribute('style', 'overflow: visible')
 
     let fillColor = colors.grey900
 
@@ -50,46 +59,56 @@ const generateValueSVG = ({
         fillColor = colors.grey600
     }
 
+    // show icon if configured in maintenance app
+    if (icon) {
+        const imageNode = document.createElementNS(svgNS, 'image')
+        imageNode.setAttribute('href', icon)
+        imageNode.setAttribute('width', iconSize)
+        imageNode.setAttribute('height', iconSize)
+        imageNode.setAttribute('y', `-${iconSize / 2}`)
+        imageNode.setAttribute('x', `-${textWidth / 2}`)
+
+        svgValue.appendChild(imageNode)
+    }
+
     const textNode = document.createElementNS(svgNS, 'text')
-    textNode.setAttribute('text-anchor', 'middle')
     textNode.setAttribute('font-size', textSize)
     textNode.setAttribute('font-weight', '300')
     textNode.setAttribute('letter-spacing', '-5')
-    textNode.setAttribute('x', '50%')
+    textNode.setAttribute('x', icon ? `-${textWidth / 2 - iconSize}` : 0)
+    textNode.setAttribute('y', 0)
     textNode.setAttribute('fill', fillColor)
+    textNode.setAttribute('alignment-baseline', 'central')
     textNode.setAttribute('data-test', 'visualization-primary-value')
+
+    if (!icon) {
+        textNode.setAttribute('text-anchor', 'middle')
+    }
+
     textNode.appendChild(document.createTextNode(formattedValue))
 
     svgValue.appendChild(textNode)
 
     if (subText) {
-        const svgSubText = document.createElementNS(svgNS, 'svg')
         const subTextSize = 40
-        svgSubText.setAttribute(
-            'viewBox',
-            `0 -50 ${textSize * 0.75 * formattedValue.length} ${textSize + 200}`
-        )
-
-        if (y) {
-            svgSubText.setAttribute('y', y)
-        }
 
         const subTextNode = document.createElementNS(svgNS, 'text')
         subTextNode.setAttribute('text-anchor', 'middle')
         subTextNode.setAttribute('font-size', subTextSize)
-        subTextNode.setAttribute('x', '50%')
-        subTextNode.setAttribute('x', '50%')
+        subTextNode.setAttribute('y', iconSize / 2)
         subTextNode.setAttribute('fill', colors.grey600)
+        subTextNode.setAttribute('alignment-baseline', 'hanging')
         subTextNode.appendChild(document.createTextNode(subText))
 
-        svgSubText.appendChild(subTextNode)
-
-        svgValue.appendChild(svgSubText)
+        svgValue.appendChild(subTextNode)
     }
 
     return svgValue
 }
 
+/* commented out to keep the code for comparison with generateItem.
+ * dashboard does not need all of the features as for DV app
+ 
 const generateDashboardItem = (
     config,
     { valueColor, titleColor, backgroundColor, noData }
@@ -125,6 +144,7 @@ const generateDashboardItem = (
     container.appendChild(
         generateValueSVG({
             formattedValue: config.formattedValue,
+            icon: config.icon,
             subText: config.subText,
             valueColor,
             noData,
@@ -134,6 +154,7 @@ const generateDashboardItem = (
 
     return container
 }
+*/
 
 const getTextAnchorFromTextAlign = (textAlign) => {
     switch (textAlign) {
@@ -159,7 +180,7 @@ const getXFromTextAlign = (textAlign) => {
     }
 }
 
-const generateDVItem = (
+const generateItem = (
     config,
     { valueColor, backgroundColor, titleColor, parentEl, fontStyle, noData }
 ) => {
@@ -186,6 +207,8 @@ const generateDVItem = (
         background.setAttribute('fill', backgroundColor)
         svg.appendChild(background)
     }
+
+    const svgWrapper = document.createElementNS(svgNS, 'svg')
 
     const title = document.createElementNS(svgNS, 'text')
     const titleFontStyle = mergeFontStyleWithDefault(
@@ -234,7 +257,7 @@ const generateDVItem = (
     if (config.title) {
         title.appendChild(document.createTextNode(config.title))
 
-        svg.appendChild(title)
+        svgWrapper.appendChild(title)
     }
 
     const subtitleFontStyle = mergeFontStyleWithDefault(
@@ -291,16 +314,20 @@ const generateDVItem = (
     if (config.subtitle) {
         subtitle.appendChild(document.createTextNode(config.subtitle))
 
-        svg.appendChild(subtitle)
+        svgWrapper.appendChild(subtitle)
     }
+
+    svg.appendChild(svgWrapper)
 
     svg.appendChild(
         generateValueSVG({
             formattedValue: config.formattedValue,
+            icon: config.icon,
             subText: config.subText,
             valueColor,
             noData,
-            y: 20,
+            containerWidth: width,
+            containerHeight: height,
         })
     )
 
@@ -328,7 +355,7 @@ const shouldUseContrastColor = (inputColor) => {
 export default function (
     config,
     parentEl,
-    { dashboard, legendSets, fontStyle, noData, legendOptions }
+    { legendSets, fontStyle, noData, legendOptions }
 ) {
     const legendSet = legendOptions && legendSets[0]
     const legendColor =
@@ -347,7 +374,7 @@ export default function (
     parentEl.style.overflow = 'hidden'
     parentEl.style.display = 'flex'
     parentEl.style.justifyContent = 'center'
-
+    /*
     if (dashboard) {
         parentEl.style.borderRadius = spacers.dp8
         return generateDashboardItem(config, {
@@ -369,4 +396,17 @@ export default function (
             noData,
         })
     }
+*/
+    parentEl.style.borderRadius = spacers.dp8
+    parentEl.style.margin = spacers.dp8
+    parentEl.style.height = `calc(100% - (${spacers.dp8} * 2))`
+
+    // TODO pass dashboard and toggle styles and other things not desired in dashboard...
+    return generateItem(config, {
+        valueColor,
+        titleColor,
+        parentEl,
+        fontStyle,
+        noData,
+    })
 }


### PR DESCRIPTION
Implements [DHIS2-10496](https://dhis2.atlassian.net/browse/DHIS2-10496)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/2236**

---

### Key features

1. embed SVG icon on left of SV value

---

### Description

An icon can be assigned to a DE/indicator in Maintenance app.
In DV app there is a new option for Single Value visualizations for showing this icon on the side of the value.

Currently the SVG icon is embedded via a `image` tag in the main SV SVG.

---

### TODO

-   [x] when in dashboard, disable font styles on title/subtitle
-   [x] figure out how to change the icon color to match the value color

---

### Known issues

-   [ ] if a subtitle is very long, it gets cut off on the sides
-   [x] is not possible to change the icon color according to the legend applied: the main reason is that the SVG icons have a specific color for the fill of the various SVG elements. It's possible to change the color via CSS, but the icons need  to be modified to use `currentColor` instead of a specific color in their fill, stroke attributes. **Solved by replacing the hardcoded color with `currentColor` after fetching the SVG from the API.**

---

### Screenshots

Example in DV:
<img width="1221" alt="Screenshot 2023-03-02 at 10 53 19" src="https://user-images.githubusercontent.com/150978/222400985-4dd1b1d4-cc04-4d57-9ae8-e8ad94170b11.png">

With contrast color applied:
<img width="856" alt="Screenshot 2023-04-14 at 16 31 29" src="https://user-images.githubusercontent.com/150978/232073864-4d01d63d-5500-42aa-a750-03586fae3abd.png">


Example in dashboard:
<img width="521" alt="Screenshot 2023-03-02 at 10 30 10" src="https://user-images.githubusercontent.com/150978/222401034-74ab8114-82d1-402d-a6e7-e7ad72708e6b.png">

Screencast of the toggling of the icon in DV:
https://user-images.githubusercontent.com/150978/222401093-f64acb37-70e2-41d4-ae4b-5b9f4550e8d5.mov



[DHIS2-10496]: https://dhis2.atlassian.net/browse/DHIS2-10496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ