### PR TITLE
fix: prevent wrong URL with duplicated path parts DHIS2-14879

### DIFF
--- a/src/components/FileMenu/GetLinkDialog.js
+++ b/src/components/FileMenu/GetLinkDialog.js
@@ -1,27 +1,39 @@
+import { useConfig } from '@dhis2/app-runtime'
 import {
     Modal,
     ModalContent,
     ModalActions,
     ButtonStrip,
     Button,
+    IconCopy24,
 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
 import i18n from '../../locales/index.js'
+import { styles } from './GetLinkDialog.styles.js'
 import { supportedFileTypes, appPathFor } from './utils.js'
 
 export const GetLinkDialog = ({ type, id, onClose }) => {
+    const { baseUrl } = useConfig()
+
     // TODO simply use href from the visualization object?
-    const appUrl = new URL(
-        appPathFor(type, id),
-        `${window.location.origin}${window.location.pathname}`
-    )
+    const appUrl = new URL(appPathFor(type, id), baseUrl)
 
     return (
         <Modal onClose={onClose}>
+            <style jsx>{styles}</style>
             <ModalContent>
                 <p>{i18n.t('Open in this app')}</p>
-                <a href={appUrl.href}>{appUrl.href}</a>
+                <div className="link-container">
+                    <a href={appUrl.href}>{appUrl.href}</a>
+                    <Button
+                        icon={<IconCopy24 />}
+                        small
+                        onClick={() =>
+                            navigator.clipboard.writeText(appUrl.href)
+                        }
+                    />
+                </div>
             </ModalContent>
             <ModalActions>
                 <ButtonStrip>

--- a/src/components/FileMenu/GetLinkDialog.styles.js
+++ b/src/components/FileMenu/GetLinkDialog.styles.js
@@ -1,0 +1,10 @@
+import { spacers } from '@dhis2/ui'
+import css from 'styled-jsx/css'
+
+export const styles = css`
+    .link-container {
+        display: flex;
+        align-items: center;
+        gap: ${spacers.dp12};
+    }
+`

--- a/src/components/FileMenu/__tests__/GetLinkDialog.spec.js
+++ b/src/components/FileMenu/__tests__/GetLinkDialog.spec.js
@@ -4,6 +4,12 @@ import React from 'react'
 import { GetLinkDialog } from '../GetLinkDialog.js'
 import { appPathFor } from '../utils.js'
 
+const testBaseUrl = 'http://test.tld/test'
+
+jest.mock('@dhis2/app-runtime', () => ({
+    useConfig: () => ({ baseUrl: testBaseUrl }),
+}))
+
 describe('The FileMenu - GetLinkDialog component', () => {
     let shallowGetLinkDialog
     let props
@@ -33,11 +39,13 @@ describe('The FileMenu - GetLinkDialog component', () => {
     it('renders a <a> tag containing the type and id props', () => {
         const href = getGetLinkDialogComponent(props).find('a').prop('href')
 
-        expect(href).toMatch(appPathFor(props.type, props.id))
+        expect(href).toMatch(
+            new URL(appPathFor(props.type, props.id), testBaseUrl).href
+        )
     })
 
     it('calls the onClose callback when the Close button is clicked', () => {
-        getGetLinkDialogComponent(props).find(Button).first().simulate('click')
+        getGetLinkDialogComponent(props).find(Button).at(1).simulate('click')
 
         expect(onClose).toHaveBeenCalled()
     })


### PR DESCRIPTION
Implements [DHIS2-14879](https://dhis2.atlassian.net/browse/DHIS2-14879)

---

### Key features

1. avoid duplicated path parts in URL
2. add a copy to clipboard button

---

### Description

Depending on the instance base URL, the previous approach did not always work.
Sometimes the baseUrl includes a part of the path (ie. `dev`) so it's not correct to always add the path when building the absolute URL.

A copy to clipboard button has also been added to facilitate sharing the URL.

---

### Screenshots

<img width="613" alt="Screenshot 2023-03-14 at 12 27 40" src="https://user-images.githubusercontent.com/150978/224992140-2c317d64-f66a-4296-b718-7370ee675742.png">




[DHIS2-14789]: https://dhis2.atlassian.net/browse/DHIS2-14789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DHIS2-14879]: https://dhis2.atlassian.net/browse/DHIS2-14879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ