### PR TITLE
fix: various issues related to the new toolbar

### DIFF
--- a/src/__demo__/Toolbar.stories.js
+++ b/src/__demo__/Toolbar.stories.js
@@ -29,7 +29,7 @@ function ToolbarWithState() {
                     click to hide
                 </a>
             </ToolbarSidebar>
-            <UpdateButton />
+            <UpdateButton onClick={() => {}} />
             <HoverMenuBar>
                 <HoverMenuDropdown label="Menu A">
                     <HoverMenuList>

--- a/src/components/FileMenu/FileMenu.js
+++ b/src/components/FileMenu/FileMenu.js
@@ -148,7 +148,7 @@ export const FileMenu = ({
                         onClick={onNew}
                         dataTest="file-menu-new"
                     />
-                    <MenuDivider />
+                    <MenuDivider dense />
                     <HoverMenuListItem
                         label={i18n.t('Open…')}
                         icon={<IconLaunch24 color={iconActiveColor} />}
@@ -230,7 +230,7 @@ export const FileMenu = ({
                         onClick={onMenuItemClick('translate')}
                         dataTest="file-menu-translate"
                     />
-                    <MenuDivider />
+                    <MenuDivider dense />
                     <HoverMenuListItem
                         label={i18n.t('Share…')}
                         icon={
@@ -263,7 +263,7 @@ export const FileMenu = ({
                         onClick={onMenuItemClick('getlink')}
                         dataTest="file-menu-getlink"
                     />
-                    <MenuDivider />
+                    <MenuDivider dense />
                     <HoverMenuListItem
                         label={i18n.t('Delete')}
                         destructive

--- a/src/components/Toolbar/HoverMenuBar/HoverMenuBar.js
+++ b/src/components/Toolbar/HoverMenuBar/HoverMenuBar.js
@@ -69,6 +69,15 @@ const HoverMenuBar = ({ children, dataTest }) => {
     const closeMenuWithEsc = useCallback(
         (event) => {
             if (event.keyCode === 27) {
+                /* Blurring the active element is needed here to prevent
+                 * the menu button which was clicked to open the hovermenu
+                 * from getting the blue outline style. This looks a bit off
+                 * in all cases, but especially when the menu item which was
+                 * clicked to open the hover menu isn't the currently opened
+                 * dropdown menu. This doesn't have to be the case since
+                 * dropdown menues open on hover once the first one has been
+                 * clicked. */
+                document.activeElement.blur()
                 closeMenu()
             }
         },

--- a/src/components/Toolbar/HoverMenuBar/HoverMenuDropdown.js
+++ b/src/components/Toolbar/HoverMenuBar/HoverMenuDropdown.js
@@ -1,5 +1,6 @@
 import { Popper } from '@dhis2-ui/popper'
 import { Portal } from '@dhis2-ui/portal'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useRef } from 'react'
 import menuButtonStyles from '../MenuButton.styles.js'
@@ -17,6 +18,7 @@ export const HoverMenuDropdown = ({ children, label, dataTest, disabled }) => {
     return (
         <>
             <button
+                className={cx({ isOpen })}
                 ref={buttonRef}
                 onClick={onDropDownButtonClick}
                 disabled={disabled}

--- a/src/components/Toolbar/HoverMenuBar/HoverMenuList.js
+++ b/src/components/Toolbar/HoverMenuBar/HoverMenuList.js
@@ -81,6 +81,7 @@ HoverMenuList.defaultProps = {
     dataTest: 'dhis2-analytics-hovermenulist',
     maxWidth: '380px',
     maxHeight: 'auto',
+    dense: true,
 }
 
 HoverMenuList.propTypes = {

--- a/src/components/Toolbar/HoverMenuBar/HoverMenuListItem.styles.js
+++ b/src/components/Toolbar/HoverMenuBar/HoverMenuListItem.styles.js
@@ -16,13 +16,10 @@ export default css`
         user-select: none;
     }
 
-    li:hover {
-        background-color: ${colors.grey200};
-    }
-
+    li:hover,
     li:active,
     li.active {
-        background-color: ${colors.grey300};
+        background-color: ${colors.grey200};
     }
 
     li.destructive {

--- a/src/components/Toolbar/MenuButton.styles.js
+++ b/src/components/Toolbar/MenuButton.styles.js
@@ -11,7 +11,6 @@ export default css`
         line-height: 14px;
         padding: 0 ${spacers.dp12};
         color: ${colors.grey900};
-        transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
         cursor: pointer;
     }
 

--- a/src/components/Toolbar/MenuButton.styles.js
+++ b/src/components/Toolbar/MenuButton.styles.js
@@ -12,6 +12,7 @@ export default css`
         padding: 0 ${spacers.dp12};
         color: ${colors.grey900};
         cursor: pointer;
+        user-select: none;
     }
 
     button:hover:enabled,

--- a/src/components/Toolbar/MenuButton.styles.js
+++ b/src/components/Toolbar/MenuButton.styles.js
@@ -15,7 +15,7 @@ export default css`
     }
 
     button:hover:enabled,
-    button:active {
+    button:active:enabled {
         background-color: ${colors.grey200};
     }
 

--- a/src/components/Toolbar/MenuButton.styles.js
+++ b/src/components/Toolbar/MenuButton.styles.js
@@ -16,7 +16,8 @@ export default css`
     }
 
     button:hover:enabled,
-    button:active:enabled {
+    button:active:enabled,
+    button.isOpen {
         background-color: ${colors.grey200};
     }
 


### PR DESCRIPTION
Implements [DHIS2-15167](https://dhis2.atlassian.net/browse/DHIS2-15167)

**Relates to:**
- https://github.com/dhis2/line-listing-app/pull/368
- https://github.com/dhis2/data-visualizer-app/pull/2358

---

### Description

The majority of the issues which were identified during [today's KFMT session](https://dhis2.slack.com/archives/G01PW9YGZD2/p1687850567396599) could be fixed here in `@dhis2/analytics`. Below is a summary of the subtasks which have been addressed in this PR:

- [DHIS2-15487](https://dhis2.atlassian.net/browse/DHIS2-15487?atlOrigin=eyJpIjoiYzgwYTQ0ZjEyNzQzNGJhN2JmNjEyZTM0NmRhZWZhNjIiLCJwIjoic2hlZXRzLWppcmEifQ)	Decrease menu item font-size and height and ensure all menus are consistent
- [DHIS2-15488](https://dhis2.atlassian.net/browse/DHIS2-15488?atlOrigin=eyJpIjoiYzgwYTQ0ZjEyNzQzNGJhN2JmNjEyZTM0NmRhZWZhNjIiLCJwIjoic2hlZXRzLWppcmEifQ)	Prevent text selection by adding `user-select: none`
- [DHIS2-15490](https://dhis2.atlassian.net/browse/DHIS2-15490?atlOrigin=eyJpIjoiYzgwYTQ0ZjEyNzQzNGJhN2JmNjEyZTM0NmRhZWZhNjIiLCJwIjoic2hlZXRzLWppcmEifQ)	Ensure `:active` highlight does not appear on disabled menu dropdown buttons (FF)
- [DHIS2-15494](https://dhis2.atlassian.net/browse/DHIS2-15494?atlOrigin=eyJpIjoiYzgwYTQ0ZjEyNzQzNGJhN2JmNjEyZTM0NmRhZWZhNjIiLCJwIjoic2hlZXRzLWppcmEifQ)	Toolbar menu items should have the grey "active" background when their dropdown menu is open
- [DHIS2-15495](https://dhis2.atlassian.net/browse/DHIS2-15495?atlOrigin=eyJpIjoiYzgwYTQ0ZjEyNzQzNGJhN2JmNjEyZTM0NmRhZWZhNjIiLCJwIjoic2hlZXRzLWppcmEifQ)	Remove transition effect from menu button change background on hover instantly
- [DHIS2-15496](https://dhis2.atlassian.net/browse/DHIS2-15496?atlOrigin=eyJpIjoiYzgwYTQ0ZjEyNzQzNGJhN2JmNjEyZTM0NmRhZWZhNjIiLCJwIjoic2hlZXRzLWppcmEifQ)	Blur dropdown button when closing dropdown menu using ESC
- [DHIS2-15497](https://dhis2.atlassian.net/browse/DHIS2-15497?atlOrigin=eyJpIjoiYzgwYTQ0ZjEyNzQzNGJhN2JmNjEyZTM0NmRhZWZhNjIiLCJwIjoic2hlZXRzLWppcmEifQ)	Ensure plain data source menu styles are consistent


[DHIS2-15167]: https://dhis2.atlassian.net/browse/DHIS2-15167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-15428]: https://dhis2.atlassian.net/browse/DHIS2-15428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-15429]: https://dhis2.atlassian.net/browse/DHIS2-15429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-15430]: https://dhis2.atlassian.net/browse/DHIS2-15430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-15487]: https://dhis2.atlassian.net/browse/DHIS2-15487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[DHIS2-15488]: https://dhis2.atlassian.net/browse/DHIS2-15488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-15490]: https://dhis2.atlassian.net/browse/DHIS2-15490?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DHIS2-15494]: https://dhis2.atlassian.net/browse/DHIS2-15494?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ