### PR TITLE
fix: fix a crash when row totals is enabled (DHIS2-17297)

### DIFF
--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -515,9 +515,19 @@ export class PivotTableEngine {
         if (!this.data[row]) {
             return undefined
         }
+
         const cellValue = this.data[row][column]
 
-        if (cellValue && !Array.isArray(cellValue)) {
+        if (!cellValue) {
+            // Empty cell
+            // The cell still needs to get the valueType to render correctly 0 and cumulative values
+            return {
+                valueType: VALUE_TYPE_NUMBER,
+                totalAggregationType: AGGREGATE_TYPE_SUM,
+            }
+        }
+
+        if (!Array.isArray(cellValue)) {
             // This is a total cell
             return {
                 valueType: cellValue.valueType,
@@ -532,6 +542,7 @@ export class PivotTableEngine {
         const dxRowIndex = this.dimensionLookup.rows.findIndex(
             (dim) => dim.isDxDimension
         )
+
         if (rowHeaders.length && dxRowIndex !== -1) {
             return {
                 valueType: rowHeaders[dxRowIndex].valueType,
@@ -553,11 +564,6 @@ export class PivotTableEngine {
             }
         }
 
-        // Empty cell
-        // The cell still needs to get the valueType to render correctly 0 and cumulative values
-        //
-        // OR
-        //
         // Data is in Filter
         // TODO : This assumes the server ignores text types, we should confirm this is the case
         return {


### PR DESCRIPTION
Implements [DHIS2-17297](https://dhis2.atlassian.net/browse/DHIS2-17297)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/3042**

---

### Key features

1. fix crash in PT in certain circumstances

---

### Description

More info in the ticket.
In short, a bug was introduced with the cumulative values feature with [this commit](https://github.com/dhis2/analytics/pull/1567/commits/d861a32b2f3c0b3240c54bd2cd73d7c6844de4d3).
The bug only happens in specific circumstances, which seem to be the following:
1) column totals option is enabled in DV
2) the visualization type is Pivot Table
3) the Data dimension (dx) must be the first of the list of selected dimensions in Rows
4) there must be a 2nd dimension in Rows
5) one column must have all empty values

With these conditions I was able to reproduce the crash.

---

### Screenshots

Here's a screenshot of the layout in DV which triggers the crash; once column totals is enabled and Update is clicked, the app crashes:

<img width="1015" alt="Screenshot 2024-05-02 at 11 39 22" src="https://github.com/dhis2/analytics/assets/150978/3e0ed647-baf8-497b-bd3a-551448fac6fc">






[DHIS2-17297]: https://dhis2.atlassian.net/browse/DHIS2-17297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ