### PR TITLE
fix: spacing in Rename and SaveAs dialogs

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2022-12-29T10:50:42.111Z\n"
-"PO-Revision-Date: 2022-12-29T10:50:42.111Z\n"
+"POT-Creation-Date: 2023-03-10T10:41:22.719Z\n"
+"PO-Revision-Date: 2023-03-10T10:41:22.719Z\n"
 
 msgid "view only"
 msgstr "view only"
@@ -592,48 +592,6 @@ msgstr "Selected Periods"
 
 msgid "No periods selected"
 msgstr "No periods selected"
-
-msgid "January"
-msgstr "January"
-
-msgid "February"
-msgstr "February"
-
-msgid "March"
-msgstr "March"
-
-msgid "April"
-msgstr "April"
-
-msgid "May"
-msgstr "May"
-
-msgid "June"
-msgstr "June"
-
-msgid "July"
-msgstr "July"
-
-msgid "August"
-msgstr "August"
-
-msgid "September"
-msgstr "September"
-
-msgid "October"
-msgstr "October"
-
-msgid "November"
-msgstr "November"
-
-msgid "December"
-msgstr "December"
-
-msgid "Week {{weekNumber}}"
-msgstr "Week {{weekNumber}}"
-
-msgid "Bi-Week {{biWeekNumber}}"
-msgstr "Bi-Week {{biWeekNumber}}"
 
 msgid "Daily"
 msgstr "Daily"

--- a/src/components/FileMenu/FileMenu.styles.js
+++ b/src/components/FileMenu/FileMenu.styles.js
@@ -42,3 +42,11 @@ export const fileMenuStyles = css`
         outline: none;
     }
 `
+
+export const modalStyles = css`
+    .modal-content {
+        display: flex;
+        flex-direction: column;
+        gap: ${spacers.dp12};
+    }
+`

--- a/src/components/FileMenu/RenameDialog.js
+++ b/src/components/FileMenu/RenameDialog.js
@@ -12,6 +12,7 @@ import {
 import PropTypes from 'prop-types'
 import React, { useMemo, useState } from 'react'
 import i18n from '../../locales/index.js'
+import { modalStyles } from './FileMenu.styles.js'
 import {
     supportedFileTypes,
     endpointFromFileType,
@@ -30,7 +31,7 @@ export const RenameDialog = ({ type, object, onClose, onRename, onError }) => {
     const [name, setName] = useState(object.name)
     const [description, setDescription] = useState(object.description)
 
-    const mutation = useMemo(() => getMutation(type), [])
+    const mutation = useMemo(() => getMutation(type), [type])
     const [mutate, { loading }] = useDataMutation(mutation, {
         onError: (error) => {
             onError(error)
@@ -52,26 +53,29 @@ export const RenameDialog = ({ type, object, onClose, onRename, onError }) => {
 
     return (
         <Modal onClose={onClose}>
+            <style jsx>{modalStyles}</style>
             <ModalTitle>
                 {i18n.t('Rename {{fileType}}', {
                     fileType: labelForFileType(type),
                 })}
             </ModalTitle>
             <ModalContent>
-                <InputField
-                    label={i18n.t('Name')}
-                    disabled={loading}
-                    required
-                    value={name}
-                    onChange={({ value }) => setName(value)}
-                />
-                <TextAreaField
-                    label={i18n.t('Description')}
-                    disabled={loading}
-                    value={description}
-                    rows={3}
-                    onChange={({ value }) => setDescription(value)}
-                />
+                <div className="modal-content">
+                    <InputField
+                        label={i18n.t('Name')}
+                        disabled={loading}
+                        required
+                        value={name}
+                        onChange={({ value }) => setName(value)}
+                    />
+                    <TextAreaField
+                        label={i18n.t('Description')}
+                        disabled={loading}
+                        value={description}
+                        rows={3}
+                        onChange={({ value }) => setDescription(value)}
+                    />
+                </div>
             </ModalContent>
             <ModalActions>
                 <ButtonStrip>

--- a/src/components/FileMenu/SaveAsDialog.js
+++ b/src/components/FileMenu/SaveAsDialog.js
@@ -11,6 +11,7 @@ import {
 import PropTypes from 'prop-types'
 import React, { useState } from 'react'
 import i18n from '../../locales/index.js'
+import { modalStyles } from './FileMenu.styles.js'
 import { supportedFileTypes, labelForFileType } from './utils.js'
 
 const NAME_MAXLENGTH = 230
@@ -37,27 +38,30 @@ export const SaveAsDialog = ({ type, object, onClose, onSaveAs }) => {
 
     return (
         <Modal onClose={onClose} dataTest="file-menu-saveas-modal">
+            <style jsx>{modalStyles}</style>
             <ModalTitle>
                 {i18n.t('Save {{fileType}} as', {
                     fileType: labelForFileType(type),
                 })}
             </ModalTitle>
             <ModalContent>
-                <InputField
-                    label={i18n.t('Name')}
-                    value={name}
-                    onChange={({ value }) =>
-                        setName(value.substring(0, NAME_MAXLENGTH))
-                    }
-                    dataTest="file-menu-saveas-modal-name"
-                />
-                <TextAreaField
-                    label={i18n.t('Description')}
-                    value={description}
-                    rows={3}
-                    onChange={({ value }) => setDescription(value)}
-                    dataTest="file-menu-saveas-modal-description"
-                />
+                <div className="modal-content">
+                    <InputField
+                        label={i18n.t('Name')}
+                        value={name}
+                        onChange={({ value }) =>
+                            setName(value.substring(0, NAME_MAXLENGTH))
+                        }
+                        dataTest="file-menu-saveas-modal-name"
+                    />
+                    <TextAreaField
+                        label={i18n.t('Description')}
+                        value={description}
+                        rows={3}
+                        onChange={({ value }) => setDescription(value)}
+                        dataTest="file-menu-saveas-modal-description"
+                    />
+                </div>
             </ModalContent>
             <ModalActions>
                 <ButtonStrip>


### PR DESCRIPTION

### Key features

1. fix spacing between name and description input fields

---

### Description

See screenshots.

---

### Screenshots

Before:
<img width="615" alt="Screenshot 2023-03-10 at 14 49 43" src="https://user-images.githubusercontent.com/150978/224332822-e559628b-53ee-4923-9ef3-67f084ec4046.png">

<img width="612" alt="Screenshot 2023-03-10 at 14 52 31" src="https://user-images.githubusercontent.com/150978/224333425-f5e52134-d7d3-40a4-885a-7abe13b10dfd.png">


After:
<img width="612" alt="Screenshot 2023-03-10 at 14 49 34" src="https://user-images.githubusercontent.com/150978/224332840-b0418b04-dabf-41ae-aacd-e8d0152b70fe.png">

<img width="607" alt="Screenshot 2023-03-10 at 14 52 20" src="https://user-images.githubusercontent.com/150978/224333451-c7142c05-bb0c-4b62-bcc9-5c5bf910003d.png">

