### PR TITLE
fix: export function for preparing payload for copy (DHIS2-15722)

### DIFF
--- a/src/components/FileMenu/utils.js
+++ b/src/components/FileMenu/utils.js
@@ -44,6 +44,7 @@ export const preparePayloadForSaveAs = ({ ...visualization }) => {
     delete visualization.id
     delete visualization.created
     delete visualization.createdBy
+    delete visualization.user
 
     return visualization
 }

--- a/src/components/FileMenu/utils.js
+++ b/src/components/FileMenu/utils.js
@@ -39,3 +39,11 @@ export const appPathFor = (fileType, id) => {
             return `${window.location.search}${window.location.hash}`
     }
 }
+
+export const preparePayloadForSaveAs = ({ ...visualization }) => {
+    delete visualization.id
+    delete visualization.created
+    delete visualization.createdBy
+
+    return visualization
+}

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ export { default as DimensionMenu } from './components/DimensionMenu.js'
 export { default as PivotTable } from './components/PivotTable/PivotTable.js'
 
 export { default as FileMenu } from './components/FileMenu/FileMenu.js'
+export { preparePayloadForSaveAs } from './components/FileMenu/utils.js'
 
 export { default as VisTypeIcon } from './components/VisTypeIcon.js'
 


### PR DESCRIPTION
Part of the fix for [DHIS2-15722](https://dhis2.atlassian.net/browse/DHIS2-15722)

**Relates to https://github.com/dhis2/line-listing-app/pull/433**

---

### Key features

1. export function for preparing the payload for visualization copy (FileMenu -> Save As)

---

### Description

The bug described in the ticket applies to all analytics apps, all need to use  the same fix.
Instead of duplicating the code in all apps, export a utility function from `analytics` that can be used by all apps.


[DHIS2-15722]: https://dhis2.atlassian.net/browse/DHIS2-15722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ