### PR TITLE
feat: add rich text parser/editor components

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,6 @@
         "styled-jsx": "^4.0.1"
     },
     "dependencies": {
-        "@dhis2/d2-ui-rich-text": "^7.4.0",
         "@dhis2/multi-calendar-dates": "1.0.0",
         "@dnd-kit/core": "^6.0.7",
         "@dnd-kit/sortable": "^7.0.2",
@@ -72,6 +71,7 @@
         "d3-color": "^1.2.3",
         "highcharts": "^10.2.0",
         "lodash": "^4.17.21",
+        "markdown-it": "^13.0.1",
         "mathjs": "^9.4.2",
         "react-beautiful-dnd": "^10.1.1",
         "resize-observer-polyfill": "^1.5.1"

--- a/src/components/AboutAOUnit/AboutAOUnit.js
+++ b/src/components/AboutAOUnit/AboutAOUnit.js
@@ -1,6 +1,5 @@
 import { useDataQuery, useDataMutation } from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
-import { Parser as RichTextParser } from '@dhis2/d2-ui-rich-text'
 import {
     Button,
     CircularLoader,
@@ -25,6 +24,7 @@ import React, {
     useImperativeHandle,
 } from 'react'
 import { formatList } from '../../modules/list.js'
+import { RichTextParser } from '../RichText/index.js'
 import styles from './styles/AboutAOUnit.style.js'
 import { getTranslatedString, AOTypeMap } from './utils.js'
 
@@ -186,7 +186,7 @@ const AboutAOUnit = forwardRef(({ type, id, renderId }, ref) => {
                     )}
                     {data && (
                         <div className="content">
-                            <p
+                            <div
                                 className={cx('detailLine', {
                                     noDescription: !data.ao.displayDescription,
                                 })}
@@ -196,9 +196,9 @@ const AboutAOUnit = forwardRef(({ type, id, renderId }, ref) => {
                                         {data.ao.displayDescription}
                                     </RichTextParser>
                                 ) : (
-                                    i18n.t('No description')
+                                    <p>{i18n.t('No description')}</p>
                                 )}
-                            </p>
+                            </div>
                             <div>
                                 <p className="detailLine">
                                     <IconShare16 color={colors.grey700} />

--- a/src/components/Interpretations/common/Message/Message.js
+++ b/src/components/Interpretations/common/Message/Message.js
@@ -1,8 +1,8 @@
-import { Parser as RichTextParser } from '@dhis2/d2-ui-rich-text'
 import { UserAvatar, spacers, colors } from '@dhis2/ui'
 import moment from 'moment'
 import PropTypes from 'prop-types'
 import React from 'react'
+import { RichTextParser } from '../../../RichText/index.js'
 
 const Message = ({ children, text, created, username }) => (
     <li className="container">

--- a/src/components/Interpretations/common/RichTextEditor/RichTextEditor.js
+++ b/src/components/Interpretations/common/RichTextEditor/RichTextEditor.js
@@ -1,5 +1,4 @@
 import i18n from '@dhis2/d2-i18n'
-import { Parser as RichTextParser } from '@dhis2/d2-ui-rich-text'
 import {
     Button,
     Popover,
@@ -14,6 +13,7 @@ import {
 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { forwardRef, useRef, useEffect, useState } from 'react'
+import { RichTextParser } from '../../../RichText/index.js'
 import { UserMentionWrapper } from '../UserMention/UserMentionWrapper.js'
 import {
     convertCtrlKey,

--- a/src/components/RichText/editor/Editor.js
+++ b/src/components/RichText/editor/Editor.js
@@ -1,0 +1,29 @@
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import convertCtrlKey from './convertCtrlKey.js'
+
+class Editor extends Component {
+    onKeyDown = (event) => {
+        convertCtrlKey(event, this.props.onEdit)
+    }
+
+    render() {
+        const { children } = this.props
+
+        return <div onKeyDown={this.onKeyDown}>{children}</div>
+    }
+}
+
+Editor.defaultProps = {
+    onEdit: null,
+}
+
+Editor.propTypes = {
+    children: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.node),
+        PropTypes.node,
+    ]),
+    onEdit: PropTypes.func,
+}
+
+export default Editor

--- a/src/components/RichText/editor/__tests__/Editor.spec.js
+++ b/src/components/RichText/editor/__tests__/Editor.spec.js
@@ -1,0 +1,37 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import convertCtrlKey from '../convertCtrlKey.js'
+import Editor from '../Editor.js'
+
+jest.mock('../convertCtrlKey')
+
+describe('RichText: Editor component', () => {
+    let richTextEditor
+    const componentProps = {
+        onEdit: jest.fn(),
+    }
+
+    beforeEach(() => {
+        convertCtrlKey.mockClear()
+    })
+
+    const renderComponent = (props) => {
+        return shallow(
+            <Editor {...props}>
+                <input />
+            </Editor>
+        )
+    }
+
+    it('renders a result', () => {
+        richTextEditor = renderComponent(componentProps)
+
+        expect(richTextEditor).toHaveLength(1)
+    })
+
+    it('calls convertCtrlKey on keydown', () => {
+        richTextEditor = renderComponent(componentProps)
+        richTextEditor.simulate('keyDown')
+        expect(convertCtrlKey).toHaveBeenCalled()
+    })
+})

--- a/src/components/RichText/editor/__tests__/convertCtrlKey.spec.js
+++ b/src/components/RichText/editor/__tests__/convertCtrlKey.spec.js
@@ -1,0 +1,230 @@
+import convertCtrlKey from '../convertCtrlKey.js'
+
+describe('convertCtrlKey', () => {
+    it('does not trigger callback if no ctrl key', () => {
+        const cb = jest.fn()
+        const e = { key: 'j', preventDefault: () => {} }
+
+        convertCtrlKey(e, cb)
+
+        expect(cb).not.toHaveBeenCalled()
+    })
+
+    describe('when ctrl key + "b" pressed', () => {
+        it('triggers callback with open/close markers and caret pos in between', () => {
+            const cb = jest.fn()
+            const e = {
+                key: 'b',
+                ctrlKey: true,
+                target: {
+                    selectionStart: 0,
+                    selectionEnd: 0,
+                    value: 'rainbow dash',
+                },
+                preventDefault: () => {},
+            }
+
+            convertCtrlKey(e, cb)
+
+            expect(cb).toHaveBeenCalled()
+            expect(cb).toHaveBeenCalledWith('** rainbow dash', 1)
+        })
+
+        it('triggers callback with open/close markers and caret pos in between (end of text)', () => {
+            const cb = jest.fn()
+            const e = {
+                key: 'b',
+                ctrlKey: true,
+                target: {
+                    selectionStart: 22,
+                    selectionEnd: 22,
+                    value: 'rainbow dash is purple',
+                },
+                preventDefault: () => {},
+            }
+
+            convertCtrlKey(e, cb)
+
+            expect(cb).toHaveBeenCalled()
+            expect(cb).toHaveBeenCalledWith('rainbow dash is purple **', 24)
+        })
+
+        it('triggers callback with open/close markers mid-text with surrounding spaces (1)', () => {
+            const cb = jest.fn()
+            const e = {
+                key: 'b',
+                metaKey: true,
+                target: {
+                    selectionStart: 4, // caret located just before "quick"
+                    selectionEnd: 4,
+                    value: 'the quick brown fox',
+                },
+                preventDefault: () => {},
+            }
+
+            convertCtrlKey(e, cb)
+
+            expect(cb).toHaveBeenCalled()
+            expect(cb).toHaveBeenCalledWith('the ** quick brown fox', 5)
+        })
+
+        it('triggers callback with open/close markers mid-text with surrounding spaces (2)', () => {
+            const cb = jest.fn()
+            const e = {
+                key: 'b',
+                metaKey: true,
+                target: {
+                    selectionStart: 3, // caret located just after "the"
+                    selectionEnd: 3,
+                    value: 'the quick brown fox',
+                },
+                preventDefault: () => {},
+            }
+
+            convertCtrlKey(e, cb)
+
+            expect(cb).toHaveBeenCalled()
+            expect(cb).toHaveBeenCalledWith('the ** quick brown fox', 5)
+        })
+
+        it('triggers callback with correct double markers and padding', () => {
+            const cb = jest.fn()
+            const e = {
+                key: 'b',
+                metaKey: true,
+                target: {
+                    selectionStart: 9, // between the underscores
+                    selectionEnd: 9,
+                    value: 'rainbow __',
+                },
+                preventDefault: () => {},
+            }
+
+            convertCtrlKey(e, cb)
+
+            expect(cb).toHaveBeenCalled()
+            expect(cb).toHaveBeenCalledWith('rainbow _**_', 10)
+        })
+
+        describe('selected text', () => {
+            it('triggers callback with open/close markers around text and caret pos after closing marker', () => {
+                const cb = jest.fn()
+                const e = {
+                    key: 'b',
+                    metaKey: true,
+                    target: {
+                        selectionStart: 5, // "ow da" is selected
+                        selectionEnd: 10,
+                        value: 'rainbow dash is purple',
+                    },
+                    preventDefault: () => {},
+                }
+
+                convertCtrlKey(e, cb)
+
+                expect(cb).toHaveBeenCalled()
+                expect(cb).toHaveBeenCalledWith(
+                    'rainb *ow da* sh is purple',
+                    13
+                )
+            })
+
+            it('triggers callback with open/close markers around text when starting at beginning of line', () => {
+                const cb = jest.fn()
+                const e = {
+                    key: 'b',
+                    metaKey: true,
+                    target: {
+                        selectionStart: 0, // "rainbow" is selected
+                        selectionEnd: 7,
+                        value: 'rainbow dash is purple',
+                    },
+                    preventDefault: () => {},
+                }
+
+                convertCtrlKey(e, cb)
+
+                expect(cb).toHaveBeenCalled()
+                expect(cb).toHaveBeenCalledWith('*rainbow* dash is purple', 9)
+            })
+
+            it('triggers callback with open/close markers around text when ending at end of line', () => {
+                const cb = jest.fn()
+                const e = {
+                    key: 'b',
+                    metaKey: true,
+                    target: {
+                        selectionStart: 16, // "purple" is selected
+                        selectionEnd: 22,
+                        value: 'rainbow dash is purple',
+                    },
+                    preventDefault: () => {},
+                }
+
+                convertCtrlKey(e, cb)
+
+                expect(cb).toHaveBeenCalled()
+                expect(cb).toHaveBeenCalledWith('rainbow dash is *purple*', 24)
+            })
+
+            it('triggers callback with open/close markers around word', () => {
+                const cb = jest.fn()
+                const e = {
+                    key: 'b',
+                    metaKey: true,
+                    target: {
+                        selectionStart: 8, // "dash" is selected
+                        selectionEnd: 12,
+                        value: 'rainbow dash is purple',
+                    },
+                    preventDefault: () => {},
+                }
+
+                convertCtrlKey(e, cb)
+
+                expect(cb).toHaveBeenCalled()
+                expect(cb).toHaveBeenCalledWith('rainbow *dash* is purple', 14)
+            })
+
+            it('triggers callback with leading/trailing spaces trimmed from selection', () => {
+                const cb = jest.fn()
+                const e = {
+                    key: 'b',
+                    metaKey: true,
+                    target: {
+                        selectionStart: 8, // " dash " is selected (note leading and trailing space)
+                        selectionEnd: 13,
+                        value: 'rainbow dash is purple',
+                    },
+                    preventDefault: () => {},
+                }
+
+                convertCtrlKey(e, cb)
+
+                expect(cb).toHaveBeenCalled()
+                expect(cb).toHaveBeenCalledWith('rainbow *dash* is purple', 14)
+            })
+        })
+    })
+
+    describe('when ctrl key + "i" pressed', () => {
+        it('triggers callback with open/close italics markers and caret pos in between', () => {
+            const cb = jest.fn()
+            const e = {
+                key: 'i',
+                ctrlKey: true,
+                target: {
+                    selectionStart: 0,
+                    selectionEnd: 0,
+                    value: '',
+                },
+                preventDefault: () => {},
+            }
+
+            convertCtrlKey(e, cb)
+
+            expect(cb).toHaveBeenCalled()
+            expect(cb).toHaveBeenCalledWith('__', 1)
+        })
+    })
+})

--- a/src/components/RichText/editor/convertCtrlKey.js
+++ b/src/components/RichText/editor/convertCtrlKey.js
@@ -1,0 +1,103 @@
+const state = {
+    boldMode: false,
+    italicMode: false,
+    element: null,
+}
+
+const markerMap = {
+    italic: '_',
+    bold: '*',
+}
+
+const trim = (str) => {
+    const leftSpaces = /^\s+/
+    const rightSpaces = /\s+$/
+
+    return str.replace(leftSpaces, '').replace(rightSpaces, '')
+}
+
+const toggleMode = (mode) => {
+    const prop = `${mode}Mode`
+
+    state[prop] = !state[prop]
+}
+
+const insertMarkers = (mode, cb) => {
+    const { selectionStart: start, selectionEnd: end, value } = state.element
+    const marker = markerMap[mode] || null
+    if (!marker || !cb || start < 0) {
+        return
+    }
+
+    toggleMode(mode)
+
+    let newValue
+    let caretPos = end + 1
+
+    const padMarkers = (text) => {
+        // is caret between two markers (i.e., "**" or "__")? Then do not add padding
+        if (start === end && value.length && start > 0) {
+            if (
+                (value[start - 1] === markerMap.bold &&
+                    value[start] === markerMap.bold) ||
+                (value[start - 1] === markerMap.italic &&
+                    value[start] === markerMap.italic)
+            ) {
+                return text
+            }
+        }
+
+        if (value.length && start > 0 && value[start - 1] !== ' ') {
+            text = ` ${text}`
+            ++caretPos
+        }
+
+        if (value.length && end !== value.length && value[end] !== ' ') {
+            text = `${text} `
+        }
+
+        return text
+    }
+
+    if (start === end) {
+        //no text
+        const valueArr = value.split('')
+
+        valueArr.splice(start, 0, padMarkers(`${marker}${marker}`))
+        newValue = valueArr.join('')
+    } else {
+        const text = value.slice(start, end)
+        const trimmedText = trim(text)
+
+        // adjust caretPos based on trimmed text selection
+        caretPos = caretPos - (text.length - trimmedText.length) + 1
+
+        newValue = [
+            value.slice(0, start),
+            padMarkers(`${marker}${trimmedText}${marker}`),
+            value.slice(end),
+        ].join('')
+
+        toggleMode(mode)
+    }
+
+    cb(newValue, caretPos)
+}
+
+const convertCtrlKey = (event, cb) => {
+    const { key, ctrlKey, metaKey } = event
+
+    const element = event.target
+
+    state.element = element
+
+    if (key === 'b' && (ctrlKey || metaKey)) {
+        event.preventDefault()
+        insertMarkers('bold', cb)
+    } else if (key === 'i' && (ctrlKey || metaKey)) {
+        event.preventDefault()
+        insertMarkers('italic', cb)
+    }
+}
+
+export default convertCtrlKey

--- a/src/components/RichText/index.js
+++ b/src/components/RichText/index.js
@@ -1,0 +1,5 @@
+export { default as RichTextEditor } from './editor/Editor.js'
+export { default as RichTextParser } from './parser/Parser.js'
+
+export { default as convertCtrlKey } from './editor/convertCtrlKey.js'
+export { default as ClassMdParser } from './parser/MdParser.js'

--- a/src/components/RichText/parser/MdParser.js
+++ b/src/components/RichText/parser/MdParser.js
@@ -1,0 +1,119 @@
+import MarkdownIt from 'markdown-it'
+
+const emojiDb = {
+    ':-)': '\u{1F642}',
+    ':)': '\u{1F642}',
+    ':-(': '\u{1F641}',
+    ':(': '\u{1F641}',
+    ':+1': '\u{1F44D}',
+    ':-1': '\u{1F44E}',
+}
+
+const codes = {
+    bold: {
+        name: 'bold',
+        char: '*',
+        domEl: 'strong',
+        encodedChar: 0x2a,
+        // see https://regex101.com/r/evswdV/8 for explanation of regexp
+        regexString: '\\B\\*((?!\\s)[^*]+(?:\\b|[^*\\s]))\\*\\B',
+        contentFn: (val) => val,
+    },
+    italic: {
+        name: 'italic',
+        char: '_',
+        domEl: 'em',
+        encodedChar: 0x5f,
+        // see https://regex101.com/r/p6LpjK/6 for explanation of regexp
+        regexString: '\\b_((?!\\s)[^_]+(?:\\B|[^_\\s]))_\\b',
+        contentFn: (val) => val,
+    },
+    emoji: {
+        name: 'emoji',
+        char: ':',
+        domEl: 'span',
+        encodedChar: 0x3a,
+        regexString: '^(:-\\)|:\\)|:\\(|:-\\(|:\\+1|:-1)',
+        contentFn: (val) => emojiDb[val],
+    },
+}
+
+let md
+let linksInText
+
+const markerIsInLinkText = (pos) =>
+    linksInText.some((link) => pos >= link.index && pos <= link.lastIndex)
+
+const parse = (code) => (state, silent) => {
+    if (silent) {
+        return false
+    }
+
+    const start = state.pos
+
+    // skip parsing emphasis if marker is within a link
+    if (markerIsInLinkText(start)) {
+        return false
+    }
+
+    const marker = state.src.charCodeAt(start)
+
+    // marker character: "_", "*", ":"
+    if (marker !== codes[code].encodedChar) {
+        return false
+    }
+
+    const MARKER_REGEX = new RegExp(codes[code].regexString)
+    const token = state.src.slice(start)
+
+    if (MARKER_REGEX.test(token)) {
+        const markerMatch = token.match(MARKER_REGEX)
+
+        // skip parsing sections where the marker is not at the start of the token
+        if (markerMatch.index !== 0) {
+            return false
+        }
+
+        const text = markerMatch[1]
+
+        state.push(`${codes[code].domEl}_open`, codes[code].domEl, 1)
+
+        const t = state.push('text', '', 0)
+        t.content = codes[code].contentFn(text)
+
+        state.push(`${codes.bold.domEl}_close`, codes[code].domEl, -1)
+        state.pos += markerMatch[0].length
+
+        return true
+    }
+
+    return false
+}
+
+class MdParser {
+    constructor() {
+        // disable all rules, enable autolink for URLs and email addresses
+        md = new MarkdownIt('zero', { linkify: true })
+
+        // *bold* -> <strong>bold</strong>
+        md.inline.ruler.push('strong', parse(codes.bold.name))
+
+        // _italic_ -> <em>italic</em>
+        md.inline.ruler.push('italic', parse(codes.italic.name))
+
+        // :-) :) :-( :( :+1 :-1 -> <span>[unicode]</span>
+        md.inline.ruler.push('emoji', parse(codes.emoji.name))
+
+        md.enable(['link', 'linkify', 'strong', 'italic', 'emoji'])
+
+        return this
+    }
+
+    render(text) {
+        linksInText = md.linkify.match(text) || []
+
+        return md.renderInline(text)
+    }
+}
+
+export default MdParser

--- a/src/components/RichText/parser/Parser.js
+++ b/src/components/RichText/parser/Parser.js
@@ -1,0 +1,38 @@
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import MdParserClass from './MdParser.js'
+
+class Parser extends Component {
+    constructor(props) {
+        super(props)
+
+        this.MdParser = new MdParserClass()
+    }
+
+    render() {
+        const { children, style } = this.props
+
+        return children ? (
+            <p
+                style={style}
+                dangerouslySetInnerHTML={{
+                    __html: this.MdParser.render(children),
+                }}
+            />
+        ) : null
+    }
+}
+
+Parser.defaultProps = {
+    style: null,
+}
+
+Parser.propTypes = {
+    children: PropTypes.oneOfType([
+        PropTypes.arrayOf(PropTypes.node),
+        PropTypes.node,
+    ]),
+    style: PropTypes.object,
+}
+
+export default Parser

--- a/src/components/RichText/parser/Parser.js
+++ b/src/components/RichText/parser/Parser.js
@@ -1,26 +1,18 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import React, { useMemo } from 'react'
 import MdParserClass from './MdParser.js'
 
-class Parser extends Component {
-    constructor(props) {
-        super(props)
+const Parser = ({ children, style }) => {
+    const MdParser = useMemo(() => new MdParserClass(), [])
 
-        this.MdParser = new MdParserClass()
-    }
-
-    render() {
-        const { children, style } = this.props
-
-        return children ? (
-            <p
-                style={style}
-                dangerouslySetInnerHTML={{
-                    __html: this.MdParser.render(children),
-                }}
-            />
-        ) : null
-    }
+    return children ? (
+        <p
+            style={style}
+            dangerouslySetInnerHTML={{
+                __html: MdParser.render(children),
+            }}
+        />
+    ) : null
 }
 
 Parser.defaultProps = {

--- a/src/components/RichText/parser/__tests__/MdParser.spec.js
+++ b/src/components/RichText/parser/__tests__/MdParser.spec.js
@@ -1,0 +1,134 @@
+import MdParser from '../MdParser.js'
+
+const Parser = new MdParser()
+
+describe('MdParser class', () => {
+    it('converts text into HTML', () => {
+        const tests = [
+            ['_italic_', '<em>italic</em>'],
+            ['*bold*', '<strong>bold</strong>'],
+            [
+                '* not bold because there is a space *',
+                '* not bold because there is a space *',
+            ],
+            [
+                '_ not italic because there is a space _',
+                '_ not italic because there is a space _',
+            ],
+            [':-)', '<span>\u{1F642}</span>'],
+            [':)', '<span>\u{1F642}</span>'],
+            [':-(', '<span>\u{1F641}</span>'],
+            [':(', '<span>\u{1F641}</span>'],
+            [':+1', '<span>\u{1F44D}</span>'],
+            [':-1', '<span>\u{1F44E}</span>'],
+            [
+                'mixed _italic_ *bold* and :+1',
+                'mixed <em>italic</em> <strong>bold</strong> and <span>\u{1F44D}</span>',
+            ],
+            ['_italic with * inside_', '<em>italic with * inside</em>'],
+            ['*bold with _ inside*', '<strong>bold with _ inside</strong>'],
+
+            // italic marker followed by : should work
+            ['_italic_:', '<em>italic</em>:'],
+            [
+                '_italic_: some text, *bold*: some other text',
+                '<em>italic</em>: some text, <strong>bold</strong>: some other text',
+            ],
+            // bold marker followed by : should work
+            ['*bold*:', '<strong>bold</strong>:'],
+            [
+                '*bold*: some text, _italic_: some other text',
+                '<strong>bold</strong>: some text, <em>italic</em>: some other text',
+            ],
+
+            // italic marker inside an italic string not allowed
+            ['_italic with _ inside_', '_italic with _ inside_'],
+            // bold marker inside a bold string not allowed
+            ['*bold with * inside*', '*bold with * inside*'],
+            [
+                '_multiple_ italic in the _same line_',
+                '<em>multiple</em> italic in the <em>same line</em>',
+            ],
+            // nested italic/bold combinations not allowed
+            [
+                '_italic with *bold* inside_',
+                '<em>italic with *bold* inside</em>',
+            ],
+            [
+                '*bold with _italic_ inside*',
+                '<strong>bold with _italic_ inside</strong>',
+            ],
+            ['text with : and :)', 'text with : and <span>\u{1F642}</span>'],
+            [
+                '(parenthesis and :))',
+                '(parenthesis and <span>\u{1F642}</span>)',
+            ],
+            [
+                ':((parenthesis:))',
+                '<span>\u{1F641}</span>(parenthesis<span>\u{1F642}</span>)',
+            ],
+            [':+1+1', '<span>\u{1F44D}</span>+1'],
+            ['-1:-1', '-1<span>\u{1F44E}</span>'],
+
+            // links
+            [
+                'example.com/path',
+                '<a href="http://example.com/path">example.com/path</a>',
+            ],
+
+            // not recognized links with italic marker inside not converted
+            [
+                'example_with_underscore.com/path',
+                'example_with_underscore.com/path',
+            ],
+            [
+                'example_with_underscore.com/path_with_underscore',
+                'example_with_underscore.com/path_with_underscore',
+            ],
+
+            // markers around non-recognized links
+            [
+                'link example_with_underscore.com/path should _not_ be converted',
+                'link example_with_underscore.com/path should <em>not</em> be converted',
+            ],
+            [
+                'link example_with_underscore.com/path should *not* be converted',
+                'link example_with_underscore.com/path should <strong>not</strong> be converted',
+            ],
+
+            // italic marker inside links not converted
+            [
+                'example.com/path_with_underscore',
+                '<a href="http://example.com/path_with_underscore">example.com/path_with_underscore</a>',
+            ],
+            [
+                '_italic_ and *bold* with a example.com/link_with_underscore',
+                '<em>italic</em> and <strong>bold</strong> with a <a href="http://example.com/link_with_underscore">example.com/link_with_underscore</a>',
+            ],
+            [
+                'example.com/path with *bold* after :)',
+                '<a href="http://example.com/path">example.com/path</a> with <strong>bold</strong> after <span>\u{1F642}</span>',
+            ],
+            [
+                '_before_ example.com/path_with_underscore *after* :)',
+                '<em>before</em> <a href="http://example.com/path_with_underscore">example.com/path_with_underscore</a> <strong>after</strong> <span>\u{1F642}</span>',
+            ],
+
+            // italic/bold markers right after non-word characters
+            [
+                '_If % of ART retention rate after 12 months >90(%)_: Sustain the efforts.',
+                '<em>If % of ART retention rate after 12 months &gt;90(%)</em>: Sustain the efforts.',
+            ],
+            [
+                '*If % of ART retention rate after 12 months >90(%)*: Sustain the efforts.',
+                '<strong>If % of ART retention rate after 12 months &gt;90(%)</strong>: Sustain the efforts.',
+            ],
+        ]
+
+        tests.forEach((test) => {
+            const renderedText = Parser.render(test[0])
+
+            expect(renderedText).toEqual(test[1])
+        })
+    })
+})

--- a/src/components/RichText/parser/__tests__/Parser.spec.js
+++ b/src/components/RichText/parser/__tests__/Parser.spec.js
@@ -1,0 +1,44 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import Parser from '../Parser.js'
+import '../MdParser.js'
+
+jest.mock('../MdParser', () => {
+    return jest.fn().mockImplementation(() => {
+        return { render: () => 'converted text' }
+    })
+})
+
+describe('RichText: Parser component', () => {
+    let richTextParser
+    const defaultProps = {
+        style: { color: 'blue' },
+    }
+
+    const renderComponent = (props, text) => {
+        return shallow(<Parser {...props}>{text}</Parser>)
+    }
+
+    it('should have rendered a result', () => {
+        richTextParser = renderComponent({}, 'test')
+
+        expect(richTextParser).toHaveLength(1)
+    })
+
+    it('should have rendered a result with the style prop', () => {
+        richTextParser = renderComponent(defaultProps, 'test prop')
+
+        expect(richTextParser.props().style).toEqual(defaultProps.style)
+    })
+
+    it('should have rendered content', () => {
+        richTextParser = renderComponent({}, 'plain text')
+
+        expect(richTextParser.html()).toEqual('<p>converted text</p>')
+    })
+
+    it('should return null if no children is passed', () => {
+        richTextParser = renderComponent({}, undefined)
+        expect(richTextParser.html()).toBe(null)
+    })
+})

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,8 @@ export {
     useCachedDataQuery,
 } from './components/CachedDataQueryProvider.js'
 
+export * from './components/RichText/index.js'
+
 // Api
 
 export { default as Analytics } from './api/analytics/Analytics.js'

--- a/yarn.lock
+++ b/yarn.lock
@@ -2198,15 +2198,6 @@
     i18next "^10.3"
     moment "^2.24.0"
 
-"@dhis2/d2-ui-rich-text@^7.4.0":
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/@dhis2/d2-ui-rich-text/-/d2-ui-rich-text-7.4.0.tgz#e1fb6eff7309ea80a6af3bee2a247c9f93ea721d"
-  integrity sha512-q8woPPyYHiqQfNtujuCQH8eq7zRcN0140XqrKHw1DXF/fnqmrcVDTNZkPSaWMuUsdPhcgTHcnuEySP0MRAXv6g==
-  dependencies:
-    babel-runtime "^6.26.0"
-    markdown-it "^8.4.2"
-    prop-types "^15.6.2"
-
 "@dhis2/multi-calendar-dates@1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@dhis2/multi-calendar-dates/-/multi-calendar-dates-1.0.0.tgz#bf7f49aecdffa9781837a5d60d56a094b74ab4df"
@@ -5594,6 +5585,11 @@ argparse@^1.0.7:
   dependencies:
     sprintf-js "~1.0.2"
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 aria-query@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-4.2.2.tgz#0d2ca6c9aceb56b8977e9fed6aed7e15bbd2f83b"
@@ -8824,6 +8820,11 @@ entities@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.0.tgz#68d6084cab1b079767540d80e56a39b423e4abf4"
   integrity sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==
+
+entities@~3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-3.0.1.tgz#2b887ca62585e96db3903482d336c1006c3001d4"
+  integrity sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==
 
 enzyme-adapter-react-16@^1.15.6:
   version "1.15.6"
@@ -13257,10 +13258,10 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
-linkify-it@^2.0.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.2.0.tgz#e3b54697e78bf915c70a38acd78fd09e0058b1cf"
-  integrity sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==
+linkify-it@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-4.0.1.tgz#01f1d5e508190d06669982ba31a7d9f56a5751ec"
+  integrity sha512-C7bfi1UZmoj8+PQx22XyeXCuBlokoyWQL5pWSP+EI6nzRylyThouddufc2c1NDIcP9k5agmN9fLpA7VNJfIiqw==
   dependencies:
     uc.micro "^1.0.1"
 
@@ -13687,14 +13688,14 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
-markdown-it@^8.4.2:
-  version "8.4.2"
-  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-8.4.2.tgz#386f98998dc15a37722aa7722084f4020bdd9b54"
-  integrity sha512-GcRz3AWTqSUphY3vsUqQSFMbgR38a4Lh3GWlHRh/7MRwz8mcu9n2IO7HOh+bXHrR9kOPDl5RNCaEsrneb+xhHQ==
+markdown-it@^13.0.1:
+  version "13.0.1"
+  resolved "https://registry.yarnpkg.com/markdown-it/-/markdown-it-13.0.1.tgz#c6ecc431cacf1a5da531423fc6a42807814af430"
+  integrity sha512-lTlxriVoy2criHP0JKRhO2VDG9c2ypWCsT237eDiLqi09rmbKoUetyGHq2uOIRoRS//kfoJckS0eUzzkDR+k2Q==
   dependencies:
-    argparse "^1.0.7"
-    entities "~1.1.1"
-    linkify-it "^2.0.0"
+    argparse "^2.0.1"
+    entities "~3.0.1"
+    linkify-it "^4.0.1"
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
@@ -13756,7 +13757,7 @@ mdn-data@2.0.6:
 mdurl@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
-  integrity sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=
+  integrity sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==
 
 media-typer@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
Implements [DHIS2-XXXX](https://dhis2.atlassian.net/browse/DHIS2-XXXX)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/XXX**

---

### Key features

1. implement rich text parser/editor components

---

### Description

These components are taken from `d2-ui-rich-text` component.
We are in the process of replacing all `d2-ui` components in the analytics apps.
The parser is actually the only part used in `analytics`.
The rich text editor has been revisited and enhanced a while ago when the new interpretations component were written and is part of the interpretations components code.
What we want at the end I think is to use the `RichTextEditor` component currently in the interpretations common components as the new and improved rich text editor.
The old one is nothing else than a wrapper around an input/textarea with some logic to detect key combinations for bold/italic.
The new one has a bit of UI built around it with buttons for the various options (bold, italic, emoji...).
I guess the discussion is also about what we want to use for rich text editing in the whole DHIS2 ecosystem, not only in the analytics apps (I know Markdown support is enabled in other apps via different solutions/dependencies).

---

### TODO

-   [ ] move the `RichTextEditor` component from interpretations and replace the old editor component?

---

### Screenshots

Example of rich text parser in action in LL app:

<img width="388" alt="Screenshot 2023-06-23 at 12 39 45" src="https://github.com/dhis2/analytics/assets/150978/895b30eb-abd5-4df2-8225-18e52c47dd91">