### PR TITLE
fix: avoid crash in DV with some chart types (DHIS2-15882)

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/chart.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/chart.js
@@ -22,7 +22,11 @@ const getEvents = () => ({
                 if (item.legendSymbol) {
                     item.legendSymbol.attr({
                         translateY:
-                            -((item.legendItem.getBBox().height * 0.75) / 4) +
+                            -(
+                                (item.legendItem.label.getBBox().height *
+                                    0.75) /
+                                4
+                            ) +
                             item.legendSymbol.r / 2,
                     })
                 }

--- a/src/visualizations/config/generators/highcharts/index.js
+++ b/src/visualizations/config/generators/highcharts/index.js
@@ -20,6 +20,8 @@ function drawLegendSymbolWrap() {
         H.seriesTypes.column.prototype,
         'drawLegendSymbol',
         function (proceed, legend, item) {
+            const legendItem = item.legendItem
+
             if (this.options.legendSet?.legends?.length) {
                 const ys = legend.baseline - legend.symbolHeight + 1, // y start
                     x = legend.symbolWidth / 2 > 8 ? legend.symbolWidth / 2 : 8, // x start
@@ -32,7 +34,7 @@ function drawLegendSymbolWrap() {
                     .attr({
                         fill: legends[legends.length >= 5 ? 1 : 0].color,
                     })
-                    .add(this.legendGroup)
+                    .add(legendItem.group)
                 this.chart.renderer
                     .path(['M', x, ye, 'A', 1, 1, 0, 0, 0, x, ys, 'V', ye])
                     .attr({
@@ -42,13 +44,14 @@ function drawLegendSymbolWrap() {
                                 : legends.length - 1
                         ].color,
                     })
-                    .add(this.legendGroup)
+                    .add(legendItem.group)
             } else {
                 var options = legend.options,
                     symbolHeight = legend.symbolHeight,
                     square = options.squareSymbol,
                     symbolWidth = square ? symbolHeight : legend.symbolWidth
-                item.legendSymbol = this.chart.renderer
+
+                legendItem.symbol = this.chart.renderer
                     .rect(
                         square ? (legend.symbolWidth - symbolHeight) / 2 : 0,
                         legend.baseline - symbolHeight + 1,
@@ -60,7 +63,7 @@ function drawLegendSymbolWrap() {
                     .attr({
                         zIndex: 3,
                     })
-                    .add(item.legendGroup)
+                    .add(legendItem.group)
             }
         }
     )


### PR DESCRIPTION
Implements [DHIS2-15882](https://dhis2.atlassian.net/browse/DHIS2-15882)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/XXX**

---

### Key features

1. use new object structure for `legendItem`

---

### Description

Highcharts changed the internal structure of the `legendItem` object from version 10.3.1.

Before there were 3 properties: `legendItem`, `legendSymbol` and `legendGroup`.
Now `legendItem` contains `label` (previously `legendItem`), `group` (previously `legendGroup`) and (apparently) `symbol` (previously `legendSymbol`).

We use this internal object for handling custom legend symbols.
This fixes the crash in DV when using certain chart types (column, stacked column, bar, stacked bar).

### TODO

-   [x] figure out why the legend symbol is not rendered
-   [x] figure out why when trying to [replicate the issue with a simple example](https://jsfiddle.net/r8sLx2h3/2/) `legendItem` is different than what we see in DV app where `legendSymbol` is still present and `legendItem` contains only `group` and `label`

---

### Known issues

-   [x] ~the legend symbol is not rendered~ solved [here](https://github.com/dhis2/analytics/pull/1582/commits/7068772326134d359f662a0a6a5086e1397e2db1)

---

### Screenshots

Before:
<img width="560" alt="Screenshot 2023-09-27 at 12 21 49" src="https://github.com/dhis2/analytics/assets/150978/4fb26fb7-f266-40ba-95c4-2f71f7cd1ea8">


After:
<img width="1128" alt="Screenshot 2023-09-27 at 15 30 30" src="https://github.com/dhis2/analytics/assets/150978/96b4d322-47c5-4dee-be42-673826a83e0c">




[DHIS2-15882]: https://dhis2.atlassian.net/browse/DHIS2-15882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ