### PR TITLE
fix: ensure the base passed to URL is absolute

### DIFF
--- a/src/components/FileMenu/GetLinkDialog.js
+++ b/src/components/FileMenu/GetLinkDialog.js
@@ -17,7 +17,9 @@ export const GetLinkDialog = ({ type, id, onClose }) => {
     const { baseUrl } = useConfig()
 
     // TODO simply use href from the visualization object?
-    const appUrl = new URL(appPathFor(type, id), baseUrl)
+    const appBaseUrl = new URL(baseUrl, self.location.href)
+
+    const appUrl = new URL(appPathFor(type, id), appBaseUrl)
 
     return (
         <Modal onClose={onClose}>


### PR DESCRIPTION
Implements [DHIS2-14789](https://dhis2.atlassian.net/browse/DHIS2-14789)

---

### Key features

1. fix for the case of baseURL being `..`

---

### Description

This should account for the case where in production `baseUrl` returned by the `useConfig` hook is `..`.


[DHIS2-14789]: https://dhis2.atlassian.net/browse/DHIS2-14789?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ