### PR TITLE
fix: use correct aggregation type if numberType undefined (DHIS2-15698)

### DIFF
--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -833,7 +833,10 @@ export class PivotTableEngine {
         if (totalCell && totalCell.count) {
             totalCell.value = applyTotalAggregationType(
                 totalCell,
-                this.visualization.numberType !== NUMBER_TYPE_VALUE &&
+                // DHIS2-15698: do not override total aggregation type when numberType option is not present
+                // (numberType option default is VALUE)
+                this.visualization.numberType &&
+                    this.visualization.numberType !== NUMBER_TYPE_VALUE &&
                     AGGREGATE_TYPE_SUM
             )
             this.adaptiveClippingController.add(


### PR DESCRIPTION
Implements [DHIS2-15698](https://dhis2.atlassian.net/browse/DHIS2-15698)

---

### Key features

1. fix subtotals/totals in PT

---

### Description

The issue is a [check](https://github.com/dhis2/analytics/blob/master/src/modules/pivotTable/PivotTableEngine.js#L836) in the PT engine on `numberType`.
Old saved AO do not necessarily have `numberType` returned if the value matches the default.
Because of that check in the PT engine, in that case a total aggregation type override variable is set to be `SUM` and that is what causes the subtotals/totals to be the sum of the column/row values.
Once Update is clicked, the app takes all the options from the Options modal and use those to control the table output.
At this point, `numberType` is set to `VALUE` (which is also the default) and the override for the aggregation type is not set, `AVERAGE` is then used and the subtotals/totals are correct.

The fix is about not overriding the aggregation type variable when no `numberType` is present, which is equivalent to have `numberType` set to its default value of `VALUE`.

---

### Screenshots

`numberType` option in DV:
<img width="333" alt="Screenshot 2023-08-15 at 12 35 38" src="https://github.com/dhis2/analytics/assets/150978/91c38e04-da05-481e-a759-25759afbf854">

Before the fix, loading an AO does not respect the total aggregation type:
<img width="1352" alt="Screenshot 2023-08-15 at 10 40 04" src="https://github.com/dhis2/analytics/assets/150978/38beea0a-790f-4bea-8f3b-dff39bceb008">


After the fix, loading the AO uses the correct aggregation type:
<img width="1352" alt="Screenshot 2023-08-15 at 10 39 45" src="https://github.com/dhis2/analytics/assets/150978/d8d89eac-590f-49f2-a406-475532b22483">


[DHIS2-15698]: https://dhis2.atlassian.net/browse/DHIS2-15698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ