### PR TITLE
fix: numbers are misaligned in pivot table (DHIS2-16900)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/analytics",
-    "version": "26.6.12",
+    "version": "999.9.9-value-align-alpha.1",
     "main": "./build/cjs/index.js",
     "module": "./build/es/index.js",
     "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/analytics",
-    "version": "999.9.9-value-align-alpha.1",
+    "version": "26.6.12",
     "main": "./build/cjs/index.js",
     "module": "./build/es/index.js",
     "exports": {

--- a/src/components/PivotTable/styles/PivotTable.style.js
+++ b/src/components/PivotTable/styles/PivotTable.style.js
@@ -147,7 +147,13 @@ export const cell = css`
     .TEXT {
         text-align: left;
     }
-    .NUMBER {
+    .NUMBER,
+    .INTEGER,
+    .INTEGER_POSITIVE,
+    .INTEGER_NEGATIVE,
+    .INTEGER_ZERO_OR_POSITIVE,
+    .UNIT_INTERVAL,
+    .PERCENTAGE {
         text-align: right;
     }
     .clickable {

--- a/src/components/PivotTable/styles/PivotTable.style.js
+++ b/src/components/PivotTable/styles/PivotTable.style.js
@@ -143,8 +143,6 @@ export const cell = css`
     }
     .value {
         background-color: #ffffff;
-    }
-    .TEXT {
         text-align: left;
     }
     .NUMBER,

--- a/src/components/PivotTable/styles/PivotTable.style.js
+++ b/src/components/PivotTable/styles/PivotTable.style.js
@@ -151,7 +151,9 @@ export const cell = css`
     .INTEGER_NEGATIVE,
     .INTEGER_ZERO_OR_POSITIVE,
     .UNIT_INTERVAL,
-    .PERCENTAGE {
+    .PERCENTAGE,
+    .BOOLEAN,
+    .TRUE_ONLY {
         text-align: right;
     }
     .clickable {


### PR DESCRIPTION
Implements [DHIS2-16900](https://dhis2.atlassian.net/browse/DHIS2-16900)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/3072**

---

### Key features

1. Left align all numeric types
2. Right align everything else by default

---

### Screenshots
_before_
![image](https://github.com/dhis2/analytics/assets/12590483/b7029d0c-6b6e-4aa7-a732-660372e44233)



_after_
![image](https://github.com/dhis2/analytics/assets/12590483/43767f28-89c9-4738-83c1-94189f393eb3)

_before_
![image](https://github.com/dhis2/analytics/assets/12590483/609985e7-2371-4e77-a8e9-76f3d5e51a07)


_after_
![image](https://github.com/dhis2/analytics/assets/12590483/525c4e0f-9772-49b7-9f26-3fe59da582a4)


[DHIS2-16900]: https://dhis2.atlassian.net/browse/DHIS2-16900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ