### PR TITLE
fix: add data-test to SV icon (DHIS2-10496)

### DIFF
--- a/src/visualizations/config/generators/dhis/singleValue.js
+++ b/src/visualizations/config/generators/dhis/singleValue.js
@@ -86,6 +86,7 @@ const generateValueSVG = ({
             `-${(iconSize + iconPadding + textWidth) / 2}`
         )
         iconSvgNode.setAttribute('style', `color: ${fillColor}`)
+        iconSvgNode.setAttribute('data-test', 'visualization-icon')
 
         const parser = new DOMParser()
         const svgIconDocument = parser.parseFromString(icon, 'image/svg+xml')


### PR DESCRIPTION
Test fix for [DHIS2-10496](https://dhis2.atlassian.net/browse/DHIS2-10496)

---

Adds the `data-test` prop to the SV icon svg element, needed for Cypress tests in DV.

![image](https://github.com/dhis2/analytics/assets/12590483/af11c448-ec93-4249-aa40-bd119d611952)


[DHIS2-10496]: https://dhis2.atlassian.net/browse/DHIS2-10496?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ