### PR TITLE
chore: new github workflow that copies build of all non-prod branches to d2-ci

### DIFF
--- a/.github/workflows/copy-build-to-d2-ci.yml
+++ b/.github/workflows/copy-build-to-d2-ci.yml
@@ -1,83 +1,42 @@
-name: Publish JavaScript Library
+name: Copy build to d2-ci
 
 on:
-  push:
-    branches-ignore:
-      - master
-  release:
-    types: [published]
+    push:
+        branches-ignore:
+            - master
 
 env:
-  GIT_AUTHOR_NAME: '@dhis2-bot'
-  GIT_AUTHOR_EMAIL: 'apps@dhis2.org'
-  GIT_COMMITTER_NAME: '@dhis2-bot'
-  GIT_COMMITTER_EMAIL: 'apps@dhis2.org'
-  NPM_TOKEN: ${{secrets.DHIS2_BOT_NPM_TOKEN}}
-  GH_TOKEN: ${{secrets.DHIS2_BOT_GITHUB_TOKEN}}
+    GIT_AUTHOR_NAME: '@dhis2-bot'
+    GIT_AUTHOR_EMAIL: 'apps@dhis2.org'
+    GIT_COMMITTER_NAME: '@dhis2-bot'
+    GIT_COMMITTER_EMAIL: 'apps@dhis2.org'
+    NPM_TOKEN: ${{secrets.DHIS2_BOT_NPM_TOKEN}}
+    GH_TOKEN: ${{secrets.DHIS2_BOT_GITHUB_TOKEN}}
 
 jobs:
-  publish-to-github:
-    runs-on: ubuntu-latest
-    if: contains(github.ref, 'alpha')
+    copy-to-d2-ci:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+              with:
+                  token: ${{env.GH_TOKEN}}
 
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          token: ${{env.GH_TOKEN}}
+            - name: Set up Node.js
+              uses: actions/setup-node@v3
+              with:
+                  node-version: '18'
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18'
+            - name: Install dependencies
+              run: npm install --frozen-lockfile
 
-      - name: Install dependencies
-        run: npm install --frozen-lockfile
+            - name: Build package
+              run: yarn build
 
-      - name: Build package
-        run: yarn build
+            - name: Pack and unpack the build
+              run: yarn pack --filename output.tgz && tar -xzf output.tgz
 
-      - name: Pack and unpack the build
-        run: yarn pack --filename output.tgz && tar -xzf output.tgz
-
-      - name: Copy package to d2-ci
-        uses: dhis2/deploy-build@master
-        with:
-          github-token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}
-
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_REGISTRY: https://npm.pkg.github.com/
-
-
-
-
-
-
-
-
-
-
-  publish-to-npm:
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/master'
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: '18'
-
-      - name: Install dependencies
-        run: npm install
-
-      - name: Build package
-        run: npm run build
-
-      - name: Publish to npm
-        run: npm publish --registry=https://registry.npmjs.org
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+            - name: Copy package to d2-ci
+              uses: dhis2/deploy-build@master
+              with:
+                  github-token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/copy-build-to-d2-ci.yml
+++ b/.github/workflows/copy-build-to-d2-ci.yml
@@ -33,7 +33,7 @@ jobs:
             - name: Build package
               run: yarn build
 
-            - name: Pack and unpack the build
+            - name: Pack and unpack the build to a directory named 'package'
               run: yarn pack --filename output.tgz && tar -xzf output.tgz
 
             - name: Copy package to d2-ci

--- a/.github/workflows/copy-build-to-d2-ci.yml
+++ b/.github/workflows/copy-build-to-d2-ci.yml
@@ -16,7 +16,6 @@ env:
 jobs:
     copy-to-d2-ci:
         runs-on: ubuntu-latest
-        if: "!contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - name: Checkout code
               uses: actions/checkout@v3
@@ -40,4 +39,5 @@ jobs:
             - name: Copy package to d2-ci
               uses: dhis2/deploy-build@master
               with:
+                  build-dir: build
                   github-token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/copy-build-to-d2-ci.yml
+++ b/.github/workflows/copy-build-to-d2-ci.yml
@@ -13,11 +13,6 @@ on:
             - '[0-9]+.[0-9]+.x'
 
 env:
-    GIT_AUTHOR_NAME: '@dhis2-bot'
-    GIT_AUTHOR_EMAIL: 'apps@dhis2.org'
-    GIT_COMMITTER_NAME: '@dhis2-bot'
-    GIT_COMMITTER_EMAIL: 'apps@dhis2.org'
-    NPM_TOKEN: ${{secrets.DHIS2_BOT_NPM_TOKEN}}
     GH_TOKEN: ${{secrets.DHIS2_BOT_GITHUB_TOKEN}}
 
 jobs:
@@ -47,4 +42,4 @@ jobs:
               uses: dhis2/deploy-build@master
               with:
                   build-dir: package
-                  github-token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}
+                  github-token: ${{env.GH_TOKEN}}

--- a/.github/workflows/copy-build-to-d2-ci.yml
+++ b/.github/workflows/copy-build-to-d2-ci.yml
@@ -35,16 +35,14 @@ jobs:
             - name: Build package
               run: yarn build
 
-            - uses: actions/upload-artifact@v2
-              with:
-                  name: lib-build
-                  path: |
-                      **/build
-                      !**/node_modules
-                  retention-days: 2
-
             - name: Pack and unpack the build to a directory named 'package'
               run: yarn pack --filename output.tgz && tar -xzf output.tgz
+
+            - uses: actions/upload-artifact@v2
+              with:
+                  name: output-build
+                  path: output.tgz
+                  retention-days: 2
 
             - name: Copy package to d2-ci
               uses: dhis2/deploy-build@master

--- a/.github/workflows/copy-build-to-d2-ci.yml
+++ b/.github/workflows/copy-build-to-d2-ci.yml
@@ -39,5 +39,5 @@ jobs:
             - name: Copy package to d2-ci
               uses: dhis2/deploy-build@master
               with:
-                  build-dir: build
+                  build-dir: package
                   github-token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}

--- a/.github/workflows/copy-build-to-d2-ci.yml
+++ b/.github/workflows/copy-build-to-d2-ci.yml
@@ -4,6 +4,13 @@ on:
     push:
         branches-ignore:
             - master
+            - next
+            - next-major
+            - alpha
+            - beta
+            - '[0-9]+.x'
+            - '[0-9]+.x.x'
+            - '[0-9]+.[0-9]+.x'
 
 env:
     GIT_AUTHOR_NAME: '@dhis2-bot'

--- a/.github/workflows/copy-build-to-d2-ci.yml
+++ b/.github/workflows/copy-build-to-d2-ci.yml
@@ -16,6 +16,7 @@ env:
 jobs:
     copy-to-d2-ci:
         runs-on: ubuntu-latest
+        if: "!contains(github.event.head_commit.message, '[skip ci]')"
         steps:
             - name: Checkout code
               uses: actions/checkout@v3
@@ -23,12 +24,12 @@ jobs:
                   token: ${{env.GH_TOKEN}}
 
             - name: Set up Node.js
-              uses: actions/setup-node@v3
+              uses: actions/setup-node@v1
               with:
-                  node-version: '18'
+                  node-version: '16.x'
 
             - name: Install dependencies
-              run: npm install --frozen-lockfile
+              run: yarn install --frozen-lockfile
 
             - name: Build package
               run: yarn build

--- a/.github/workflows/copy-build-to-d2-ci.yml
+++ b/.github/workflows/copy-build-to-d2-ci.yml
@@ -1,0 +1,83 @@
+name: Publish JavaScript Library
+
+on:
+  push:
+    branches-ignore:
+      - master
+  release:
+    types: [published]
+
+env:
+  GIT_AUTHOR_NAME: '@dhis2-bot'
+  GIT_AUTHOR_EMAIL: 'apps@dhis2.org'
+  GIT_COMMITTER_NAME: '@dhis2-bot'
+  GIT_COMMITTER_EMAIL: 'apps@dhis2.org'
+  NPM_TOKEN: ${{secrets.DHIS2_BOT_NPM_TOKEN}}
+  GH_TOKEN: ${{secrets.DHIS2_BOT_GITHUB_TOKEN}}
+
+jobs:
+  publish-to-github:
+    runs-on: ubuntu-latest
+    if: contains(github.ref, 'alpha')
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          token: ${{env.GH_TOKEN}}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm install --frozen-lockfile
+
+      - name: Build package
+        run: yarn build
+
+      - name: Pack and unpack the build
+        run: yarn pack --filename output.tgz && tar -xzf output.tgz
+
+      - name: Copy package to d2-ci
+        uses: dhis2/deploy-build@master
+        with:
+          github-token: ${{ secrets.DHIS2_BOT_GITHUB_TOKEN }}
+
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_REGISTRY: https://npm.pkg.github.com/
+
+
+
+
+
+
+
+
+
+
+  publish-to-npm:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/master'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build package
+        run: npm run build
+
+      - name: Publish to npm
+        run: npm publish --registry=https://registry.npmjs.org
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/copy-build-to-d2-ci.yml
+++ b/.github/workflows/copy-build-to-d2-ci.yml
@@ -35,6 +35,14 @@ jobs:
             - name: Build package
               run: yarn build
 
+            - uses: actions/upload-artifact@v2
+              with:
+                  name: lib-build
+                  path: |
+                      **/build
+                      !**/node_modules
+                  retention-days: 2
+
             - name: Pack and unpack the build to a directory named 'package'
               run: yarn pack --filename output.tgz && tar -xzf output.tgz
 

--- a/.github/workflows/copy-build-to-d2-ci.yml
+++ b/.github/workflows/copy-build-to-d2-ci.yml
@@ -35,14 +35,6 @@ jobs:
             - name: Build package
               run: yarn build
 
-            - uses: actions/upload-artifact@v2
-              with:
-                  name: lib-build
-                  path: |
-                      **/build
-                      !**/node_modules
-                  retention-days: 2
-
             - name: Pack and unpack the build to a directory named 'package'
               run: yarn pack --filename output.tgz && tar -xzf output.tgz
 

--- a/.github/workflows/copy-build-to-d2-ci.yml
+++ b/.github/workflows/copy-build-to-d2-ci.yml
@@ -35,14 +35,16 @@ jobs:
             - name: Build package
               run: yarn build
 
-            - name: Pack and unpack the build to a directory named 'package'
-              run: yarn pack --filename output.tgz && tar -xzf output.tgz
-
             - uses: actions/upload-artifact@v2
               with:
-                  name: output-build
-                  path: output.tgz
+                  name: lib-build
+                  path: |
+                      **/build
+                      !**/node_modules
                   retention-days: 2
+
+            - name: Pack and unpack the build to a directory named 'package'
+              run: yarn pack --filename output.tgz && tar -xzf output.tgz
 
             - name: Copy package to d2-ci
               uses: dhis2/deploy-build@master

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 **24.x**
 [![Test](https://github.com/dhis2/analytics/actions/workflows/node-test.yml/badge.svg?branch=24.x)](https://github.com/dhis2/analytics/actions/workflows/node-test.yml) [![DHIS2: Release](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml/badge.svg?branch=24.x)](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml)
 
-
 ## Overview
 
 The analytics library contains components and modules that are used in DHIS 2 analytics apps, including:
@@ -36,9 +35,10 @@ Commits to .x branches (e.g. 24.x) cannot trigger a major version bump, even if 
 
 Builds for all non-production branches are automatically copied to [d2-ci/analytics](https://github.com/d2-ci/analytics) for use during development and testing, prior to production release.
 
-To test changes in a development branch, change the analytics dependency of package.json of the app you are testing with. There are a few options: 
+To test changes in a development branch, change the analytics dependency of package.json of the app you are testing with. There are a few options:
 
 1. point to a specific commit:
+
 ```
 "dependencies": {
         "@dhis2/analytics": "git+https://github.com/d2-ci/analytics.git#70249ebe8be39051fa10142f850de449e1ec488c",
@@ -47,6 +47,7 @@ To test changes in a development branch, change the analytics dependency of pack
 ```
 
 2. point to a branch:
+
 ```
 "dependencies": {
         "@dhis2/analytics": "git+https://github.com/d2-ci/analytics.git#chore/some-chore",

--- a/README.md
+++ b/README.md
@@ -3,23 +3,9 @@
 **master**
 [![Test](https://github.com/dhis2/analytics/actions/workflows/node-test.yml/badge.svg)](https://github.com/dhis2/analytics/actions/workflows/node-test.yml) [![DHIS2: Release](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml/badge.svg)](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml)
 
-**21.x**
-[![Test](https://github.com/dhis2/analytics/actions/workflows/node-test.yml/badge.svg?branch=21.x)](https://github.com/dhis2/analytics/actions/workflows/node-test.yml) [![DHIS2: Release](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml/badge.svg?branch=21.x)](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml)
+**24.x**
+[![Test](https://github.com/dhis2/analytics/actions/workflows/node-test.yml/badge.svg?branch=24.x)](https://github.com/dhis2/analytics/actions/workflows/node-test.yml) [![DHIS2: Release](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml/badge.svg?branch=24.x)](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml)
 
-**20.x**
-[![Test](https://github.com/dhis2/analytics/actions/workflows/node-test.yml/badge.svg?branch=20.x)](https://github.com/dhis2/analytics/actions/workflows/node-test.yml) [![DHIS2: Release](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml/badge.svg?branch=20.x)](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml)
-
-**16.x**
-[![Test](https://github.com/dhis2/analytics/actions/workflows/node-test.yml/badge.svg?branch=16.x)](https://github.com/dhis2/analytics/actions/workflows/node-test.yml) [![DHIS2: Release](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml/badge.svg?branch=16.x)](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml)
-
-**11.0.x**
-[![Test](https://github.com/dhis2/analytics/actions/workflows/node-test.yml/badge.svg?branch=11.0.x)](https://github.com/dhis2/analytics/actions/workflows/node-test.yml) [![DHIS2: Release](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml/badge.svg?branch=11.0.x)](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml)
-
-**4.x**
-[![Test](https://github.com/dhis2/analytics/actions/workflows/node-test.yml/badge.svg?branch=4.x)](https://github.com/dhis2/analytics/actions/workflows/node-test.yml) [![DHIS2: Release](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml/badge.svg?branch=4.x)](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml)
-
-**2.4.x**
-[![Test](https://github.com/dhis2/analytics/actions/workflows/node-test.yml/badge.svg?branch=2.4.x)](https://github.com/dhis2/analytics/actions/workflows/node-test.yml) [![DHIS2: Release](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml/badge.svg?branch=2.4.x)](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml)
 
 ## Overview
 
@@ -28,6 +14,7 @@ The analytics library contains components and modules that are used in DHIS 2 an
 -   [dhis2/dashboards-app](https://github.com/dhis2/dashboards-app)
 -   [dhis2/data-visualizer-app](https://github.com/dhis2/data-visualizer-app)
 -   [dhis2/maps-app](https://github.com/dhis2/maps-app)
+-   [dhis2/line-listing-app](https://github.com/dhis2/line-listing-app)
 
 [Module layout documentation](./docs/module-layout.md)
 
@@ -35,7 +22,7 @@ The analytics library contains components and modules that are used in DHIS 2 an
 
 The analytics package is published to npm as @dhis2/analytics.
 
-To publish, simply mark the commit using [semantic release terminology](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) (see notes below for branch-specific restrictions). Once committed, github actions will take care of publishing the new version to npm.
+To publish, mark the commit using [semantic release terminology](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) (see notes below for branch-specific restrictions). Once committed, github actions will take care of publishing the new version to npm.
 
 ### master branch
 
@@ -43,7 +30,29 @@ The master branch follows semantic versioning according to spec.
 
 ### .x branches
 
-Commits to .x branches (e.g. 16.x) cannot trigger a major version bump, even if it is technically a breaking change. This is because the next version has already been published. Additionally, branches that use .x for the patch version (e.g. 11.0.x, 2.4.x), cannot trigger a minor version bump. In the unlikely case that you need to commit a change that would trigger a version bump that's not possible, you will have to mark it to only trigger a patch or minor bump respectively, then make sure to update the apps that are locked to the .x version of analytics
+Commits to .x branches (e.g. 24.x) cannot trigger a major version bump, even if it is technically a breaking change. This is because the next version has already been published. Additionally, branches that use .x for the patch version (e.g. 11.0.x, 2.4.x), cannot trigger a minor version bump. In the unlikely case that you need to commit a change that would trigger a version bump that's not possible, you will have to mark it to only trigger a patch or minor bump respectively, then make sure to update the apps that are locked to the .x version of analytics
+
+## Publishing pre-release versions during app development
+
+Builds for all non-production branches are automatically copied to [d2-ci/analytics](https://github.com/d2-ci/analytics) for use during development and testing, prior to production release.
+
+To test changes in a development branch, change the analytics dependency of package.json of the app you are testing with. There are a few options: 
+
+1. point to a specific commit:
+```
+"dependencies": {
+        "@dhis2/analytics": "git+https://github.com/d2-ci/analytics.git#70249ebe8be39051fa10142f850de449e1ec488c",
+        ...
+}
+```
+
+2. point to a branch:
+```
+"dependencies": {
+        "@dhis2/analytics": "git+https://github.com/d2-ci/analytics.git#chore/some-chore",
+        ...
+}
+```
 
 ## Report an issue
 

--- a/src/components/AboutAOUnit/AboutAOUnit.js
+++ b/src/components/AboutAOUnit/AboutAOUnit.js
@@ -65,7 +65,7 @@ const AboutAOUnit = forwardRef(({ type, id, renderId }, ref) => {
 
     const queries = useMemo(() => getQueries(type), [type])
 
-    console.log('testing build from d2-ci')
+    console.log('testing build from d2-ci 2')
 
     const {
         data,

--- a/src/components/AboutAOUnit/AboutAOUnit.js
+++ b/src/components/AboutAOUnit/AboutAOUnit.js
@@ -65,7 +65,7 @@ const AboutAOUnit = forwardRef(({ type, id, renderId }, ref) => {
 
     const queries = useMemo(() => getQueries(type), [type])
 
-    console.log('testing build from d2-ci 2')
+    console.log('testing build from d2-ci 3')
 
     const {
         data,

--- a/src/components/AboutAOUnit/AboutAOUnit.js
+++ b/src/components/AboutAOUnit/AboutAOUnit.js
@@ -65,8 +65,6 @@ const AboutAOUnit = forwardRef(({ type, id, renderId }, ref) => {
 
     const queries = useMemo(() => getQueries(type), [type])
 
-    console.log('testing build from d2-ci 3')
-
     const {
         data,
         loading: dataIsLoading,
@@ -214,7 +212,7 @@ const AboutAOUnit = forwardRef(({ type, id, renderId }, ref) => {
                                 </p>
                                 <p className="detailLine">
                                     <IconClock16 color={colors.grey700} />
-                                    {i18n.t('Testing testing {{time}}', {
+                                    {i18n.t('Last updated {{time}}', {
                                         time: moment(
                                             fromServerDate(data.ao.lastUpdated)
                                         ).fromNow(),

--- a/src/components/AboutAOUnit/AboutAOUnit.js
+++ b/src/components/AboutAOUnit/AboutAOUnit.js
@@ -65,6 +65,8 @@ const AboutAOUnit = forwardRef(({ type, id, renderId }, ref) => {
 
     const queries = useMemo(() => getQueries(type), [type])
 
+    console.log('testing build from d2-ci')
+
     const {
         data,
         loading: dataIsLoading,
@@ -212,7 +214,7 @@ const AboutAOUnit = forwardRef(({ type, id, renderId }, ref) => {
                                 </p>
                                 <p className="detailLine">
                                     <IconClock16 color={colors.grey700} />
-                                    {i18n.t('Last updated {{time}}', {
+                                    {i18n.t('Testing testing {{time}}', {
                                         time: moment(
                                             fromServerDate(data.ao.lastUpdated)
                                         ).fromNow(),


### PR DESCRIPTION
Slightly related to: https://dhis2.atlassian.net/browse/DHIS2-17300

Every branch that is not listed as one of the prod branches (from node-publish.yml) will now have it's build pushed to d2-ci for every pushed commit. We can then use these builds during development and testing.

Changes to README
- remove build badges for versions that are no longer supported
- add docs about how to use the build

New gh workflow file
- after building the lib, use yarn pack to create the correct structure of the packaged lib. Then unzip the result and push that to d2-ci, which can then be installed by the consuming apps.