### PR TITLE
fix: add white-space css to preserve paragraphs in interpretations (DHIS2-16365)

### DIFF
--- a/src/components/Interpretations/common/Message/Message.js
+++ b/src/components/Interpretations/common/Message/Message.js
@@ -49,6 +49,7 @@ const Message = ({ children, text, created, username }) => {
                     line-height: 19px;
                     color: ${colors.grey900};
                     word-break: break-word;
+                    white-space: pre-line;
                 }
 
                 .content :global(p:first-child) {


### PR DESCRIPTION
Fixes [DHIS2-16365](https://dhis2.atlassian.net/browse/DHIS2-16365)

Before: 
<img width="391" alt="image" src="https://github.com/dhis2/analytics/assets/6113918/1703bc01-1058-4138-9970-0c8b0ee12c9f">

After:
<img width="413" alt="image" src="https://github.com/dhis2/analytics/assets/6113918/8965518c-d49b-403e-9b58-bf3921e16c55">


[DHIS2-16365]: https://dhis2.atlassian.net/browse/DHIS2-16365?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ