### PR TITLE
fix: decrease padding left/right to 12px for dense hover menu list item

### DIFF
--- a/src/components/Toolbar/HoverMenuBar/HoverMenuListItem.styles.js
+++ b/src/components/Toolbar/HoverMenuBar/HoverMenuListItem.styles.js
@@ -22,6 +22,10 @@ export default css`
         background-color: ${colors.grey200};
     }
 
+    li.dense {
+        padding: 0px ${spacers.dp12};
+    }
+
     li.destructive {
         color: ${colors.red700};
         fill: ${colors.red600};


### PR DESCRIPTION
When @cooper-joe reviewed the UI tweaks implemented in https://github.com/dhis2/analytics/pull/1522 he identified one issue that should have been addressed: dense hover menu items had too much padding on the left and right. Since the PR was already merged when the issue was found, this PR was created to fix it.