### PR TITLE
fix: use translated title and subtitle when available (DHIS2-16216)

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/subtitle/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/subtitle/index.js
@@ -50,8 +50,11 @@ export default function (series, layout, metaData, dashboard) {
     }
 
     // DHIS2-578: allow for optional custom subtitle
-    if (isString(layout.subtitle)) {
-        subtitle.text = layout.subtitle
+    const customSubtitle =
+        (layout.subtitle && layout.displaySubtitle) || layout.subtitle
+
+    if (isString(customSubtitle) && customSubtitle.length) {
+        subtitle.text = customSubtitle
     } else {
         const filterTitle = getFilterText(layout.filters, metaData)
 

--- a/src/visualizations/config/adapters/dhis_highcharts/title/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/title/index.js
@@ -55,8 +55,10 @@ export default function (layout, metaData, dashboard) {
         return title
     }
 
-    if (isString(layout.title) && layout.title.length) {
-        title.text = layout.title
+    const customTitle = (layout.title && layout.displayTitle) || layout.title
+
+    if (isString(customTitle) && customTitle.length) {
+        title.text = customTitle
     } else {
         switch (layout.type) {
             case VIS_TYPE_GAUGE:


### PR DESCRIPTION
Fixes [DHIS2-16216](https://dhis2.atlassian.net/browse/DHIS2-16216)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/2929**

---

### Key features

1. use translated title and subtitle in charts

---

### Description

When translations are available for `title` and `subtitle`, they should be used instead of the original version.
These translations can be added in the Translations app.

---

### Screenshots

Before:
<img width="1010" alt="Screenshot 2023-12-07 at 16 00 08" src="https://github.com/dhis2/analytics/assets/150978/9cbbf0fa-4a60-44b0-8e31-1dea2acda5ab">

After:
<img width="1001" alt="Screenshot 2023-12-07 at 16 04 42" src="https://github.com/dhis2/analytics/assets/150978/0ded4d18-d4fe-474a-b45e-7347e8af7510">


[DHIS2-16216]: https://dhis2.atlassian.net/browse/DHIS2-16216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ