### PR TITLE
fix: interpretations panel renders with flashing when liking or unliking an interpretation

### DIFF
--- a/src/components/Interpretations/InterpretationModal/InterpretationModal.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationModal.js
@@ -99,6 +99,7 @@ const InterpretationModal = ({
     }
 
     const onLikeToggled = ({ likedBy }) => {
+        setIsDirty(true)
         interpretation.likedBy = likedBy
         interpretation.likes = likedBy.length
     }

--- a/src/components/Interpretations/InterpretationModal/InterpretationModal.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationModal.js
@@ -77,13 +77,15 @@ const InterpretationModal = ({
 }) => {
     const modalContentWidth = useModalContentWidth()
     const modalContentCSS = getModalContentCSS(modalContentWidth)
+    const [isLikeToggle, setIsLikeToggle] = useState(false)
     const [isDirty, setIsDirty] = useState(false)
     const { data, error, loading, fetching, refetch } = useDataQuery(query, {
         lazy: true,
+        onComplete: () => setIsLikeToggle(false),
     })
     const interpretation = data?.interpretation
     const shouldRenderModalContent = !error && interpretation
-    const shouldCssHideModal = loading || isVisualizationLoading
+    const loadingInProgress = loading || isVisualizationLoading
     const handleClose = () => {
         if (isDirty) {
             onInterpretationUpdate()
@@ -91,10 +93,11 @@ const InterpretationModal = ({
         }
         onClose()
     }
-    const onThreadUpdated = (affectsInterpretation) => {
+    const onThreadUpdated = (affectsInterpretation, isLike = false) => {
         if (affectsInterpretation) {
             setIsDirty(true)
         }
+        setIsLikeToggle(isLike)
         refetch({ id: interpretationId })
     }
     const onInterpretationDeleted = () => {
@@ -111,7 +114,7 @@ const InterpretationModal = ({
 
     return (
         <>
-            {shouldCssHideModal && (
+            {loadingInProgress && (
                 <Layer>
                     <CenteredContent>
                         <CircularLoader />
@@ -122,7 +125,7 @@ const InterpretationModal = ({
                 fluid
                 onClose={handleClose}
                 className={cx(modalCSS.className, {
-                    hidden: shouldCssHideModal,
+                    hidden: loadingInProgress,
                 })}
                 dataTest="interpretation-modal"
             >
@@ -183,6 +186,7 @@ const InterpretationModal = ({
                                         downloadMenuComponent={
                                             downloadMenuComponent
                                         }
+                                        isLikeToggle={isLikeToggle}
                                     />
                                 </div>
                             </div>

--- a/src/components/Interpretations/InterpretationModal/InterpretationModal.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationModal.js
@@ -77,11 +77,9 @@ const InterpretationModal = ({
 }) => {
     const modalContentWidth = useModalContentWidth()
     const modalContentCSS = getModalContentCSS(modalContentWidth)
-    const [isLikeToggle, setIsLikeToggle] = useState(false)
     const [isDirty, setIsDirty] = useState(false)
     const { data, error, loading, fetching, refetch } = useDataQuery(query, {
         lazy: true,
-        onComplete: () => setIsLikeToggle(false),
     })
     const interpretation = data?.interpretation
     const shouldRenderModalContent = !error && interpretation
@@ -93,13 +91,18 @@ const InterpretationModal = ({
         }
         onClose()
     }
-    const onThreadUpdated = (affectsInterpretation, isLike = false) => {
+    const onThreadUpdated = (affectsInterpretation) => {
         if (affectsInterpretation) {
             setIsDirty(true)
         }
-        setIsLikeToggle(isLike)
         refetch({ id: interpretationId })
     }
+
+    const onLikeToggled = ({ likedBy }) => {
+        interpretation.likedBy = likedBy
+        interpretation.likes = likedBy.length
+    }
+
     const onInterpretationDeleted = () => {
         setIsDirty(false)
         onInterpretationUpdate()
@@ -186,7 +189,7 @@ const InterpretationModal = ({
                                         downloadMenuComponent={
                                             downloadMenuComponent
                                         }
-                                        isLikeToggle={isLikeToggle}
+                                        onLikeToggled={onLikeToggled}
                                     />
                                 </div>
                             </div>

--- a/src/components/Interpretations/InterpretationModal/InterpretationThread.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationThread.js
@@ -35,7 +35,7 @@ const InterpretationThread = ({
     )
 
     return (
-        <div className={cx('container', { fetching: fetching })}>
+        <div className={cx('container', { fetching })}>
             <div className={'title'}>
                 <IconClock16 color={colors.grey700} />
                 {moment(fromServerDate(interpretation.created)).format('LLL')}
@@ -53,10 +53,9 @@ const InterpretationThread = ({
                             ? () => focusRef.current?.focus()
                             : null
                     }
-                    onUpdated={(isLike) => onThreadUpdated(true, isLike)}
+                    onUpdated={() => onThreadUpdated(true)}
                     onDeleted={onInterpretationDeleted}
                     isInThread={true}
-                    fetching={fetching}
                 />
                 <div className={'comments'}>
                     {interpretation.comments.map((comment) => (

--- a/src/components/Interpretations/InterpretationModal/InterpretationThread.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationThread.js
@@ -16,6 +16,7 @@ const InterpretationThread = ({
     initialFocus,
     onThreadUpdated,
     downloadMenuComponent: DownloadMenu,
+    isLikeToggle,
 }) => {
     const { fromServerDate } = useTimeZoneConversion()
     const focusRef = useRef()
@@ -34,7 +35,9 @@ const InterpretationThread = ({
     )
 
     return (
-        <div className={cx('container', { fetching })}>
+        <div
+            className={cx('container', { fetching: fetching && !isLikeToggle })}
+        >
             <div className={'title'}>
                 <IconClock16 color={colors.grey700} />
                 {moment(fromServerDate(interpretation.created)).format('LLL')}
@@ -51,9 +54,10 @@ const InterpretationThread = ({
                             ? () => focusRef.current?.focus()
                             : null
                     }
-                    onUpdated={() => onThreadUpdated(true)}
+                    onUpdated={(isLike) => onThreadUpdated(true, isLike)}
                     onDeleted={onInterpretationDeleted}
                     isInThread={true}
+                    fetching={fetching}
                 />
                 <div className={'comments'}>
                     {interpretation.comments.map((comment) => (
@@ -150,6 +154,7 @@ InterpretationThread.propTypes = {
     currentUser: PropTypes.object.isRequired,
     fetching: PropTypes.bool.isRequired,
     interpretation: PropTypes.object.isRequired,
+    isLikeToggle: PropTypes.bool.isRequired,
     onInterpretationDeleted: PropTypes.func.isRequired,
     downloadMenuComponent: PropTypes.oneOfType([
         PropTypes.object,

--- a/src/components/Interpretations/InterpretationModal/InterpretationThread.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationThread.js
@@ -13,10 +13,10 @@ const InterpretationThread = ({
     fetching,
     interpretation,
     onInterpretationDeleted,
+    onLikeToggled,
     initialFocus,
     onThreadUpdated,
     downloadMenuComponent: DownloadMenu,
-    isLikeToggle,
 }) => {
     const { fromServerDate } = useTimeZoneConversion()
     const focusRef = useRef()
@@ -35,9 +35,7 @@ const InterpretationThread = ({
     )
 
     return (
-        <div
-            className={cx('container', { fetching: fetching && !isLikeToggle })}
-        >
+        <div className={cx('container', { fetching: fetching })}>
             <div className={'title'}>
                 <IconClock16 color={colors.grey700} />
                 {moment(fromServerDate(interpretation.created)).format('LLL')}
@@ -49,6 +47,7 @@ const InterpretationThread = ({
                 <Interpretation
                     currentUser={currentUser}
                     interpretation={interpretation}
+                    onLikeToggled={onLikeToggled}
                     onReplyIconClick={
                         interpretationAccess.comment
                             ? () => focusRef.current?.focus()
@@ -154,8 +153,8 @@ InterpretationThread.propTypes = {
     currentUser: PropTypes.object.isRequired,
     fetching: PropTypes.bool.isRequired,
     interpretation: PropTypes.object.isRequired,
-    isLikeToggle: PropTypes.bool.isRequired,
     onInterpretationDeleted: PropTypes.func.isRequired,
+    onLikeToggled: PropTypes.func.isRequired,
     downloadMenuComponent: PropTypes.oneOfType([
         PropTypes.object,
         PropTypes.func,

--- a/src/components/Interpretations/InterpretationsUnit/InterpretationList.js
+++ b/src/components/Interpretations/InterpretationsUnit/InterpretationList.js
@@ -22,6 +22,7 @@ export const InterpretationList = ({
     currentUser,
     interpretations,
     onInterpretationClick,
+    onLikeToggled,
     onReplyIconClick,
     refresh,
     disabled,
@@ -65,6 +66,7 @@ export const InterpretationList = ({
                                         interpretation={interpretation}
                                         currentUser={currentUser}
                                         onClick={onInterpretationClick}
+                                        onLikeToggled={onLikeToggled}
                                         onReplyIconClick={onReplyIconClick}
                                         onDeleted={refresh}
                                         onUpdated={refresh}
@@ -119,6 +121,7 @@ InterpretationList.propTypes = {
     interpretations: PropTypes.array.isRequired,
     refresh: PropTypes.func.isRequired,
     onInterpretationClick: PropTypes.func.isRequired,
+    onLikeToggled: PropTypes.func.isRequired,
     onReplyIconClick: PropTypes.func.isRequired,
     disabled: PropTypes.bool,
 }

--- a/src/components/Interpretations/InterpretationsUnit/InterpretationList.js
+++ b/src/components/Interpretations/InterpretationsUnit/InterpretationList.js
@@ -26,7 +26,6 @@ export const InterpretationList = ({
     onReplyIconClick,
     refresh,
     disabled,
-    fetching,
 }) => {
     const { fromServerDate } = useTimeZoneConversion()
     const interpretationsByDate = interpretations.reduce(
@@ -71,7 +70,6 @@ export const InterpretationList = ({
                                         onDeleted={refresh}
                                         onUpdated={refresh}
                                         disabled={disabled}
-                                        fetching={fetching}
                                     />
                                 ))}
                         </ol>
@@ -117,7 +115,6 @@ export const InterpretationList = ({
 
 InterpretationList.propTypes = {
     currentUser: PropTypes.object.isRequired,
-    fetching: PropTypes.bool.isRequired,
     interpretations: PropTypes.array.isRequired,
     refresh: PropTypes.func.isRequired,
     onInterpretationClick: PropTypes.func.isRequired,

--- a/src/components/Interpretations/InterpretationsUnit/InterpretationList.js
+++ b/src/components/Interpretations/InterpretationsUnit/InterpretationList.js
@@ -25,6 +25,7 @@ export const InterpretationList = ({
     onReplyIconClick,
     refresh,
     disabled,
+    fetching,
 }) => {
     const { fromServerDate } = useTimeZoneConversion()
     const interpretationsByDate = interpretations.reduce(
@@ -68,6 +69,7 @@ export const InterpretationList = ({
                                         onDeleted={refresh}
                                         onUpdated={refresh}
                                         disabled={disabled}
+                                        fetching={fetching}
                                     />
                                 ))}
                         </ol>
@@ -113,6 +115,7 @@ export const InterpretationList = ({
 
 InterpretationList.propTypes = {
     currentUser: PropTypes.object.isRequired,
+    fetching: PropTypes.bool.isRequired,
     interpretations: PropTypes.array.isRequired,
     refresh: PropTypes.func.isRequired,
     onInterpretationClick: PropTypes.func.isRequired,

--- a/src/components/Interpretations/InterpretationsUnit/InterpretationsUnit.js
+++ b/src/components/Interpretations/InterpretationsUnit/InterpretationsUnit.js
@@ -56,12 +56,9 @@ export const InterpretationsUnit = forwardRef(
         const showNoTimeDimensionHelpText =
             type === 'eventVisualization' && !visualizationHasTimeDimension
 
-        const { data, loading, fetching, refetch } = useDataQuery(
-            interpretationsQuery,
-            {
-                lazy: true,
-            }
-        )
+        const { data, loading, refetch } = useDataQuery(interpretationsQuery, {
+            lazy: true,
+        })
 
         const onCompleteAction = useCallback(() => {
             refetch({ type, id })
@@ -87,11 +84,6 @@ export const InterpretationsUnit = forwardRef(
                     expanded: isExpanded,
                 })}
             >
-                {fetching && !loading && (
-                    <div className="fetching-loader">
-                        <CircularLoader small />
-                    </div>
-                )}
                 <div
                     className="header"
                     onClick={() => setIsExpanded(!isExpanded)}

--- a/src/components/Interpretations/InterpretationsUnit/InterpretationsUnit.js
+++ b/src/components/Interpretations/InterpretationsUnit/InterpretationsUnit.js
@@ -66,10 +66,9 @@ export const InterpretationsUnit = forwardRef(
             }
         )
 
-        const onCompleteAction = useCallback(
-            () => refetch({ type, id }),
-            [type, id, refetch]
-        )
+        const onCompleteAction = useCallback(() => {
+            refetch({ type, id })
+        }, [type, id, refetch])
 
         useImperativeHandle(
             ref,

--- a/src/components/Interpretations/InterpretationsUnit/InterpretationsUnit.js
+++ b/src/components/Interpretations/InterpretationsUnit/InterpretationsUnit.js
@@ -139,11 +139,10 @@ export const InterpretationsUnit = forwardRef(
                                     onInterpretationClick={
                                         onInterpretationClick
                                     }
+                                    onLikeToggled={onLikeToggled}
                                     onReplyIconClick={onReplyIconClick}
                                     refresh={onCompleteAction}
                                     disabled={disabled}
-                                    fetching={fetching}
-                                    onLikeToggled={onLikeToggled}
                                 />
                             </>
                         )}

--- a/src/components/Interpretations/InterpretationsUnit/InterpretationsUnit.js
+++ b/src/components/Interpretations/InterpretationsUnit/InterpretationsUnit.js
@@ -53,23 +53,21 @@ export const InterpretationsUnit = forwardRef(
         ref
     ) => {
         const [isExpanded, setIsExpanded] = useState(true)
-        const [isLikeToggle, setIsLikeToggle] = useState(false)
+        const [interpretations, setInterpretations] = useState([])
         const showNoTimeDimensionHelpText =
             type === 'eventVisualization' && !visualizationHasTimeDimension
 
-        const { data, loading, fetching, refetch } = useDataQuery(
+        const { loading, fetching, refetch } = useDataQuery(
             interpretationsQuery,
             {
                 lazy: true,
-                onComplete: () => setIsLikeToggle(false),
+                onComplete: (data) =>
+                    setInterpretations(data.interpretations.interpretations),
             }
         )
 
         const onCompleteAction = useCallback(
-            (isLike = false) => {
-                setIsLikeToggle(isLike)
-                refetch({ type, id })
-            },
+            () => refetch({ type, id }),
             [type, id, refetch]
         )
 
@@ -87,13 +85,21 @@ export const InterpretationsUnit = forwardRef(
             }
         }, [type, id, renderId, refetch])
 
+        const onLikeToggled = ({ id, likedBy }) => {
+            const interpretation = interpretations.find(
+                (interp) => interp.id === id
+            )
+            interpretation.likedBy = likedBy
+            interpretation.likes = likedBy.length
+        }
+
         return (
             <div
                 className={cx('container', {
                     expanded: isExpanded,
                 })}
             >
-                {fetching && !loading && !isLikeToggle && (
+                {fetching && !loading && (
                     <div className="fetching-loader">
                         <CircularLoader small />
                     </div>
@@ -116,7 +122,7 @@ export const InterpretationsUnit = forwardRef(
                                 <CircularLoader small />
                             </div>
                         )}
-                        {data && (
+                        {interpretations && (
                             <>
                                 <InterpretationForm
                                     currentUser={currentUser}
@@ -130,9 +136,7 @@ export const InterpretationsUnit = forwardRef(
                                 />
                                 <InterpretationList
                                     currentUser={currentUser}
-                                    interpretations={
-                                        data.interpretations.interpretations
-                                    }
+                                    interpretations={interpretations}
                                     onInterpretationClick={
                                         onInterpretationClick
                                     }
@@ -140,6 +144,7 @@ export const InterpretationsUnit = forwardRef(
                                     refresh={onCompleteAction}
                                     disabled={disabled}
                                     fetching={fetching}
+                                    onLikeToggled={onLikeToggled}
                                 />
                             </>
                         )}

--- a/src/components/Interpretations/InterpretationsUnit/InterpretationsUnit.js
+++ b/src/components/Interpretations/InterpretationsUnit/InterpretationsUnit.js
@@ -53,16 +53,25 @@ export const InterpretationsUnit = forwardRef(
         ref
     ) => {
         const [isExpanded, setIsExpanded] = useState(true)
+        const [isLikeToggle, setIsLikeToggle] = useState(false)
         const showNoTimeDimensionHelpText =
             type === 'eventVisualization' && !visualizationHasTimeDimension
 
-        const { data, loading, refetch } = useDataQuery(interpretationsQuery, {
-            lazy: true,
-        })
+        const { data, loading, fetching, refetch } = useDataQuery(
+            interpretationsQuery,
+            {
+                lazy: true,
+                onComplete: () => setIsLikeToggle(false),
+            }
+        )
 
-        const onCompleteAction = useCallback(() => {
-            refetch({ type, id })
-        }, [type, id, refetch])
+        const onCompleteAction = useCallback(
+            (isLike = false) => {
+                setIsLikeToggle(isLike)
+                refetch({ type, id })
+            },
+            [type, id, refetch]
+        )
 
         useImperativeHandle(
             ref,
@@ -84,6 +93,11 @@ export const InterpretationsUnit = forwardRef(
                     expanded: isExpanded,
                 })}
             >
+                {fetching && !loading && !isLikeToggle && (
+                    <div className="fetching-loader">
+                        <CircularLoader small />
+                    </div>
+                )}
                 <div
                     className="header"
                     onClick={() => setIsExpanded(!isExpanded)}
@@ -125,6 +139,7 @@ export const InterpretationsUnit = forwardRef(
                                     onReplyIconClick={onReplyIconClick}
                                     refresh={onCompleteAction}
                                     disabled={disabled}
+                                    fetching={fetching}
                                 />
                             </>
                         )}

--- a/src/components/Interpretations/common/Interpretation/Interpretation.js
+++ b/src/components/Interpretations/common/Interpretation/Interpretation.js
@@ -32,7 +32,7 @@ export const Interpretation = ({
 }) => {
     const [isUpdateMode, setIsUpdateMode] = useState(false)
     const [showSharingDialog, setShowSharingDialog] = useState(false)
-    const { isLikedByCurrentUser, toggleLike, toggleLikeInProgress } = useLike({
+    const { toggleLike, isLikedByCurrentUser, toggleLikeInProgress } = useLike({
         interpretation,
         currentUser,
         onComplete: (likedBy) =>

--- a/src/components/Interpretations/common/Interpretation/Interpretation.js
+++ b/src/components/Interpretations/common/Interpretation/Interpretation.js
@@ -29,13 +29,18 @@ export const Interpretation = ({
     onReplyIconClick,
     isInThread,
     fetching,
+    onLikeToggled,
 }) => {
     const [isUpdateMode, setIsUpdateMode] = useState(false)
     const [showSharingDialog, setShowSharingDialog] = useState(false)
-    const { toggleLike, isLikedByCurrentUser, toggleLikeInProgress } = useLike({
+    const { isLikedByCurrentUser, toggleLike, toggleLikeInProgress } = useLike({
         interpretation,
         currentUser,
-        onComplete: () => onUpdated(true),
+        onComplete: (likedBy) =>
+            onLikeToggled({
+                id: interpretation.id,
+                likedBy,
+            }),
     })
     const shouldShowButton = !!onClick && !disabled
 
@@ -153,6 +158,7 @@ Interpretation.propTypes = {
     fetching: PropTypes.bool.isRequired,
     interpretation: PropTypes.object.isRequired,
     onDeleted: PropTypes.func.isRequired,
+    onLikeToggled: PropTypes.func.isRequired,
     onReplyIconClick: PropTypes.func.isRequired,
     onUpdated: PropTypes.func.isRequired,
     disabled: PropTypes.bool,

--- a/src/components/Interpretations/common/Interpretation/Interpretation.js
+++ b/src/components/Interpretations/common/Interpretation/Interpretation.js
@@ -28,13 +28,14 @@ export const Interpretation = ({
     disabled,
     onReplyIconClick,
     isInThread,
+    fetching,
 }) => {
     const [isUpdateMode, setIsUpdateMode] = useState(false)
     const [showSharingDialog, setShowSharingDialog] = useState(false)
     const { toggleLike, isLikedByCurrentUser, toggleLikeInProgress } = useLike({
         interpretation,
         currentUser,
-        onComplete: onUpdated,
+        onComplete: () => onUpdated(true),
     })
     const shouldShowButton = !!onClick && !disabled
 
@@ -83,7 +84,7 @@ export const Interpretation = ({
                         onClick={toggleLike}
                         selected={isLikedByCurrentUser}
                         count={interpretation.likes}
-                        disabled={toggleLikeInProgress}
+                        disabled={toggleLikeInProgress || fetching}
                         dataTest="interpretation-like-unlike-button"
                     />
                     <MessageIconButton
@@ -149,6 +150,7 @@ export const Interpretation = ({
 
 Interpretation.propTypes = {
     currentUser: PropTypes.object.isRequired,
+    fetching: PropTypes.bool.isRequired,
     interpretation: PropTypes.object.isRequired,
     onDeleted: PropTypes.func.isRequired,
     onReplyIconClick: PropTypes.func.isRequired,

--- a/src/components/Interpretations/common/Interpretation/Interpretation.js
+++ b/src/components/Interpretations/common/Interpretation/Interpretation.js
@@ -28,7 +28,6 @@ export const Interpretation = ({
     disabled,
     onReplyIconClick,
     isInThread,
-    fetching,
     onLikeToggled,
 }) => {
     const [isUpdateMode, setIsUpdateMode] = useState(false)
@@ -89,7 +88,7 @@ export const Interpretation = ({
                         onClick={toggleLike}
                         selected={isLikedByCurrentUser}
                         count={interpretation.likes}
-                        disabled={toggleLikeInProgress || fetching}
+                        disabled={toggleLikeInProgress}
                         dataTest="interpretation-like-unlike-button"
                     />
                     <MessageIconButton
@@ -155,7 +154,6 @@ export const Interpretation = ({
 
 Interpretation.propTypes = {
     currentUser: PropTypes.object.isRequired,
-    fetching: PropTypes.bool.isRequired,
     interpretation: PropTypes.object.isRequired,
     onDeleted: PropTypes.func.isRequired,
     onLikeToggled: PropTypes.func.isRequired,

--- a/src/components/Interpretations/common/Interpretation/useLike.js
+++ b/src/components/Interpretations/common/Interpretation/useLike.js
@@ -7,11 +7,28 @@ const useLike = ({ interpretation, currentUser, onComplete }) => {
     const unlikeMutationRef = useRef({ resource, type: 'delete' })
     const [like, { loading: likeLoading }] = useDataMutation(
         likeMutationRef.current,
-        { onComplete }
+        {
+            onComplete: () => {
+                const newLikedBy = interpretation.likedBy.concat({
+                    id: currentUser.id,
+                })
+                setIsLikedByCurrentUser(true)
+                onComplete(newLikedBy)
+            },
+        }
     )
     const [unlike, { loading: unlikeLoading }] = useDataMutation(
         unlikeMutationRef.current,
-        { onComplete }
+        {
+            onComplete: () => {
+                const newLikedBy = interpretation.likedBy.filter(
+                    (lb) => lb.id !== currentUser.id
+                )
+
+                setIsLikedByCurrentUser(false)
+                onComplete(newLikedBy)
+            },
+        }
     )
     const [isLikedByCurrentUser, setIsLikedByCurrentUser] = useState(false)
     const toggleLike = () => {


### PR DESCRIPTION
Fixes: https://dhis2.atlassian.net/browse/DHIS2-16392

Fixes flashing when liking/unliking an interpretation.
Seems unnecessary to render a loader when fetching. There is already a loader for loading state, which happens on initial load.

Adding the spinner to the DOM was causing big flashing:

Before:
https://github.com/dhis2/analytics/assets/6113918/482f3d0d-cb71-4751-b072-5a367199c364

After:

https://github.com/dhis2/analytics/assets/6113918/092829c0-55b2-486e-bd78-dfcf23c09f7c


