### PR TITLE
fix: handle both Set and array for currentUser.authorities when checking interpretations access [DHIS2-15964]

### DIFF
--- a/src/components/Interpretations/common/__tests__/getInterpretationAccess.spec.js
+++ b/src/components/Interpretations/common/__tests__/getInterpretationAccess.spec.js
@@ -1,4 +1,5 @@
 import {
+    hasAuthority,
     getInterpretationAccess,
     getCommentAccess,
 } from '../getInterpretationAccess.js'
@@ -34,6 +35,18 @@ const userJane = {
 }
 
 describe('interpretation and comment access', () => {
+    describe('hasAuthority', () => {
+        it('throws an error when no authority is provided', () => {
+            expect(() => hasAuthority([], undefined)).toThrow(
+                '"hasAuthority" requires "authority" to be a populated string but received undefined'
+            )
+        })
+        it('throws an error when authority is not a string', () => {
+            expect(() => hasAuthority([], 12)).toThrow(
+                '"hasAuthority" requires "authority" to be a populated string but received 12'
+            )
+        })
+    })
     describe('getInterpretationAccess', () => {
         it('returns true for all accesses for superuser', () => {
             const interpretation = {
@@ -129,7 +142,7 @@ describe('interpretation and comment access', () => {
             })
         })
 
-        it('returns false for all accesses when no currentUser provided', () => {
+        it('throws an error for all accesses when no currentUser provided', () => {
             const interpretation = {
                 access: {
                     write: false,
@@ -138,15 +151,12 @@ describe('interpretation and comment access', () => {
                 createdBy: userJane,
             }
 
-            expect(getInterpretationAccess(interpretation)).toMatchObject({
-                share: false,
-                comment: false,
-                edit: false,
-                delete: false,
-            })
+            expect(() => getInterpretationAccess(interpretation)).toThrow(
+                '"hasAuthority" requires "authorities" to be an array or set of authorities (strings)'
+            )
         })
 
-        it('returns false for all accesses when currentUser missing authorities', () => {
+        it('throws an error when currentUser is missing authorities', () => {
             const interpretation = {
                 access: {
                     write: false,
@@ -155,16 +165,13 @@ describe('interpretation and comment access', () => {
                 createdBy: userJane,
             }
 
-            expect(
+            expect(() =>
                 getInterpretationAccess(interpretation, {
                     id: 'usernoauthorties',
                 })
-            ).toMatchObject({
-                share: false,
-                comment: false,
-                edit: false,
-                delete: false,
-            })
+            ).toThrow(
+                '"hasAuthority" requires "authorities" to be an array or set of authorities (strings)'
+            )
         })
     })
 

--- a/src/components/Interpretations/common/__tests__/getInterpretationAccess.spec.js
+++ b/src/components/Interpretations/common/__tests__/getInterpretationAccess.spec.js
@@ -3,23 +3,38 @@ import {
     getCommentAccess,
 } from '../getInterpretationAccess.js'
 
-const superuser = {
+const superuserD2CurrentUser = {
     id: 'iamsuper',
     authorities: new Set(['ALL']),
 }
 
-const userJoe = {
+const userJoeD2CurrentUser = {
     id: 'johndoe',
     authorities: new Set(['Some']),
 }
 
-const userJane = {
+const userJaneD2CurrentUser = {
     id: 'jane',
     authorities: new Set(['Some']),
 }
 
+const superuser = {
+    id: 'iamsuper',
+    authorities: ['ALL'],
+}
+
+const userJoe = {
+    id: 'johndoe',
+    authorities: ['Some'],
+}
+
+const userJane = {
+    id: 'jane',
+    authorities: ['Some'],
+}
+
 describe('interpretation and comment access', () => {
-    describe('getInterpretationAccess', () => {
+    describe('getInterpretationAccess with D2', () => {
         it('returns true for all accesses for superuser', () => {
             const interpretation = {
                 access: {
@@ -109,6 +124,234 @@ describe('interpretation and comment access', () => {
             ).toMatchObject({
                 share: false,
                 comment: false,
+                edit: false,
+                delete: false,
+            })
+        })
+
+        it('returns false for all accesses when no currentUser provided', () => {
+            const interpretation = {
+                access: {
+                    write: false,
+                    manage: false,
+                },
+                createdBy: userJane,
+            }
+
+            expect(getInterpretationAccess(interpretation)).toMatchObject({
+                share: false,
+                comment: false,
+                edit: false,
+                delete: false,
+            })
+        })
+
+        it('returns false for all accesses when currentUser missing authorities', () => {
+            const interpretation = {
+                access: {
+                    write: false,
+                    manage: false,
+                },
+                createdBy: userJane,
+            }
+
+            expect(
+                getInterpretationAccess(interpretation, {
+                    id: 'usernoauthorties',
+                })
+            ).toMatchObject({
+                share: false,
+                comment: false,
+                edit: false,
+                delete: false,
+            })
+        })
+    })
+
+    describe('getInterpretationAccess using D2.currentUser', () => {
+        it('returns true for all accesses for superuser', () => {
+            const interpretation = {
+                access: {
+                    write: true,
+                    manage: true,
+                },
+                createdBy: userJoeD2CurrentUser,
+            }
+
+            expect(
+                getInterpretationAccess(interpretation, superuserD2CurrentUser)
+            ).toMatchObject({
+                share: true,
+                comment: true,
+                edit: true,
+                delete: true,
+            })
+        })
+        it('returns true for all accesses for creator', () => {
+            const interpretation = {
+                access: {
+                    write: true,
+                    manage: true,
+                },
+                createdBy: userJoeD2CurrentUser,
+            }
+
+            expect(
+                getInterpretationAccess(interpretation, userJoeD2CurrentUser)
+            ).toMatchObject({
+                share: true,
+                comment: true,
+                edit: true,
+                delete: true,
+            })
+        })
+
+        it('returns false for edit/delete if user is not creator/superuser', () => {
+            const interpretation = {
+                access: {
+                    write: true,
+                    manage: true,
+                },
+                createdBy: userJaneD2CurrentUser,
+            }
+
+            expect(
+                getInterpretationAccess(interpretation, userJoeD2CurrentUser)
+            ).toMatchObject({
+                share: true,
+                comment: true,
+                edit: false,
+                delete: false,
+            })
+        })
+
+        it('returns false for comment/edit/delete if user is not creator/superuser and no write access', () => {
+            const interpretation = {
+                access: {
+                    write: false,
+                    manage: true,
+                },
+                createdBy: userJaneD2CurrentUser,
+            }
+
+            expect(
+                getInterpretationAccess(interpretation, userJoeD2CurrentUser)
+            ).toMatchObject({
+                share: true,
+                comment: false,
+                edit: false,
+                delete: false,
+            })
+        })
+
+        it('returns false for share/comment/edit/delete if user is not creator/superuser and no write or manage access', () => {
+            const interpretation = {
+                access: {
+                    write: false,
+                    manage: false,
+                },
+                createdBy: userJaneD2CurrentUser,
+            }
+
+            expect(
+                getInterpretationAccess(interpretation, userJoeD2CurrentUser)
+            ).toMatchObject({
+                share: false,
+                comment: false,
+                edit: false,
+                delete: false,
+            })
+        })
+    })
+
+    describe('getCommentAccess using D2.currentUser', () => {
+        it('returns true for all accesses for superuser', () => {
+            const interpretation = {
+                access: {
+                    write: true,
+                },
+            }
+
+            const comment = {
+                createdBy: userJoeD2CurrentUser,
+            }
+
+            expect(
+                getCommentAccess(
+                    comment,
+                    interpretation.access.write,
+                    superuserD2CurrentUser
+                )
+            ).toMatchObject({
+                edit: true,
+                delete: true,
+            })
+        })
+
+        it('returns true for all accesses for creator when interpretation has write access', () => {
+            const interpretation = {
+                access: {
+                    write: true,
+                },
+            }
+
+            const comment = {
+                createdBy: userJoeD2CurrentUser,
+            }
+
+            expect(
+                getCommentAccess(
+                    comment,
+                    interpretation.access.write,
+                    userJoeD2CurrentUser
+                )
+            ).toMatchObject({
+                edit: true,
+                delete: true,
+            })
+        })
+
+        it('returns true for edit and false for delete for creator when interpretation does not have write access', () => {
+            const interpretation = {
+                access: {
+                    write: false,
+                },
+            }
+
+            const comment = {
+                createdBy: userJoeD2CurrentUser,
+            }
+
+            expect(
+                getCommentAccess(
+                    comment,
+                    interpretation.access.write,
+                    userJoeD2CurrentUser
+                )
+            ).toMatchObject({
+                edit: true,
+                delete: false,
+            })
+        })
+
+        it('returns false for edit/delete for user who is not creator or superuser', () => {
+            const interpretation = {
+                access: {
+                    write: true,
+                },
+            }
+
+            const comment = {
+                createdBy: userJaneD2CurrentUser,
+            }
+
+            expect(
+                getCommentAccess(
+                    comment,
+                    interpretation.access.write,
+                    userJoeD2CurrentUser
+                )
+            ).toMatchObject({
                 edit: false,
                 delete: false,
             })

--- a/src/components/Interpretations/common/__tests__/getInterpretationAccess.spec.js
+++ b/src/components/Interpretations/common/__tests__/getInterpretationAccess.spec.js
@@ -1,5 +1,4 @@
 import {
-    hasAuthority,
     getInterpretationAccess,
     getCommentAccess,
 } from '../getInterpretationAccess.js'
@@ -35,18 +34,6 @@ const userJane = {
 }
 
 describe('interpretation and comment access', () => {
-    describe('hasAuthority', () => {
-        it('throws an error when no authority is provided', () => {
-            expect(() => hasAuthority([], undefined)).toThrow(
-                '"hasAuthority" requires "authority" to be a populated string but received undefined'
-            )
-        })
-        it('throws an error when authority is not a string', () => {
-            expect(() => hasAuthority([], 12)).toThrow(
-                '"hasAuthority" requires "authority" to be a populated string but received 12'
-            )
-        })
-    })
     describe('getInterpretationAccess', () => {
         it('returns true for all accesses for superuser', () => {
             const interpretation = {

--- a/src/components/Interpretations/common/__tests__/getInterpretationAccess.spec.js
+++ b/src/components/Interpretations/common/__tests__/getInterpretationAccess.spec.js
@@ -34,7 +34,7 @@ const userJane = {
 }
 
 describe('interpretation and comment access', () => {
-    describe('getInterpretationAccess with D2', () => {
+    describe('getInterpretationAccess', () => {
         it('returns true for all accesses for superuser', () => {
             const interpretation = {
                 access: {

--- a/src/components/Interpretations/common/getInterpretationAccess.js
+++ b/src/components/Interpretations/common/getInterpretationAccess.js
@@ -1,12 +1,15 @@
 // For backwards compatibility
 // accept both Set (from the old d2.currentUser object) and array
-const hasAuthority = (authorities = [], authority) => {
-    if (Array.isArray(authorities)) {
+const hasAuthority = (authorities, authority) => {
+    if (!authority || typeof authority !== 'string) {
+        throw new Error(`"hasAuthority" requires "authority" to be a populated string but received ${authority}`)
+    } else if (Array.isArray(authorities)) {
         return authorities.includes(authority)
+    } else if (typeof authorities.has === 'function') {
+        return authorities.has(authority)
+    } else {
+        throw new Error(`"hasAuthority" requires "authorities" to be an array or set of authorities (strings)`)
     }
-    return typeof authorities.has === 'function'
-        ? authorities.has(authority)
-        : false
 }
 
 const isSuperuser = (authorities) => hasAuthority(authorities, 'ALL')

--- a/src/components/Interpretations/common/getInterpretationAccess.js
+++ b/src/components/Interpretations/common/getInterpretationAccess.js
@@ -1,15 +1,20 @@
 // For backwards compatibility
 // accept both Set (from the old d2.currentUser object) and array
-const hasAuthority = (authorities, authority) => {
-    if (!authority || typeof authority !== 'string) {
-        throw new Error(`"hasAuthority" requires "authority" to be a populated string but received ${authority}`)
-    } else if (Array.isArray(authorities)) {
-        return authorities.includes(authority)
-    } else if (typeof authorities.has === 'function') {
-        return authorities.has(authority)
-    } else {
-        throw new Error(`"hasAuthority" requires "authorities" to be an array or set of authorities (strings)`)
+export const hasAuthority = (authorities, authority) => {
+    if (!authority || typeof authority !== 'string') {
+        throw new Error(
+            `"hasAuthority" requires "authority" to be a populated string but received ${authority}`
+        )
     }
+    if (!(Array.isArray(authorities) || authorities instanceof Set)) {
+        throw new Error(
+            `"hasAuthority" requires "authorities" to be an array or set of authorities (strings)`
+        )
+    }
+
+    return Array.isArray(authorities)
+        ? authorities.includes(authority)
+        : authorities.has(authority)
 }
 
 const isSuperuser = (authorities) => hasAuthority(authorities, 'ALL')

--- a/src/components/Interpretations/common/getInterpretationAccess.js
+++ b/src/components/Interpretations/common/getInterpretationAccess.js
@@ -1,6 +1,6 @@
 // For backwards compatibility
 // accept both Set (from the old d2.currentUser object) and array
-export const hasAuthority = (authorities, authority) => {
+const hasAuthority = (authorities, authority) => {
     if (!authority || typeof authority !== 'string') {
         throw new Error(
             `"hasAuthority" requires "authority" to be a populated string but received ${authority}`

--- a/src/components/Interpretations/common/getInterpretationAccess.js
+++ b/src/components/Interpretations/common/getInterpretationAccess.js
@@ -1,6 +1,17 @@
+import { isArray } from 'lodash'
+
+// For backwards compatibility
+// accept both Set (from the old d2.currentUser object) and array
+const isSuperuser = (authorities = []) => {
+    if (isArray(authorities)) {
+        return authorities.includes('ALL')
+    }
+    return authorities.has('ALL')
+}
+
 const isCreatorOrSuperuser = (object, currentUser) =>
     object?.createdBy.id === currentUser?.id ||
-    currentUser?.authorities.has('ALL')
+    isSuperuser(currentUser?.authorities)
 
 export const getInterpretationAccess = (interpretation, currentUser) => {
     const canEditDelete = isCreatorOrSuperuser(interpretation, currentUser)


### PR DESCRIPTION
Fixes https://dhis2.atlassian.net/browse/DHIS2-15964

In the olden days when we used d2.currentUser, `authorities` was a Set.
With the migration to the app-runtime, requesting currentUser or /me with the dataEngine, the `authorities` will be an array.

Choosing here to handle both instead of requiring array (and thus a major upgrade) since we have no documentation or strict types on our functions/components.

So apps that get the currentUser from d2 (like DV) and apps that get currentUser from dataEngine(like LL) will both work.

Maybe support for Set can be removed in a future major release.