### PR TITLE
feat: implement cumulative values in PT engine (DHIS2-5497)

### DIFF
--- a/src/__demo__/PivotTable.stories.js
+++ b/src/__demo__/PivotTable.stories.js
@@ -785,12 +785,52 @@ storiesOf('PivotTable', module).add(
 )
 
 storiesOf('PivotTable', module).add(
+    'cumulative + empty columns (weekly) - shown',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...weeklyColumnsVisualization,
+            ...pivotTableOptions,
+            hideEmptyColumns: false,
+            cumulativeValues: true,
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable
+                    data={weeklyColumnsData}
+                    visualization={visualization}
+                />
+            </div>
+        )
+    }
+)
+
+storiesOf('PivotTable', module).add(
     'empty columns (weekly) - hidden',
     (_, { pivotTableOptions }) => {
         const visualization = {
             ...weeklyColumnsVisualization,
             ...pivotTableOptions,
             hideEmptyColumns: true,
+        }
+        return (
+            <div style={{ width: 800, height: 600 }}>
+                <PivotTable
+                    data={weeklyColumnsData}
+                    visualization={visualization}
+                />
+            </div>
+        )
+    }
+)
+
+storiesOf('PivotTable', module).add(
+    'cumulative + empty columns (weekly) - hidden',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...weeklyColumnsVisualization,
+            ...pivotTableOptions,
+            hideEmptyColumns: true,
+            cumulativeValues: true,
         }
         return (
             <div style={{ width: 800, height: 600 }}>

--- a/src/components/Options/VisualizationOptions.js
+++ b/src/components/Options/VisualizationOptions.js
@@ -18,6 +18,7 @@ import {
     modalContent,
     tabSection,
     tabSectionTitle,
+    tabSectionTitleDisabled,
     tabSectionTitleMargin,
     tabSectionOption,
     tabSectionOptionItem,
@@ -95,6 +96,7 @@ const VisualizationOptions = ({
                     {tabContent.styles}
                     {tabSection.styles}
                     {tabSectionTitle.styles}
+                    {tabSectionTitleDisabled.styles}
                     {tabSectionTitleMargin.styles}
                     {tabSectionOption.styles}
                     {tabSectionOptionItem.styles}

--- a/src/components/Options/styles/VisualizationOptions.style.js
+++ b/src/components/Options/styles/VisualizationOptions.style.js
@@ -51,6 +51,12 @@ export const tabSectionTitle = css.resolve`
     }
 `
 
+export const tabSectionTitleDisabled = css.resolve`
+    span {
+        color: ${colors.grey600};
+    }
+`
+
 export const tabSectionTitleMargin = css.resolve`
     span {
         margin-top: ${spacers.dp8};

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -424,7 +424,7 @@ export class PivotTableEngine {
                 column: mappedColumn,
             })
 
-            if (cumulativeValue) {
+            if (cumulativeValue !== undefined && cumulativeValue !== null) {
                 // force to NUMBER for accumulated values
                 value.valueType =
                     value.valueType === undefined || value.valueType === null

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -336,6 +336,7 @@ export class PivotTableEngine {
     getRaw({ row, column }) {
         const cellType = this.getRawCellType({ row, column })
         const dxDimension = this.getRawCellDxDimension({ row, column })
+        const valueType = dxDimension?.valueType || VALUE_TYPE_TEXT
 
         const headers = [
             ...this.getRawRowHeader(row),
@@ -353,6 +354,7 @@ export class PivotTableEngine {
             return {
                 cellType,
                 empty: true,
+                valueType,
                 ouId,
                 peId,
             }
@@ -365,7 +367,6 @@ export class PivotTableEngine {
                 ? dataRow[this.dimensionLookup.dataHeaders.value]
                 : dataRow.value
         let renderedValue = rawValue
-        const valueType = dxDimension?.valueType || VALUE_TYPE_TEXT
 
         if (valueType === VALUE_TYPE_NUMBER) {
             rawValue = parseValue(rawValue)

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -422,7 +422,7 @@ export class PivotTableEngine {
             const dxDimension = this.getRawCellDxDimension({ row, column })
 
             // XXX this doesn't make much sense, it has to be numeric for accumulation
-            value.valueType = dxDimension?.valueType || VALUE_TYPE_TEXT
+            value.valueType = dxDimension?.valueType || VALUE_TYPE_NUMBER
             value.empty = false
             value.renderedValue = renderValue(
                 this.getCumulative({

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -417,7 +417,7 @@ export class PivotTableEngine {
 
         const value = this.getRaw({ row: mappedRow, column: mappedColumn })
 
-        // XXX cannot be done directly in getRaw because of the resetAccumulators function
+        // NB: cannot be done directly in getRaw because of the resetAccumulators function
         if (this.options.cumulativeValues) {
             const cumulativeValue = this.getCumulative({
                 row: mappedRow,
@@ -431,11 +431,7 @@ export class PivotTableEngine {
                         ? VALUE_TYPE_NUMBER
                         : value.valueType
                 value.empty = false
-                value.renderedValue = renderValue(
-                    cumulativeValue,
-                    value.valueType,
-                    this.visualization
-                )
+                value.renderedValue = cumulativeValue
             }
         }
 
@@ -1014,7 +1010,13 @@ export class PivotTableEngine {
                     if (value.valueType === VALUE_TYPE_NUMBER) {
                         acc += value.empty ? 0 : value.rawValue
 
-                        this.accumulators.rows[row][column] = acc
+                        const renderedValue = renderValue(
+                            acc,
+                            value.valueType,
+                            this.visualization
+                        )
+
+                        this.accumulators.rows[row][column] = renderedValue
                     }
 
                     return acc

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -1017,6 +1017,13 @@ export class PivotTableEngine {
                         )
 
                         this.accumulators.rows[row][column] = renderedValue
+
+                        // override cell sizes based on their new content
+                        // this works for non empty cells where the new value can require a wider cell
+                        this.adaptiveClippingController.add(
+                            { row, column },
+                            renderedValue
+                        )
                     }
 
                     return acc

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -520,10 +520,8 @@ export class PivotTableEngine {
             return undefined
         }
         const cellValue = this.data[row][column]
-        if (!cellValue) {
-            return undefined
-        }
-        if (!Array.isArray(cellValue)) {
+
+        if (cellValue && !Array.isArray(cellValue)) {
             // This is a total cell
             return {
                 valueType: cellValue.valueType,
@@ -559,6 +557,11 @@ export class PivotTableEngine {
             }
         }
 
+        // Empty cell
+        // The cell still needs to get the valueType to render correctly 0 and cumulative values
+        //
+        // OR
+        //
         // Data is in Filter
         // TODO : This assumes the server ignores text types, we should confirm this is the case
         return {


### PR DESCRIPTION
Implements [DHIS2-5497](https://dhis2.atlassian.net/browse/DHIS2-5497)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/2746**

**Published in [26.2.0-cumulative-values-alpha.1](https://www.npmjs.com/package/@dhis2/analytics/v/26.2.0-cumulative-values-alpha.1)**

---

### Key features

1. accumulate values horizontally when `cumulativeValues` option is checked
2. add example in Storybook

---

### Description

Similarly to the option for other vis types, values in a pivot table can be accumulated horizontally.
This behaviour is controlled by the `cumulativeValues` option in DV.

---

### TODO

-   [x] address XXX comments after code review

---

### Screenshots

Data before accumulating the values horizontally:
![Screenshot 2023-11-13 at 14 42 24](https://github.com/dhis2/analytics/assets/150978/cc4fdc41-6f45-46cc-a831-c12fbc5c3035)

Same data with accumulation:
![Screenshot 2023-11-13 at 14 43 48](https://github.com/dhis2/analytics/assets/150978/9cb0db43-2e23-453a-806b-7eaeef374c20)

[DHIS2-5497]: https://dhis2.atlassian.net/browse/DHIS2-5497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ