### PR TITLE
fix: sv size when downloading is a small square (DHIS2-15178) 

### DIFF
--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -173,8 +173,8 @@ const generateDVItem = (
     const svg = document.createElementNS(svgNS, 'svg')
     svg.setAttribute('xmlns', svgNS)
     svg.setAttribute('viewBox', `0 0 ${width} ${height}`)
-    svg.setAttribute('width', '100%')
-    svg.setAttribute('height', '100%')
+    svg.setAttribute('width', width)
+    svg.setAttribute('height', height)
     svg.setAttribute('data-test', 'visualization-container')
 
     if (backgroundColor) {


### PR DESCRIPTION
Implements [DHIS2-15178](https://dhis2.atlassian.net/browse/DHIS2-15178)

---

### Key features

1. Replace relative height/width with actual value

---

### Description

Prevents SV download from defaulting to 400x400px by explicitly setting an actual value for height and width

---

### Screenshots

_original AO in DV_
![image](https://user-images.githubusercontent.com/12590483/233636159-8ec16b90-be03-44bb-ac0c-257d6033d694.png)

_download before_
![image](https://user-images.githubusercontent.com/12590483/233636903-d4f510a0-2068-4162-887b-cfe09eaf032b.png)

_download after_
![image](https://user-images.githubusercontent.com/12590483/233636226-de5f35a8-410c-47a1-b1a0-1ba0dcb55e3f.png)



[DHIS2-15178]: https://dhis2.atlassian.net/browse/DHIS2-15178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ