### PR TITLE
feat: add classname prop to hover-menu-dropdown

### DIFF
--- a/src/components/Toolbar/HoverMenuBar/HoverMenuDropdown.js
+++ b/src/components/Toolbar/HoverMenuBar/HoverMenuDropdown.js
@@ -6,7 +6,13 @@ import React, { useRef } from 'react'
 import menuButtonStyles from '../MenuButton.styles.js'
 import { useHoverMenubarContext } from './HoverMenuBar.js'
 
-export const HoverMenuDropdown = ({ children, label, dataTest, disabled }) => {
+export const HoverMenuDropdown = ({
+    children,
+    className,
+    label,
+    dataTest,
+    disabled,
+}) => {
     const buttonRef = useRef()
     const {
         onDropDownButtonClick,
@@ -18,7 +24,7 @@ export const HoverMenuDropdown = ({ children, label, dataTest, disabled }) => {
     return (
         <>
             <button
-                className={cx({ isOpen })}
+                className={cx(className, { isOpen })}
                 ref={buttonRef}
                 onClick={onDropDownButtonClick}
                 disabled={disabled}
@@ -46,6 +52,7 @@ HoverMenuDropdown.defaultProps = {
 HoverMenuDropdown.propTypes = {
     children: PropTypes.node.isRequired,
     label: PropTypes.node.isRequired,
+    className: PropTypes.string,
     dataTest: PropTypes.string,
     disabled: PropTypes.bool,
 }

--- a/src/components/Toolbar/HoverMenuBar/__tests__/HoverMenuDropdown.spec.js
+++ b/src/components/Toolbar/HoverMenuBar/__tests__/HoverMenuDropdown.spec.js
@@ -17,4 +17,15 @@ describe('<HoverMenuDropdown/>', () => {
 
         expect(wrapper.find('button').prop('data-test')).toBe(dataTest)
     })
+
+    it('accepts a `className` prop', () => {
+        const className = 'test'
+        const wrapper = shallow(
+            <HoverMenuDropdown label="test dropdown" className={className}>
+                children
+            </HoverMenuDropdown>
+        )
+
+        expect(wrapper.find('button')).toHaveClassName(className)
+    })
 })


### PR DESCRIPTION
Implements: No issue number available

**Relates to [DHIS2-15367](https://dhis2.atlassian.net/browse/DHIS2-15367) (push-analytics)**

---

### Key features

1. Allows providing a classname to the `HoverMenuItem` component

---

### Description

Push analytics relies on clearly identifyable elements to be in the DOM to trigger a download. This PR will allow the consuming apps to provide a unique static classname on the download dropdown menu.

Note that the same is also needed for the the `HoverMenuListItem` component, but this already had a `className` prop.

---


[DHIS2-15367]: https://dhis2.atlassian.net/browse/DHIS2-15367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ