### PR TITLE
fix: system / user setting for display name not respected in Org Unit tree (DHIS2-15000)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/analytics",
-    "version": "999.9.9-ouname-alpha.1",
+    "version": "26.6.8",
     "main": "./build/cjs/index.js",
     "module": "./build/es/index.js",
     "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/analytics",
-    "version": "26.6.8",
+    "version": "999.9.9-ouname-alpha.1",
     "main": "./build/cjs/index.js",
     "module": "./build/es/index.js",
     "exports": {

--- a/src/components/OrgUnitDimension/OrgUnitDimension.js
+++ b/src/components/OrgUnitDimension/OrgUnitDimension.js
@@ -40,6 +40,7 @@ const OrgUnitDimension = ({
     hideLevelSelect,
     hideUserOrgUnits,
     warning,
+    displayNameProp,
 }) => {
     const [ouLevels, setOuLevels] = useState([])
     const [ouGroups, setOuGroups] = useState([])
@@ -79,13 +80,16 @@ const OrgUnitDimension = ({
             setOuLevels(result)
         }
         const doFetchOuGroups = async () => {
-            const result = await apiFetchOrganisationUnitGroups(dataEngine)
+            const result = await apiFetchOrganisationUnitGroups(
+                dataEngine,
+                displayNameProp
+            )
             setOuGroups(result)
         }
 
         !hideLevelSelect && doFetchOuLevels()
         !hideGroupSelect && doFetchOuGroups()
-    }, [dataEngine, hideLevelSelect, hideGroupSelect])
+    }, [dataEngine, hideLevelSelect, hideGroupSelect, displayNameProp])
 
     const onLevelChange = (ids) => {
         const items = ids.map((id) => ({
@@ -369,6 +373,7 @@ OrgUnitDimension.defaultProps = {
 }
 
 OrgUnitDimension.propTypes = {
+    displayNameProp: PropTypes.string,
     hideGroupSelect: PropTypes.bool,
     hideLevelSelect: PropTypes.bool,
     hideUserOrgUnits: PropTypes.bool,


### PR DESCRIPTION
Implements [DHIS2-15000](https://dhis2.atlassian.net/browse/DHIS2-15000)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/3051**
**Relates to https://github.com/dhis2/line-listing-app/pull/509**
**Relates to https://github.com/dhis2/maps-app/pull/3195**
**Relates to https://github.com/dhis2/dashboard-app/pull/2971**

---

### Key features

1. Enables display name prop to be used when fetching org unit groups

---

### Screenshots

_shortName being displayed in the group select_


![image](https://github.com/dhis2/analytics/assets/12590483/b0fc6a02-f915-4b60-bff5-346231484d51)



[DHIS2-15000]: https://dhis2.atlassian.net/browse/DHIS2-15000?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ