### PR TITLE
fix: set white-space pre-line to preserve newlines

### DIFF
--- a/src/components/AboutAOUnit/AboutAOUnit.js
+++ b/src/components/AboutAOUnit/AboutAOUnit.js
@@ -193,6 +193,7 @@ const AboutAOUnit = forwardRef(({ type, id, renderId }, ref) => {
                         <div className="content">
                             <p
                                 className={cx('detailLine', {
+                                    description: true,
                                     noDescription: !data.ao.displayDescription,
                                 })}
                             >

--- a/src/components/AboutAOUnit/styles/AboutAOUnit.style.js
+++ b/src/components/AboutAOUnit/styles/AboutAOUnit.style.js
@@ -48,6 +48,10 @@ export default css`
         flex-shrink: 0;
     }
 
+    .description {
+        white-space: pre-line;
+    }
+
     .noDescription {
         color: ${colors.grey600};
     }


### PR DESCRIPTION
Fixes https://dhis2.atlassian.net/browse/DHIS2-15914

Before:
<img width="403" alt="image" src="https://github.com/dhis2/analytics/assets/6113918/8e8c4fe9-d854-4540-8665-9e2d88eb48f8">


After: 
<img width="408" alt="image" src="https://github.com/dhis2/analytics/assets/6113918/4e51eace-cbb1-4561-8037-0b70fe5b615e">
