### PR TITLE
feat(pivot-table): truncate title and show full in tooltip (DHIS2-14827)

### DIFF
--- a/src/__demo__/PivotTable.stories.js
+++ b/src/__demo__/PivotTable.stories.js
@@ -1119,3 +1119,29 @@ storiesOf('PivotTable', module).add('DEGS', (_, { pivotTableOptions }) => {
         </div>
     )
 })
+
+storiesOf('PivotTable', module).add(
+    'Truncated header cell',
+    (_, { pivotTableOptions }) => {
+        const visualization = {
+            ...narrativeVisualization,
+            ...visualizationReset,
+            ...pivotTableOptions,
+            columns: narrativeVisualization.filters,
+            filters: narrativeVisualization.columns,
+            rowTotals: true,
+            colTotals: true,
+        }
+
+        const data = {
+            ...narrativeData,
+            rows: [narrativeData.rows[0]],
+        }
+
+        return (
+            <div style={{ width: 250, height: 600, marginTop: 50 }}>
+                <PivotTable data={data} visualization={visualization} />
+            </div>
+        )
+    }
+)

--- a/src/__demo__/PivotTable.stories.js
+++ b/src/__demo__/PivotTable.stories.js
@@ -1123,6 +1123,13 @@ storiesOf('PivotTable', module).add('DEGS', (_, { pivotTableOptions }) => {
 storiesOf('PivotTable', module).add(
     'Truncated header cell',
     (_, { pivotTableOptions }) => {
+        const widths = [250, 200, 500]
+        const [width, setWidth] = useState(250)
+        const toggleWidth = () =>
+            setWidth(
+                (currentWidth) =>
+                    widths[widths.indexOf(currentWidth) + 1] ?? widths[0]
+            )
         const visualization = {
             ...narrativeVisualization,
             ...visualizationReset,
@@ -1139,7 +1146,15 @@ storiesOf('PivotTable', module).add(
         }
 
         return (
-            <div style={{ width: 250, height: 600, marginTop: 50 }}>
+            <div
+                style={{
+                    width,
+                    height: 600,
+                    marginTop: 50,
+                    transition: 'width 1s',
+                }}
+            >
+                <button onClick={toggleWidth}>Toggle width</button>
                 <PivotTable data={data} visualization={visualization} />
             </div>
         )

--- a/src/components/PivotTable/PivotTableTitleRow.js
+++ b/src/components/PivotTable/PivotTableTitleRow.js
@@ -1,6 +1,6 @@
 import { Tooltip } from '@dhis2/ui'
 import PropTypes from 'prop-types'
-import React, { useRef, useMemo, useState, useEffect } from 'react'
+import React, { useRef, useState, useEffect } from 'react'
 import { PivotTableCell } from './PivotTableCell.js'
 import { usePivotTableEngine } from './PivotTableEngineContext.js'
 import { cell as cellStyle } from './styles/PivotTable.style.js'
@@ -9,25 +9,14 @@ export const PivotTableTitleRow = ({
     title,
     scrollPosition,
     containerWidth,
-    totalWidth,
 }) => {
     const containerRef = useRef(null)
     const [scrollWidth, setScrollWidth] = useState(0)
     const [isTitleTruncated, setIsTitleTruncated] = useState(false)
     const engine = usePivotTableEngine()
     const columnCount = engine.width + engine.rowDepth
-    const maxWidth = useMemo(
-        () => containerWidth - (engine.cellPadding * 2 + 2),
-        [containerWidth, engine.cellPadding]
-    )
-    const marginLeft = useMemo(
-        () =>
-            Math.max(
-                0,
-                Math.min(scrollPosition?.x ?? 0, totalWidth - containerWidth)
-            ),
-        [containerWidth, scrollPosition.x, totalWidth]
-    )
+    const maxWidth = containerWidth - (engine.cellPadding * 2 + 2)
+    const marginLeft = Math.max(0, scrollPosition?.x ?? 0)
 
     useEffect(() => {
         if (containerRef.current) {
@@ -91,5 +80,4 @@ PivotTableTitleRow.propTypes = {
     scrollPosition: PropTypes.shape({ x: PropTypes.number.isRequired })
         .isRequired,
     title: PropTypes.string.isRequired,
-    totalWidth: PropTypes.number.isRequired,
 }

--- a/src/components/PivotTable/PivotTableTitleRows.js
+++ b/src/components/PivotTable/PivotTableTitleRows.js
@@ -13,10 +13,6 @@ export const PivotTableTitleRows = ({ clippingResult, width }) => {
                     title={engine.options.title}
                     scrollPosition={clippingResult.scrollPosition}
                     containerWidth={width}
-                    totalWidth={
-                        engine.adaptiveClippingController.columns.totalSize +
-                        engine.adaptiveClippingController.columns.headerSize
-                    }
                 />
             ) : null}
             {engine.options.subtitle ? (
@@ -24,10 +20,6 @@ export const PivotTableTitleRows = ({ clippingResult, width }) => {
                     title={engine.options.subtitle}
                     scrollPosition={clippingResult.scrollPosition}
                     containerWidth={width}
-                    totalWidth={
-                        engine.adaptiveClippingController.columns.totalSize +
-                        engine.adaptiveClippingController.columns.headerSize
-                    }
                 />
             ) : null}
             {engine.visualization.filters?.length ? (
@@ -38,10 +30,6 @@ export const PivotTableTitleRows = ({ clippingResult, width }) => {
                     )}
                     scrollPosition={clippingResult.scrollPosition}
                     containerWidth={width}
-                    totalWidth={
-                        engine.adaptiveClippingController.columns.totalSize +
-                        engine.adaptiveClippingController.columns.headerSize
-                    }
                 />
             ) : null}
         </>

--- a/src/components/PivotTable/styles/PivotTable.style.js
+++ b/src/components/PivotTable/styles/PivotTable.style.js
@@ -112,12 +112,22 @@ export const cell = css`
     .title-cell {
         font-weight: bold;
         background-color: #cddaed;
+        padding: 0;
     }
     .title-cell-content {
         text-align: center;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
+    }
+    .title-cell.displaydensity-COMPACT > .title-cell-content {
+        padding: ${DISPLAY_DENSITY_PADDING_COMPACT}px;
+    }
+    .title-cell.displaydensity-NORMAL > .title-cell-content {
+        padding: ${DISPLAY_DENSITY_PADDING_NORMAL}px;
+    }
+    .title-cell.displaydensity-COMFORTABLE > .title-cell-content {
+        padding: ${DISPLAY_DENSITY_PADDING_COMFORTABLE}px;
     }
     .row-header {
         background-color: #dae6f8;

--- a/src/components/PivotTable/styles/PivotTable.style.js
+++ b/src/components/PivotTable/styles/PivotTable.style.js
@@ -109,9 +109,15 @@ export const cell = css`
         align-items: center;
         justify-content: center;
     }
-    .title {
+    .title-cell {
         font-weight: bold;
         background-color: #cddaed;
+    }
+    .title-cell-content {
+        text-align: center;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
     .row-header {
         background-color: #dae6f8;


### PR DESCRIPTION
Implements [DHIS2-14827](https://dhis2.atlassian.net/browse/DHIS2-14827)

---

### Key features

1. Because we now truncate the title, long filters won't stretch the table horizontally anymore
2. Once the title gets truncated a tooltip will be available for users to see the full title

---

### Description

Before adding the tooltip functionality, I also addressed a small bug: the `max-width` for `div.title-cell-content` didn't take into account the cell padding and border and as such the value was a bit too high.

The tooltip is only added if the title text is overflowing the container.

I also added a story to demo the feature.

---

### Considerations

-   The title cell has 5px padding in all directions. As a result, `div.title-cell-content`, which is the tooltip anchor element, has 5px of whitespace around it. So the tooltip only shows when hovering the actual text, not the entire table cell. I'm not sure if this is a bug or a feature. I _think_ changing this behaviour should be relatively simple, but just not sure whether we want to.

---

### TODO

-   [ ] Upgrade DV to the to-be-released version of @dhis2/analytics so it can benefit form this feature.
-   [x] Decide if we want to keep the padding around the tooltip anchor, and make necessary changes if we don't. WE DECIDED TO FILL OUT THE CELL (see [2a47d1a](https://github.com/dhis2/analytics/pull/1579/commits/2a47d1ac9459641058af62d9082fbb8898032002))

---


### Screenshots

<img width="313" alt="Screenshot 2023-09-13 at 09 48 44" src="https://github.com/dhis2/analytics/assets/353236/e2745b3e-18b3-4f3c-9ee3-174b7ca5de79">


[DHIS2-14827]: https://dhis2.atlassian.net/browse/DHIS2-14827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ