### PR TITLE
fix: operands should look and act like data elements

### DIFF
--- a/src/__demo__/CalculationModal.stories.js
+++ b/src/__demo__/CalculationModal.stories.js
@@ -14,16 +14,6 @@ const DATA_ELEMENTS = {
     },
     dataElements: [
         {
-            dimensionItemType: 'DATA_ELEMENT_OPERAND',
-            id: 'fbfJHSPpUQD.pq2XI5kz2BY',
-            name: 'ANC 1st visit Fixed',
-        },
-        {
-            dimensionItemType: 'DATA_ELEMENT_OPERAND',
-            id: 'fbfJHSPpUQD.PT59n8BQbqM',
-            name: 'ANC 1st visit Outreach',
-        },
-        {
             dimensionItemType: 'DATA_ELEMENT',
             id: 'fbfJHSPpUQD',
             name: 'ANC 1st visit',
@@ -103,6 +93,29 @@ const DATA_ELEMENTS = {
             dimensionItemType: 'DATA_ELEMENT',
             id: 'HLPuaFB7Frw',
             name: 'Anaemia new',
+        },
+    ],
+}
+
+const DATA_ELEMENT_OPERANDS = {
+    pager: {
+        page: 1,
+        pageCount: 43,
+        total: 2122,
+        pageSize: 50,
+        nextPage:
+            'https://debug.dhis2.org/dev/api/dataElementOperands.json?page=2',
+    },
+    dataElementOperands: [
+        {
+            dimensionItemType: 'DATA_ELEMENT_OPERAND',
+            id: 'fbfJHSPpUQD.pq2XI5kz2BY',
+            name: 'ANC 1st visit Fixed',
+        },
+        {
+            dimensionItemType: 'DATA_ELEMENT_OPERAND',
+            id: 'fbfJHSPpUQD.PT59n8BQbqM',
+            name: 'ANC 1st visit Outreach',
         },
     ],
 }
@@ -202,6 +215,12 @@ const calculation = {
     expression: '#{fbfJHSPpUQD}/10*#{hfdmMSPBgLG}',
 }
 
+const calculationWithOperand = {
+    id: 'calcid2',
+    name: 'Calculation with operand',
+    expression: '#{cYeuwXTCPkU}*10-#{fbfJHSPpUQD.pq2XI5kz2BY}',
+}
+
 storiesOf('CalculationModal', module)
     .add('Default', () => {
         return (
@@ -209,6 +228,7 @@ storiesOf('CalculationModal', module)
                 data={{
                     dataElements: DATA_ELEMENTS,
                     dataElementGroups: DATA_ELEMENT_GROUPS,
+                    dataElementOperands: DATA_ELEMENT_OPERANDS,
                 }}
             >
                 <CalculationModal
@@ -226,10 +246,30 @@ storiesOf('CalculationModal', module)
                 data={{
                     dataElements: DATA_ELEMENTS,
                     dataElementGroups: DATA_ELEMENT_GROUPS,
+                    dataElementOperands: DATA_ELEMENT_OPERANDS,
                 }}
             >
                 <CalculationModal
                     calculation={calculation}
+                    displayNameProp="name"
+                    onClose={Function.prototype}
+                    onDelete={Function.prototype}
+                    onSave={Function.prototype}
+                />
+            </CustomDataProvider>
+        )
+    })
+    .add('With calculation containing operand', () => {
+        return (
+            <CustomDataProvider
+                data={{
+                    dataElements: DATA_ELEMENTS,
+                    dataElementGroups: DATA_ELEMENT_GROUPS,
+                    dataElementOperands: DATA_ELEMENT_OPERANDS,
+                }}
+            >
+                <CalculationModal
+                    calculation={calculationWithOperand}
                     displayNameProp="name"
                     onClose={Function.prototype}
                     onDelete={Function.prototype}

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -18,7 +18,7 @@ import {
     parseExpressionToArray,
     parseArrayToExpression,
     validateExpression,
-    EXPRESSION_TYPE_DATA_ELEMENT,
+    EXPRESSION_TYPE_DATA,
     EXPRESSION_TYPE_NUMBER,
     INVALID_EXPRESSION,
     VALID_EXPRESSION,
@@ -75,6 +75,7 @@ const CalculationModal = ({
                 ...(data.dataElements?.dataElements || []),
                 ...(data.dataElementOperands?.dataElementOperands || []),
             ]
+
             setExpressionArray(
                 parseExpressionToArray(calculation.expression, metadata).map(
                     (item, i) => ({
@@ -126,8 +127,7 @@ const CalculationModal = ({
 
         const newItem = {
             id: `${type}-${newIdCount}`,
-            value:
-                type === EXPRESSION_TYPE_DATA_ELEMENT ? `#{${value}}` : value,
+            value: type === EXPRESSION_TYPE_DATA ? `#{${value}}` : value,
             label,
             type,
         }
@@ -201,6 +201,8 @@ const CalculationModal = ({
             moveItem({ sourceIndex: item.sourceIndex, destIndex })
         }
     }
+
+    console.log('expressionArray', expressionArray)
 
     return (
         <>

--- a/src/components/DataDimension/CalculationModal.js
+++ b/src/components/DataDimension/CalculationModal.js
@@ -202,8 +202,6 @@ const CalculationModal = ({
         }
     }
 
-    console.log('expressionArray', expressionArray)
-
     return (
         <>
             <Modal dataTest="calculation-modal" position="top" large>

--- a/src/components/DataDimension/DraggableTransferOption.js
+++ b/src/components/DataDimension/DraggableTransferOption.js
@@ -3,6 +3,7 @@ import { CSS } from '@dnd-kit/utilities'
 import PropTypes from 'prop-types'
 import React from 'react'
 import { getIcon, getTooltipText } from '../../modules/dimensionListItem.js'
+import { EXPRESSION_TYPE_DATA } from '../../modules/expressions.js'
 import { TransferOption } from '../TransferOption.js'
 import styles from './styles/DraggableTransferOption.style.js'
 
@@ -15,7 +16,7 @@ const DraggableTransferOption = ({
 }) => {
     const { attributes, listeners, setNodeRef, transform } = useSortable({
         id: value,
-        data: { value, label, type, index: -1 },
+        data: { value, label, type: EXPRESSION_TYPE_DATA, index: -1 },
         disabled,
     })
     const style = {

--- a/src/components/DataDimension/DraggableTransferOption.js
+++ b/src/components/DataDimension/DraggableTransferOption.js
@@ -14,9 +14,10 @@ const DraggableTransferOption = ({
     disabled,
     onDoubleClick,
 }) => {
+    const data = { label, value, type: EXPRESSION_TYPE_DATA }
     const { attributes, listeners, setNodeRef, transform } = useSortable({
         id: value,
-        data: { value, label, type: EXPRESSION_TYPE_DATA, index: -1 },
+        data,
         disabled,
     })
     const style = {
@@ -43,9 +44,7 @@ const DraggableTransferOption = ({
                     })}
                     disabled={disabled}
                     onClick={Function.prototype}
-                    onDoubleClick={({ label, value }) =>
-                        onDoubleClick({ label, value, type })
-                    }
+                    onDoubleClick={() => onDoubleClick(data)}
                     dataTest="dimension-option"
                 />
             </div>

--- a/src/components/DataDimension/DraggingItem.js
+++ b/src/components/DataDimension/DraggingItem.js
@@ -4,7 +4,7 @@ import React from 'react'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../modules/dataTypes.js'
 import { getIcon } from '../../modules/dimensionListItem.js'
 import {
-    EXPRESSION_TYPE_DATA_ELEMENT,
+    EXPRESSION_TYPE_DATA,
     EXPRESSION_TYPE_NUMBER,
     EXPRESSION_TYPE_OPERATOR,
 } from '../../modules/expressions.js'
@@ -20,10 +20,10 @@ const DraggingItem = ({ label, type, value }) => {
                 className={cx('dragging-item', {
                     operator: type === EXPRESSION_TYPE_OPERATOR,
                     number: type === EXPRESSION_TYPE_NUMBER,
-                    'data-element': type === EXPRESSION_TYPE_DATA_ELEMENT,
+                    data: type === EXPRESSION_TYPE_DATA,
                 })}
             >
-                {type === EXPRESSION_TYPE_DATA_ELEMENT && (
+                {type === EXPRESSION_TYPE_DATA && (
                     <span className="icon">
                         {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
                     </span>

--- a/src/components/DataDimension/FormulaItem.js
+++ b/src/components/DataDimension/FormulaItem.js
@@ -7,7 +7,7 @@ import { DIMENSION_TYPE_DATA_ELEMENT } from '../../modules/dataTypes.js'
 import { getIcon } from '../../modules/dimensionListItem.js'
 import {
     EXPRESSION_TYPE_NUMBER,
-    EXPRESSION_TYPE_DATA_ELEMENT,
+    EXPRESSION_TYPE_DATA,
 } from '../../modules/expressions.js'
 import DragHandleIcon from './DragHandleIcon.js'
 import styles from './styles/FormulaItem.style.js'
@@ -143,13 +143,13 @@ const FormulaItem = ({
             )
         }
 
-        if (type === EXPRESSION_TYPE_DATA_ELEMENT) {
+        if (type === EXPRESSION_TYPE_DATA) {
             return (
                 <>
                     <span className="icon">
                         {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
                     </span>
-                    <span className="data-element-label">{label}</span>
+                    <span className="data-label">{label}</span>
                     <style jsx>{styles}</style>
                 </>
             )

--- a/src/components/DataDimension/styles/DraggingItem.style.js
+++ b/src/components/DataDimension/styles/DraggingItem.style.js
@@ -19,7 +19,7 @@ export default css`
         padding: ${spacers.dp4} ${spacers.dp8};
     }
 
-    .data-element {
+    .data {
         padding: ${spacers.dp4};
     }
 

--- a/src/components/DataDimension/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/styles/FormulaItem.style.js
@@ -58,7 +58,7 @@ export default css`
         padding: 0 6px;
     }
 
-    .data-element-label {
+    .data-label {
         padding: 0 4px;
         max-width: 280px;
         text-overflow: ellipsis;

--- a/src/modules/__tests__/expressions.spec.js
+++ b/src/modules/__tests__/expressions.spec.js
@@ -2,7 +2,7 @@ import {
     validateExpression,
     parseArrayToExpression,
     parseExpressionToArray,
-    EXPRESSION_TYPE_DATA_ELEMENT,
+    EXPRESSION_TYPE_DATA,
     EXPRESSION_TYPE_NUMBER,
     EXPRESSION_TYPE_OPERATOR,
     INVALID_EXPRESSION,
@@ -63,13 +63,13 @@ describe('parseArrayToExpression', () => {
             {
                 label: 'abc123',
                 value: '#{abc123}',
-                type: EXPRESSION_TYPE_DATA_ELEMENT,
+                type: EXPRESSION_TYPE_DATA,
             },
             { label: '+', value: '+', type: EXPRESSION_TYPE_OPERATOR },
             {
                 label: 'def456.xyz999',
                 value: '#{def456.xyz999}',
-                type: EXPRESSION_TYPE_DATA_ELEMENT,
+                type: EXPRESSION_TYPE_DATA,
             },
             { label: '/', value: '/', type: EXPRESSION_TYPE_OPERATOR },
             { label: '10', value: '10', type: EXPRESSION_TYPE_NUMBER },
@@ -87,7 +87,7 @@ describe('parseExpressionToArray', () => {
             {
                 label: 'abc123',
                 value: '#{abc123}',
-                type: EXPRESSION_TYPE_DATA_ELEMENT,
+                type: EXPRESSION_TYPE_DATA,
             },
             { label: '/', value: '/', type: EXPRESSION_TYPE_OPERATOR },
             { label: '10', value: '10', type: EXPRESSION_TYPE_NUMBER },

--- a/src/modules/expressions.js
+++ b/src/modules/expressions.js
@@ -1,9 +1,8 @@
 import i18n from '../locales/index.js'
-import { DIMENSION_TYPE_DATA_ELEMENT } from './dataTypes.js'
 
 export const EXPRESSION_TYPE_NUMBER = 'EXPRESSION_TYPE_NUMBER'
 export const EXPRESSION_TYPE_OPERATOR = 'EXPRESSION_TYPE_OPERATOR'
-export const EXPRESSION_TYPE_DATA_ELEMENT = DIMENSION_TYPE_DATA_ELEMENT
+export const EXPRESSION_TYPE_DATA = 'EXPRESSION_TYPE_DATA'
 
 export const VALID_EXPRESSION = 'OK'
 export const INVALID_EXPRESSION = 'ERROR'
@@ -34,7 +33,7 @@ export const parseExpressionToArray = (expression = '', metadata = []) => {
                 const id = value.slice(2, -1)
                 const label =
                     metadata.find((item) => item.id === id)?.name || id
-                return { value, label, type: EXPRESSION_TYPE_DATA_ELEMENT }
+                return { value, label, type: EXPRESSION_TYPE_DATA }
             }
 
             if (isNaN(value)) {


### PR DESCRIPTION
- when an operand is added to the formula, it is now given the same EXPRESSION_TYPE_DATA as data elements. This way it gets the same styling and is given the same markers in the expression `#{xyz.pdq}`

The only real change is in DraggableTransferOption where the type is set to EXPRESSION_TYPE_DATA instead of using the original backend types of DATA_ELEMENT and DATA_ELEMENT_OPERAND when they are added (either by dropping or doubleclicking)

The rest of the changes are just renaming to EXPRESSION_TYPE_DATA (to encompass both element and element operand)

- added a story for testing
![image](https://user-images.githubusercontent.com/6113918/222446100-8be0cbb1-2f1a-4324-9c43-5837c5f8e9af.png)
