### PR TITLE
fix: adjust width of interpretation reply input when in focus

### DIFF
--- a/src/components/Interpretations/common/RichTextEditor/styles/RichTextEditor.style.js
+++ b/src/components/Interpretations/common/RichTextEditor/styles/RichTextEditor.style.js
@@ -36,6 +36,7 @@ export const mainClasses = css`
     .textarea:focus {
         outline: none;
         box-shadow: 0 0 0 3px ${theme.focus};
+        width: calc(100% - 3px);
     }
 
     .textarea:disabled {


### PR DESCRIPTION
Fixes: https://dhis2.atlassian.net/browse/DHIS2-16429

Reduce width by the width of the box shadow so it doesn't get cut off.

Before:

<img width="341" alt="image" src="https://github.com/dhis2/analytics/assets/6113918/89113533-8d5e-4bb7-b303-0fc20f4d042e">


After:
<img width="356" alt="image" src="https://github.com/dhis2/analytics/assets/6113918/f036e889-d956-4705-951b-71b3e6e30efd">
