### PR TITLE
fix: generate correct link for line listing app in FileMenu (DHIS2-16018)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/analytics",
-    "version": "999.9.9-ll-link-alpha.1",
+    "version": "26.6.12",
     "main": "./build/cjs/index.js",
     "module": "./build/es/index.js",
     "exports": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dhis2/analytics",
-    "version": "26.6.12",
+    "version": "999.9.9-ll-link-alpha.1",
     "main": "./build/cjs/index.js",
     "module": "./build/es/index.js",
     "exports": {

--- a/src/components/FileMenu/utils.js
+++ b/src/components/FileMenu/utils.js
@@ -35,6 +35,8 @@ export const appPathFor = (fileType, id) => {
             return `dhis-web-data-visualizer/#/${id}`
         case FILE_TYPE_MAP:
             return `dhis-web-maps/index.html?id=${id}`
+        case FILE_TYPE_EVENT_VISUALIZATION:
+            return `api/apps/line-listing/#/${id}`
         default:
             return `${window.location.search}${window.location.hash}`
     }


### PR DESCRIPTION
Implements [DHIS2-16018](https://dhis2.atlassian.net/browse/DHIS2-16018)

**Relates to https://github.com/dhis2/line-listing-app/pull/530**

---

### Key features

1. Adds the correct link for the line listing app in `FileMenu`

---

### Screenshots

_before: https://test.e2e.dhis2.org/analytics-2.41/#/AFjkDs7acBh_

![image](https://github.com/dhis2/analytics/assets/12590483/617d0921-31ea-4934-abd3-32209f1552e3)


_after: https://test.e2e.dhis2.org/api/apps/line-listing/#/AFjkDs7acBh_

![image](https://github.com/dhis2/analytics/assets/12590483/81924d34-0b99-41e0-aabd-2b21a3bde2d4)



[DHIS2-16018]: https://dhis2.atlassian.net/browse/DHIS2-16018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ