### PR TITLE
feat: single value background color change based upon legend (DHIS2-13702) part 2

### DIFF
--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -110,9 +110,13 @@ const generateDashboardItem = (
         container.appendChild(title)
     }
 
-    const subtitle = document.createElement('span')
-    subtitle.setAttribute('style', titleStyle + ' margin-top: 4px')
     if (config.subtitle) {
+        const subtitle = document.createElement('span')
+        subtitle.setAttribute(
+            'style',
+            titleStyle + ' margin-top: 4px; padding: 0 8px'
+        )
+
         subtitle.appendChild(document.createTextNode(config.subtitle))
 
         container.appendChild(subtitle)

--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -92,7 +92,7 @@ const generateValueSVG = ({
 
 const generateDashboardItem = (
     config,
-    { valueColor, backgroundColor, noData }
+    { valueColor, titleColor, backgroundColor, noData }
 ) => {
     const container = document.createElement('div')
     container.setAttribute(
@@ -100,7 +100,7 @@ const generateDashboardItem = (
         `display: flex; flex-direction: column; align-items: center; justify-content: center; width: 100%; height: 100%; background-color:${backgroundColor};`
     )
 
-    const titleStyle = 'font-size: 12px; color: #666;'
+    const titleStyle = `font-size: 12px; color: ${titleColor || '#666'};`
 
     const title = document.createElement('span')
     title.setAttribute('style', titleStyle)
@@ -354,6 +354,9 @@ export default function (
             valueColor,
             backgroundColor,
             noData,
+            ...(shouldUseContrastColor(legendColor)
+                ? { titleColor: colors.white }
+                : {}),
         })
     } else {
         parentEl.style.height = `100%`

--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -90,11 +90,14 @@ const generateValueSVG = ({
     return svgValue
 }
 
-const generateDashboardItem = (config, { valueColor, noData }) => {
+const generateDashboardItem = (
+    config,
+    { valueColor, backgroundColor, noData }
+) => {
     const container = document.createElement('div')
     container.setAttribute(
         'style',
-        'display: flex; flex-direction: column; align-items: center; justify-content: center; width: 100%; height: 100%'
+        `display: flex; flex-direction: column; align-items: center; justify-content: center; width: 100%; height: 100%; background-color:${backgroundColor};`
     )
 
     const titleStyle = 'font-size: 12px; color: #666;'
@@ -154,7 +157,7 @@ const getXFromTextAlign = (textAlign) => {
 
 const generateDVItem = (
     config,
-    { valueColor, titleColor, parentEl, fontStyle, noData }
+    { valueColor, backgroundColor, titleColor, parentEl, fontStyle, noData }
 ) => {
     const parentElBBox = parentEl.getBoundingClientRect()
 
@@ -169,6 +172,16 @@ const generateDVItem = (
     svg.setAttribute('width', '100%')
     svg.setAttribute('height', '100%')
     svg.setAttribute('data-test', 'visualization-container')
+
+    if (backgroundColor) {
+        svg.setAttribute('style', `background-color: ${backgroundColor};`)
+
+        const background = document.createElementNS(svgNS, 'rect')
+        background.setAttribute('width', '100%')
+        background.setAttribute('height', '100%')
+        background.setAttribute('fill', backgroundColor)
+        svg.appendChild(background)
+    }
 
     const title = document.createElementNS(svgNS, 'text')
     const titleFontStyle = mergeFontStyleWithDefault(
@@ -316,10 +329,10 @@ export default function (
     const legendSet = legendOptions && legendSets[0]
     const legendColor =
         legendSet && getColorByValueFromLegendSet(legendSet, config.value)
-    let valueColor, titleColor
+    let valueColor, titleColor, backgroundColor
     if (legendColor) {
         if (legendOptions.style === LEGEND_DISPLAY_STYLE_FILL) {
-            parentEl.style.background = legendColor
+            backgroundColor = legendColor
             valueColor = titleColor =
                 shouldUseContrastColor(legendColor) && colors.white
         } else {
@@ -333,11 +346,16 @@ export default function (
 
     if (dashboard) {
         parentEl.style.borderRadius = spacers.dp8
-        return generateDashboardItem(config, { valueColor, noData })
+        return generateDashboardItem(config, {
+            valueColor,
+            backgroundColor,
+            noData,
+        })
     } else {
         parentEl.style.height = `100%`
         return generateDVItem(config, {
             valueColor,
+            backgroundColor,
             titleColor,
             parentEl,
             fontStyle,

--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -330,13 +330,12 @@ export default function (
     parentEl.style.overflow = 'hidden'
     parentEl.style.display = 'flex'
     parentEl.style.justifyContent = 'center'
-    parentEl.style.borderRadius = spacers.dp8
 
     if (dashboard) {
+        parentEl.style.borderRadius = spacers.dp8
         return generateDashboardItem(config, { valueColor, noData })
     } else {
-        parentEl.style.margin = spacers.dp8
-        parentEl.style.height = `calc(100% - (${spacers.dp8} * 2))`
+        parentEl.style.height = `100%`
         return generateDVItem(config, {
             valueColor,
             titleColor,


### PR DESCRIPTION
Fixes for issues found during the KFMT of https://github.com/dhis2/analytics/pull/1402, for more info see the original PR

1. Removes the border radius from DV [DHIS2-15124](https://dhis2.atlassian.net/browse/DHIS2-15124)
2. Removes the margin from DV [DHIS2-15121](https://dhis2.atlassian.net/browse/DHIS2-15121)
3. Moves the bg color from the parent el so it's included in the download
4. Adds a `rect` element with a `fill` that acts as background when downloading [DHIS2-15123](https://dhis2.atlassian.net/browse/DHIS2-15123)
5. Adds padding on the side of the subtitle [DHIS2-15119]
6. Apply contrast color to title/subtitle for dashboard items [DHIS2-15118](https://dhis2.atlassian.net/browse/DHIS2-15118)

[DHIS2-15124]: https://dhis2.atlassian.net/browse/DHIS2-15124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-15121]: https://dhis2.atlassian.net/browse/DHIS2-15121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-15123]: https://dhis2.atlassian.net/browse/DHIS2-15123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-15119]: https://dhis2.atlassian.net/browse/DHIS2-15119

[DHIS2-15118]: https://dhis2.atlassian.net/browse/DHIS2-15118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ