### PR TITLE
fix: use visual feedback on Interpretation action buttons

### DIFF
--- a/src/components/Interpretations/InterpretationsUnit/InterpretationForm.js
+++ b/src/components/Interpretations/InterpretationsUnit/InterpretationForm.js
@@ -56,7 +56,7 @@ export const InterpretationForm = ({
                         <Button
                             primary
                             small
-                            disabled={saveMutationInProgress}
+                            loading={saveMutationInProgress}
                             onClick={() => save({ interpretationText })}
                         >
                             {i18n.t('Post interpretation')}

--- a/src/components/Interpretations/common/Message/MessageIconButton.js
+++ b/src/components/Interpretations/common/Message/MessageIconButton.js
@@ -1,4 +1,4 @@
-import { Tooltip, colors, spacers } from '@dhis2/ui'
+import { Tooltip, colors, spacers, theme } from '@dhis2/ui'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
@@ -68,6 +68,15 @@ const MessageIconButton = ({
 
                     .button.selected:hover :global(svg) {
                         color: ${colors.teal700};
+                    }
+
+                    .button:disabled {
+                        color: ${theme.disabled};
+                        cursor: not-allowed;
+                    }
+
+                    .button:disabled :global(svg) {
+                        color: ${theme.disabled};
                     }
                 `}</style>
             </span>


### PR DESCRIPTION
Implements [DHIS2-15523](https://dhis2.atlassian.net/browse/DHIS2-15523)

---

### Key features

1. use loading variant on the `Post interpretation` button while waiting for the request to complete
2. use a different icon color for the disabled state on the icon buttons

---

### Screenshots

Loading state on the Post interpretation button:
<img width="454" alt="Screenshot 2023-06-30 at 15 33 20" src="https://github.com/dhis2/analytics/assets/150978/ccb91c9c-554d-42da-a541-ae9c39764633">

[DHIS2-15523]: https://dhis2.atlassian.net/browse/DHIS2-15523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ