### PR TITLE
fix: use json+patch for PATCH requests

### DIFF
--- a/src/api/expression.js
+++ b/src/api/expression.js
@@ -11,11 +11,14 @@ export const createCalculationMutation = {
 }
 
 export const updateCalculationMutation = {
-    type: 'update',
+    type: 'json-patch',
     resource: 'expressionDimensionItems',
-    partial: true,
     id: ({ id }) => id,
-    data: ({ name, expression }) => ({ name, shortName: name, expression }),
+    data: ({ name, expression }) => [
+        { op: 'add', path: '/name', value: name },
+        { op: 'add', path: '/shortName', value: name },
+        { op: 'add', path: '/expression', value: expression },
+    ],
 }
 
 export const deleteCalculationMutation = {

--- a/src/components/FileMenu/RenameDialog.js
+++ b/src/components/FileMenu/RenameDialog.js
@@ -19,12 +19,25 @@ import {
     labelForFileType,
 } from './utils.js'
 
+const formatPayload = (name, description) => {
+    const payload = [{ op: 'add', path: '/name', value: name }]
+
+    if (description) {
+        payload.push({
+            op: 'add',
+            path: '/description',
+            value: description,
+        })
+    }
+
+    return payload
+}
+
 const getMutation = (type) => ({
     resource: endpointFromFileType(type),
     id: ({ id }) => id,
-    type: 'update',
-    partial: true,
-    data: ({ name, description }) => ({ name, description }),
+    type: 'json-patch',
+    data: ({ name, description }) => formatPayload(name, description),
 })
 
 export const RenameDialog = ({ type, object, onClose, onRename, onError }) => {

--- a/src/components/FileMenu/RenameDialog.js
+++ b/src/components/FileMenu/RenameDialog.js
@@ -65,7 +65,7 @@ export const RenameDialog = ({ type, object, onClose, onRename, onError }) => {
     }
 
     return (
-        <Modal onClose={onClose}>
+        <Modal onClose={onClose} dataTest="file-menu-rename-modal">
             <style jsx>{modalStyles}</style>
             <ModalTitle>
                 {i18n.t('Rename {{fileType}}', {
@@ -80,6 +80,7 @@ export const RenameDialog = ({ type, object, onClose, onRename, onError }) => {
                         required
                         value={name}
                         onChange={({ value }) => setName(value)}
+                        dataTest="file-menu-rename-modal-name"
                     />
                     <TextAreaField
                         label={i18n.t('Description')}
@@ -87,15 +88,26 @@ export const RenameDialog = ({ type, object, onClose, onRename, onError }) => {
                         value={description}
                         rows={3}
                         onChange={({ value }) => setDescription(value)}
+                        dataTest="file-menu-rename-modal-description"
                     />
                 </div>
             </ModalContent>
             <ModalActions>
                 <ButtonStrip>
-                    <Button onClick={onClose} disabled={loading} secondary>
+                    <Button
+                        onClick={onClose}
+                        disabled={loading}
+                        secondary
+                        dataTest="file-menu-rename-modal-cancel"
+                    >
                         {i18n.t('Cancel')}
                     </Button>
-                    <Button onClick={renameObject} disabled={loading} primary>
+                    <Button
+                        onClick={renameObject}
+                        disabled={loading}
+                        primary
+                        dataTest="file-menu-rename-modal-rename"
+                    >
                         {i18n.t('Rename')}
                     </Button>
                 </ButtonStrip>


### PR DESCRIPTION
Fixes [DHIS2-16154](https://dhis2.atlassian.net/browse/DHIS2-16154)

**Relates to https://github.com/dhis2/line-listing-app/pull/455**

---

### Key features

1. fix PATCH request in FileMenu -> Rename
2. fix PATCH request in custom calculations

---

### Description

In some cases we don't want to send the whole payload when updating some object via an api request.
Before we used an `update` request type with `partial` set to true in `app-runtime`.
This type of PATCH request is deprecated.
The new way of doing this is by using a `json+patch` request.
`app-runtime` supports this but some changes are needed in our apps wherever a partial update is used.

---

### Screenshots

Before, adding/editing a description in the rename dialog throws an error:
![Screenshot 2023-11-06 at 14 17 43](https://github.com/dhis2/analytics/assets/150978/ac5d08cc-9885-402e-a48d-a11a4b3f2e86)


After, adding/editing the description in the rename dialog works, the payload is now formatted as json+patch:
![Screenshot 2023-11-06 at 14 20 36](https://github.com/dhis2/analytics/assets/150978/a44682e2-6fc9-4faf-a9db-c76f0e5fd175)
![Screenshot 2023-11-06 at 14 22 51](https://github.com/dhis2/analytics/assets/150978/ea6aa2ea-9b5d-4c11-bbf7-7fe875d13b2f)


[DHIS2-16154]: https://dhis2.atlassian.net/browse/DHIS2-16154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ