### PR TITLE
FIX: removing duplicate app path name from links [DHIS2-14879]

### DIFF
--- a/src/components/FileMenu/GetLinkDialog.js
+++ b/src/components/FileMenu/GetLinkDialog.js
@@ -14,7 +14,7 @@ export const GetLinkDialog = ({ type, id, onClose }) => {
     // TODO simply use href from the visualization object?
     const appUrl = new URL(
         appPathFor(type, id),
-        `${window.location.origin}${window.location.pathname}`
+        `${window.location.origin}`
     )
 
     return (


### PR DESCRIPTION
[Update:](https://github.com/dhis2/analytics/pull/1449)
Implements [DHIS2-1489](https://dhis2.atlassian.net/browse/DHIS2-14879)

**Relates to https://github.com/dhis2/data-visualizer-app/**
as well as
**[https://github.com/dhis2/maps-app](https://github.com/dhis2/maps-app)**

---

### Fix

Fixing the Get Link option in the File Menu bar.

---

### Description

appPathFor already returns the app path name, so including the app path again when creating the URL link is creating a duplicate app path name. The fix here is to remove the app path name from the URL() base. Hopefully this should fix it. Please test! Thanks!

---

### Screenshots
![image](https://user-images.githubusercontent.com/45095831/223454277-67215b91-80c5-42cb-8ee0-cd26275e8075.png)


[DHIS2-1489]: https://dhis2.atlassian.net/browse/DHIS2-1489?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ