### PR TITLE
feat: disable Save button when onSave not passed (TECH-1013)

### DIFF
--- a/src/components/FileMenu/FileMenu.js
+++ b/src/components/FileMenu/FileMenu.js
@@ -189,14 +189,18 @@ export const FileMenu = ({
                                 icon={
                                     <IconSave24
                                         color={
-                                            !fileObject?.id ||
-                                            fileObject?.access?.update
-                                                ? iconActiveColor
-                                                : iconInactiveColor
+                                            !onSave ||
+                                            !(
+                                                !fileObject?.id ||
+                                                fileObject?.access?.update
+                                            )
+                                                ? iconInactiveColor
+                                                : iconActiveColor
                                         }
                                     />
                                 }
                                 disabled={
+                                    !onSave ||
                                     !(
                                         !fileObject?.id ||
                                         fileObject?.access?.update
@@ -344,7 +348,6 @@ FileMenu.defaultProps = {
     onNew: Function.prototype,
     onOpen: Function.prototype,
     onRename: Function.prototype,
-    onSave: Function.prototype,
     onSaveAs: Function.prototype,
     onTranslate: Function.prototype,
 }


### PR DESCRIPTION
We need a way of disabling the Save button in certain situations. The logic should be in the consumer app.
The idea is to leverage the onSave prop and use it to enable/disable the Save button.
If the callback is not passed disable the Save button.

(cherry picked from commit fa87c8b9ef3fe8e237e7d21423c81daf0ff6c817)