### PR TITLE
fix: show correct date and time in About AO Unit [DHIS2-15825, DHIS2-16365] [24.x]

### DIFF
--- a/src/components/AboutAOUnit/AboutAOUnit.js
+++ b/src/components/AboutAOUnit/AboutAOUnit.js
@@ -1,4 +1,8 @@
-import { useDataQuery, useDataMutation } from '@dhis2/app-runtime'
+import {
+    useDataQuery,
+    useDataMutation,
+    useTimeZoneConversion,
+} from '@dhis2/app-runtime'
 import i18n from '@dhis2/d2-i18n'
 import { Parser as RichTextParser } from '@dhis2/d2-ui-rich-text'
 import {
@@ -57,6 +61,7 @@ const getUnsubscribeMutation = (type, id) => ({
 
 const AboutAOUnit = forwardRef(({ type, id, renderId }, ref) => {
     const [isExpanded, setIsExpanded] = useState(true)
+    const { fromServerDate } = useTimeZoneConversion()
 
     const queries = useMemo(() => getQueries(type), [type])
 
@@ -208,7 +213,7 @@ const AboutAOUnit = forwardRef(({ type, id, renderId }, ref) => {
                                     <IconClock16 color={colors.grey700} />
                                     {i18n.t('Last updated {{time}}', {
                                         time: moment(
-                                            data.ao.lastUpdated
+                                            fromServerDate(data.ao.lastUpdated)
                                         ).fromNow(),
                                     })}
                                 </p>
@@ -219,7 +224,9 @@ const AboutAOUnit = forwardRef(({ type, id, renderId }, ref) => {
                                               'Created {{time}} by {{author}}',
                                               {
                                                   time: moment(
-                                                      data.ao.created
+                                                      fromServerDate(
+                                                          data.ao.created
+                                                      )
                                                   ).fromNow(),
                                                   author: data.ao.createdBy
                                                       .displayName,
@@ -227,7 +234,9 @@ const AboutAOUnit = forwardRef(({ type, id, renderId }, ref) => {
                                           )
                                         : i18n.t('Created {{time}}', {
                                               time: moment(
-                                                  data.ao.created
+                                                  fromServerDate(
+                                                      data.ao.created
+                                                  )
                                               ).fromNow(),
                                           })}
                                 </p>

--- a/src/components/Interpretations/InterpretationModal/InterpretationThread.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationThread.js
@@ -38,11 +38,7 @@ const InterpretationThread = ({
                     )}
                 </div>
                 {DownloadMenu && (
-                    <DownloadMenu
-                        relativePeriodDate={fromServerDate(
-                            interpretation.created
-                        )}
-                    />
+                    <DownloadMenu relativePeriodDate={interpretation.created} />
                 )}
                 <div className={'thread'}>
                     <Interpretation

--- a/src/components/Interpretations/InterpretationModal/InterpretationThread.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationThread.js
@@ -1,3 +1,4 @@
+import { useTimeZoneConversion } from '@dhis2/app-runtime'
 import { IconClock16, colors } from '@dhis2/ui'
 import cx from 'classnames'
 import moment from 'moment'
@@ -16,6 +17,7 @@ const InterpretationThread = ({
     onThreadUpdated,
     downloadMenuComponent: DownloadMenu,
 }) => {
+    const { fromServerDate } = useTimeZoneConversion()
     const focusRef = useRef()
 
     useEffect(() => {
@@ -31,10 +33,16 @@ const InterpretationThread = ({
             <div className={'scrollbox'}>
                 <div className={'title'}>
                     <IconClock16 color={colors.grey700} />
-                    {moment(interpretation.created).format('LLL')}
+                    {moment(fromServerDate(interpretation.created)).format(
+                        'LLL'
+                    )}
                 </div>
                 {DownloadMenu && (
-                    <DownloadMenu relativePeriodDate={interpretation.created} />
+                    <DownloadMenu
+                        relativePeriodDate={fromServerDate(
+                            interpretation.created
+                        )}
+                    />
                 )}
                 <div className={'thread'}>
                     <Interpretation

--- a/src/components/Interpretations/InterpretationsUnit/InterpretationList.js
+++ b/src/components/Interpretations/InterpretationsUnit/InterpretationList.js
@@ -1,3 +1,4 @@
+import { useTimeZoneConversion } from '@dhis2/app-runtime'
 import { IconCalendar24, colors, spacers } from '@dhis2/ui'
 import moment from 'moment'
 import PropTypes from 'prop-types'
@@ -25,6 +26,7 @@ export const InterpretationList = ({
     refresh,
     disabled,
 }) => {
+    const { fromServerDate } = useTimeZoneConversion()
     const interpretationsByDate = interpretations.reduce(
         (groupedInterpretations, interpretation) => {
             const date = interpretation.created.split('T')[0]
@@ -50,7 +52,7 @@ export const InterpretationList = ({
                         <div className="date-section">
                             <IconCalendar24 color={colors.grey600} />
                             <time dateTime={date} className="date-header">
-                                {moment(date).format('ll')}
+                                {moment(fromServerDate(date)).format('ll')}
                             </time>
                         </div>
                         <ol className="interpretation-list">

--- a/src/components/Interpretations/common/Message/Message.js
+++ b/src/components/Interpretations/common/Message/Message.js
@@ -1,63 +1,71 @@
+import { useTimeZoneConversion } from '@dhis2/app-runtime'
 import { Parser as RichTextParser } from '@dhis2/d2-ui-rich-text'
 import { UserAvatar, spacers, colors } from '@dhis2/ui'
 import moment from 'moment'
 import PropTypes from 'prop-types'
 import React from 'react'
 
-const Message = ({ children, text, created, username }) => (
-    <li className="container">
-        <div className="header">
-            <UserAvatar name={username} extrasmall />
-            {username}
-            <time dateTime={created}>{moment(created).format('lll')}</time>
-        </div>
-        <div className="content">
-            <RichTextParser>{text}</RichTextParser>
-        </div>
-        <div className="footer">{children}</div>
-        <style jsx>{`
-            .container {
-                padding: ${spacers.dp8};
-                background-color: ${colors.grey100};
-                border-radius: 5px;
-                display: flex;
-                flex-direction: column;
-                gap: ${spacers.dp8};
-            }
+const Message = ({ children, text, created, username }) => {
+    const { fromServerDate } = useTimeZoneConversion()
+    return (
+        <li className="container">
+            <div className="header">
+                <UserAvatar name={username} extrasmall />
+                {username}
+                <time dateTime={created}>
+                    {moment(fromServerDate(created)).format('lll')}
+                </time>
+            </div>
+            <div className="content">
+                <RichTextParser>{text}</RichTextParser>
+            </div>
+            <div className="footer">{children}</div>
+            <style jsx>{`
+                .container {
+                    padding: ${spacers.dp8};
+                    background-color: ${colors.grey100};
+                    border-radius: 5px;
+                    display: flex;
+                    flex-direction: column;
+                    gap: ${spacers.dp8};
+                }
 
-            .header {
-                display: flex;
-                gap: 6px;
-                align-items: center;
-                font-size: 13px;
-                line-height: 16px;
-                color: ${colors.grey900};
-            }
+                .header {
+                    display: flex;
+                    gap: 6px;
+                    align-items: center;
+                    font-size: 13px;
+                    line-height: 16px;
+                    color: ${colors.grey900};
+                }
 
-            .header time {
-                font-size: 12px;
-                color: ${colors.grey600};
-            }
+                .header time {
+                    font-size: 12px;
+                    color: ${colors.grey600};
+                }
 
-            .content {
-                font-size: 14px;
-                line-height: 19px;
-                color: ${colors.grey900};
-            }
+                .content {
+                    font-size: 14px;
+                    line-height: 19px;
+                    color: ${colors.grey900};
+                    word-break: break-word;
+                    white-space: pre-line;
+                }
 
-            .content :global(p:first-child) {
-                margin: 0;
-            }
+                .content :global(p:first-child) {
+                    margin: 0;
+                }
 
-            .footer {
-                display: flex;
-                flex-direction: column;
-                align-items: flex-start;
-                gap: ${spacers.dp8};
-            }
-        `}</style>
-    </li>
-)
+                .footer {
+                    display: flex;
+                    flex-direction: column;
+                    align-items: flex-start;
+                    gap: ${spacers.dp8};
+                }
+            `}</style>
+        </li>
+    )
+}
 
 Message.propTypes = {
     children: PropTypes.node.isRequired,


### PR DESCRIPTION
Fixes https://dhis2.atlassian.net/browse/DHIS2-15825 and https://dhis2.atlassian.net/browse/DHIS2-16365

### Key features

1. Show correct date and time in About AO Unit
before (just after creating an AO while in GMT+1)
![image](https://github.com/dhis2/analytics/assets/6113918/aa3e122d-4f5a-4cdd-8928-1db0e755571f)

after:
![image](https://github.com/dhis2/analytics/assets/6113918/fab6c9ca-63ee-4ca0-b5e5-91401b45e6cc)


2. Preserve paragraphs in interpretations and replies (addition of lines 51 and 52 in Message.js)
before:
![image](https://github.com/dhis2/analytics/assets/6113918/4f79e601-0fae-4702-845b-0c44d67b880a)
![image](https://github.com/dhis2/analytics/assets/6113918/bae25f2b-7656-480e-9928-4c6f850215f0)
![image](https://github.com/dhis2/analytics/assets/6113918/c4c4f35a-4b90-4e78-a672-51d70d5a3dfd)
![image](https://github.com/dhis2/analytics/assets/6113918/01d10475-eb70-4186-b479-3bb61842f3ea)


after:
![image](https://github.com/dhis2/analytics/assets/6113918/bd064d82-82b6-46be-97f0-cc84e5378f45)
![image](https://github.com/dhis2/analytics/assets/6113918/7f603ec1-a638-4416-babc-08902e973b06)
![image](https://github.com/dhis2/analytics/assets/6113918/76299c07-7b9a-401a-9225-8dde4cf8e4f0)
![image](https://github.com/dhis2/analytics/assets/6113918/9c0b956d-b186-47ba-8cd5-b100d91f32a6)



