### PR TITLE
fix: use correct colors in "basic" color set (DHIS2-16108)

### DIFF
--- a/src/visualizations/util/colors/colorSets.js
+++ b/src/visualizations/util/colors/colorSets.js
@@ -37,7 +37,14 @@ export const colorSets = {
         ],
     },
     [COLOR_SET_BASIC]: {
-        colors: ['#348F41', '#9F2241', '#DDDDDD', '#B4A269'],
+        colors: [
+            '#348F41',
+            '#9F2241',
+            '#B4A269',
+            '#EBEEF3',
+            '#58595B',
+            '#1A5632',
+        ],
     },
     [COLOR_SET_EXTENDED]: {
         colors: [


### PR DESCRIPTION
Implements [DHIS2-16108](https://dhis2.atlassian.net/browse/DHIS2-16108)

This PR updates the colors of the "Basic" color set according to the request from HISP SA.

- [x] Test DV locally

[DHIS2-16108]: https://dhis2.atlassian.net/browse/DHIS2-16108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

After:

![Screenshot from 2023-11-03 15-07-49](https://github.com/dhis2/analytics/assets/1010094/9baf514d-d9a6-4b0a-bc61-71e53cf4fec4)
