### PR TITLE
fix: use translated dimension labels in PT (DHIS2-15750)

### DIFF
--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -1,3 +1,4 @@
+import i18n from '@dhis2/d2-i18n'
 import times from 'lodash/times'
 import {
     DIMENSION_TYPE_DATA,
@@ -448,27 +449,31 @@ export class PivotTableEngine {
             columnLevel === lastColumnLevel &&
             this.dimensionLookup.columns[lastColumnLevel]
         ) {
-            return `${this.dimensionLookup.rows[lastRowLevel].meta.name} / ${this.dimensionLookup.columns[lastColumnLevel].meta.name}`
+            return `${i18n.t(
+                this.dimensionLookup.rows[lastRowLevel].meta.name
+            )} / ${i18n.t(
+                this.dimensionLookup.columns[lastColumnLevel].meta.name
+            )}`
         }
 
         if (lastRowLevel === -1) {
-            return this.dimensionLookup.columns[columnLevel].meta.name
+            return i18n.t(this.dimensionLookup.columns[columnLevel].meta.name)
         }
         if (lastColumnLevel === -1) {
-            return this.dimensionLookup.rows[rowLevel].meta.name
+            return i18n.t(this.dimensionLookup.rows[rowLevel].meta.name)
         }
 
         if (
             rowLevel === lastRowLevel &&
             this.dimensionLookup.columns[columnLevel]
         ) {
-            return this.dimensionLookup.columns[columnLevel].meta.name
+            return i18n.t(this.dimensionLookup.columns[columnLevel].meta.name)
         }
         if (
             columnLevel === lastColumnLevel &&
             this.dimensionLookup.rows[rowLevel]
         ) {
-            return this.dimensionLookup.rows[rowLevel].meta.name
+            return i18n.t(this.dimensionLookup.rows[rowLevel].meta.name)
         }
     }
 


### PR DESCRIPTION
Fixes [DHIS2-15750](https://dhis2.atlassian.net/browse/DHIS2-15750)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/XXX**

---

### Key features

1. use translated strings for dimension labels in PT

---

### Description

In Pivot Table visualizations it's possible to enable dimension labels via options.
These were not translated.
The PR fixes the issue by marking those strings for translation.

---

### Screenshots

Before:
<img width="374" alt="Screenshot 2023-09-06 at 12 00 10" src="https://github.com/dhis2/analytics/assets/150978/a9839834-cc4d-4dac-b159-65bc6ebc040a">

<img width="260" alt="Screenshot 2023-09-06 at 12 12 52" src="https://github.com/dhis2/analytics/assets/150978/2e840b9c-1c1d-4ce5-9738-40592b5164e7">

<img width="446" alt="Screenshot 2023-09-06 at 12 12 33" src="https://github.com/dhis2/analytics/assets/150978/ee003f04-c8a0-46bc-b415-c862ac4786ba">


After:
<img width="377" alt="Screenshot 2023-09-06 at 12 00 29" src="https://github.com/dhis2/analytics/assets/150978/e804f251-ce6b-4bf5-8953-e67fbd34aa30">

<img width="266" alt="Screenshot 2023-09-06 at 12 00 47" src="https://github.com/dhis2/analytics/assets/150978/3b229ac6-4257-4dbb-a739-a00061d527b0">

<img width="468" alt="Screenshot 2023-09-06 at 12 11 46" src="https://github.com/dhis2/analytics/assets/150978/a1f552f4-f187-432f-afd2-4b7961551421">



[DHIS2-15750]: https://dhis2.atlassian.net/browse/DHIS2-15750?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ