### PR TITLE
fix: separator for hundreds, thousands and millions is missing in the Pie charts (DHIS2-16172)

### DIFF
--- a/src/modules/renderValue.js
+++ b/src/modules/renderValue.js
@@ -6,9 +6,7 @@ import { isNumericValueType } from './valueTypes.js'
 
 const trimTrailingZeros = (stringValue) => stringValue.replace(/\.?0+$/, '')
 
-const decimalSeparator = '.'
-
-const separateDigitGroups = (stringValue, decimalSeparator) => {
+export const separateDigitGroups = (stringValue, decimalSeparator = '.') => {
     const isNegative = stringValue[0] === '-'
     const [integer, remainder] = stringValue.replace(/^-/, '').split('.')
 
@@ -68,9 +66,8 @@ export const renderValue = (value, valueType, visualization) => {
         )
 
         return (
-            separateDigitGroups(stringValue, decimalSeparator).join(
-                getSeparator(visualization)
-            ) + '%'
+            separateDigitGroups(stringValue).join(getSeparator(visualization)) +
+            '%'
         )
     } else {
         const stringValue = toFixedPrecisionString(
@@ -78,7 +75,7 @@ export const renderValue = (value, valueType, visualization) => {
             visualization.skipRounding
         )
 
-        return separateDigitGroups(stringValue, decimalSeparator).join(
+        return separateDigitGroups(stringValue).join(
             getSeparator(visualization)
         )
     }

--- a/src/visualizations/config/adapters/dhis_highcharts/series/__tests__/pie.spec.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/__tests__/pie.spec.js
@@ -4,63 +4,63 @@ describe('formatDataLabel', () => {
     it('should format data label correctly with integers', () => {
         const result = formatDataLabel('Test', 1000, 50)
         expect(result).toEqual(
-            '<span style="font-weight:normal">Test</span><br/>1 000<span style="font-weight:normal"> (50 %)</span>'
+            '<span style="font-weight:normal">Test</span><br/>1 000<span style="font-weight:normal"> (50%)</span>'
         )
     })
 
     it('should format data label correctly with decimals', () => {
         const result = formatDataLabel('Test', 1000.123456789, 50.1234)
         expect(result).toEqual(
-            '<span style="font-weight:normal">Test</span><br/>1 000.123456789<span style="font-weight:normal"> (50.1 %)</span>'
+            '<span style="font-weight:normal">Test</span><br/>1 000.123456789<span style="font-weight:normal"> (50.1%)</span>'
         )
     })
 
     it('should handle large numbers correctly', () => {
         const result = formatDataLabel('Test', 1000000, 75.5678)
         expect(result).toEqual(
-            '<span style="font-weight:normal">Test</span><br/>1 000 000<span style="font-weight:normal"> (75.6 %)</span>'
+            '<span style="font-weight:normal">Test</span><br/>1 000 000<span style="font-weight:normal"> (75.6%)</span>'
         )
     })
 
     it('should handle small percentages correctly', () => {
         const result = formatDataLabel('Test', 1000.000001, 0.09)
         expect(result).toEqual(
-            '<span style="font-weight:normal">Test</span><br/>1 000.000001<span style="font-weight:normal"> (0.1 %)</span>'
+            '<span style="font-weight:normal">Test</span><br/>1 000.000001<span style="font-weight:normal"> (0.1%)</span>'
         )
     })
 
     it('should handle zero correctly', () => {
         const result = formatDataLabel('Test', 0, 0)
         expect(result).toEqual(
-            '<span style="font-weight:normal">Test</span><br/>0<span style="font-weight:normal"> (0 %)</span>'
+            '<span style="font-weight:normal">Test</span><br/>0<span style="font-weight:normal"> (0%)</span>'
         )
     })
 
     it('should handle negative numbers correctly', () => {
         const result = formatDataLabel('Test', -1000, -50)
         expect(result).toEqual(
-            '<span style="font-weight:normal">Test</span><br/>-1 000<span style="font-weight:normal"> (-50 %)</span>'
+            '<span style="font-weight:normal">Test</span><br/>-1 000<span style="font-weight:normal"> (-50%)</span>'
         )
     })
 
     it('should handle empty string as name correctly', () => {
         const result = formatDataLabel('', 1000, 50)
         expect(result).toEqual(
-            '<span style="font-weight:normal"></span><br/>1 000<span style="font-weight:normal"> (50 %)</span>'
+            '<span style="font-weight:normal"></span><br/>1 000<span style="font-weight:normal"> (50%)</span>'
         )
     })
 
     it('should handle undefined as name correctly', () => {
         const result = formatDataLabel(undefined, 1000, 50)
         expect(result).toEqual(
-            '<span style="font-weight:normal"></span><br/>1 000<span style="font-weight:normal"> (50 %)</span>'
+            '<span style="font-weight:normal"></span><br/>1 000<span style="font-weight:normal"> (50%)</span>'
         )
     })
 
     it('should handle special characters in name correctly', () => {
         const result = formatDataLabel('Test&Test', 1000, 50)
         expect(result).toEqual(
-            '<span style="font-weight:normal">Test&Test</span><br/>1 000<span style="font-weight:normal"> (50 %)</span>'
+            '<span style="font-weight:normal">Test&Test</span><br/>1 000<span style="font-weight:normal"> (50%)</span>'
         )
     })
 })

--- a/src/visualizations/config/adapters/dhis_highcharts/series/__tests__/pie.spec.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/__tests__/pie.spec.js
@@ -1,0 +1,66 @@
+import { formatDataLabel } from '../pie.js'
+
+describe('formatDataLabel', () => {
+    it('should format data label correctly with integer percentage', () => {
+        const result = formatDataLabel('Test', 1000, 50)
+        expect(result).toEqual(
+            '<span style="font-weight:normal">Test</span><br/>1 000<span style="font-weight:normal"> (50 %)</span>'
+        )
+    })
+
+    it('should format data label correctly with decimal percentage', () => {
+        const result = formatDataLabel('Test', 1000, 50.1234)
+        expect(result).toEqual(
+            '<span style="font-weight:normal">Test</span><br/>1 000<span style="font-weight:normal"> (50.1 %)</span>'
+        )
+    })
+
+    it('should handle large numbers correctly', () => {
+        const result = formatDataLabel('Test', 1000000, 75.5678)
+        expect(result).toEqual(
+            '<span style="font-weight:normal">Test</span><br/>1 000 000<span style="font-weight:normal"> (75.6 %)</span>'
+        )
+    })
+
+    it('should handle small percentages correctly', () => {
+        const result = formatDataLabel('Test', 1000, 0.1234)
+        expect(result).toEqual(
+            '<span style="font-weight:normal">Test</span><br/>1 000<span style="font-weight:normal"> (0.1 %)</span>'
+        )
+    })
+
+    it('should handle zero correctly', () => {
+        const result = formatDataLabel('Test', 0, 0)
+        expect(result).toEqual(
+            '<span style="font-weight:normal">Test</span><br/>0<span style="font-weight:normal"> (0 %)</span>'
+        )
+    })
+
+    it('should handle negative numbers correctly', () => {
+        const result = formatDataLabel('Test', -1000, -50)
+        expect(result).toEqual(
+            '<span style="font-weight:normal">Test</span><br/>-1 000<span style="font-weight:normal"> (-50 %)</span>'
+        )
+    })
+
+    it('should handle empty string as name correctly', () => {
+        const result = formatDataLabel('', 1000, 50)
+        expect(result).toEqual(
+            '<span style="font-weight:normal"></span><br/>1 000<span style="font-weight:normal"> (50 %)</span>'
+        )
+    })
+
+    it('should handle undefined as name correctly', () => {
+        const result = formatDataLabel(undefined, 1000, 50)
+        expect(result).toEqual(
+            '<span style="font-weight:normal"></span><br/>1 000<span style="font-weight:normal"> (50 %)</span>'
+        )
+    })
+
+    it('should handle special characters in name correctly', () => {
+        const result = formatDataLabel('Test&Test', 1000, 50)
+        expect(result).toEqual(
+            '<span style="font-weight:normal">Test&Test</span><br/>1 000<span style="font-weight:normal"> (50 %)</span>'
+        )
+    })
+})

--- a/src/visualizations/config/adapters/dhis_highcharts/series/__tests__/pie.spec.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/__tests__/pie.spec.js
@@ -1,17 +1,17 @@
 import { formatDataLabel } from '../pie.js'
 
 describe('formatDataLabel', () => {
-    it('should format data label correctly with integer percentage', () => {
+    it('should format data label correctly with integers', () => {
         const result = formatDataLabel('Test', 1000, 50)
         expect(result).toEqual(
             '<span style="font-weight:normal">Test</span><br/>1 000<span style="font-weight:normal"> (50 %)</span>'
         )
     })
 
-    it('should format data label correctly with decimal percentage', () => {
-        const result = formatDataLabel('Test', 1000, 50.1234)
+    it('should format data label correctly with decimals', () => {
+        const result = formatDataLabel('Test', 1000.123456789, 50.1234)
         expect(result).toEqual(
-            '<span style="font-weight:normal">Test</span><br/>1 000<span style="font-weight:normal"> (50.1 %)</span>'
+            '<span style="font-weight:normal">Test</span><br/>1 000.123456789<span style="font-weight:normal"> (50.1 %)</span>'
         )
     })
 
@@ -23,9 +23,9 @@ describe('formatDataLabel', () => {
     })
 
     it('should handle small percentages correctly', () => {
-        const result = formatDataLabel('Test', 1000, 0.1234)
+        const result = formatDataLabel('Test', 1000.000001, 0.09)
         expect(result).toEqual(
-            '<span style="font-weight:normal">Test</span><br/>1 000<span style="font-weight:normal"> (0.1 %)</span>'
+            '<span style="font-weight:normal">Test</span><br/>1 000.000001<span style="font-weight:normal"> (0.1 %)</span>'
         )
     })
 

--- a/src/visualizations/config/adapters/dhis_highcharts/series/pie.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/pie.js
@@ -1,11 +1,7 @@
+import { separateDigitGroups } from '../../../../../modules/renderValue.js'
+
 export const formatDataLabel = (name = '', y, percentage) => {
-    const spaceSeparatedValue = y
-        .toString()
-        .replace(/\B(?=(\d{3})+(?!\d))/g, ' ') // add space as thousand separator, but also adds it to decimals
-    const parts = spaceSeparatedValue.split('.')
-    const value = parts[1]
-        ? `${parts[0]}.${parts[1].replace(/\s+/g, '')}` // remove spaces from decimals
-        : parts[0]
+    const value = separateDigitGroups(y.toString()).join(' ')
     return (
         '<span style="font-weight:normal">' +
         name +

--- a/src/visualizations/config/adapters/dhis_highcharts/series/pie.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/pie.js
@@ -1,9 +1,16 @@
 export const formatDataLabel = (name = '', y, percentage) => {
+    const spaceSeparatedValue = y
+        .toString()
+        .replace(/\B(?=(\d{3})+(?!\d))/g, ' ') // add space as thousand separator, but also adds it to decimals
+    const parts = spaceSeparatedValue.split('.')
+    const value = parts[1]
+        ? `${parts[0]}.${parts[1].replace(/\s+/g, '')}` // remove spaces from decimals
+        : parts[0]
     return (
         '<span style="font-weight:normal">' +
         name +
         '</span><br/>' +
-        y.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ') +
+        value +
         '<span style="font-weight:normal"> (' +
         parseFloat(percentage.toFixed(1)) +
         ' %)</span>'

--- a/src/visualizations/config/adapters/dhis_highcharts/series/pie.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/pie.js
@@ -1,3 +1,15 @@
+export const formatDataLabel = (name = '', y, percentage) => {
+    return (
+        '<span style="font-weight:normal">' +
+        name +
+        '</span><br/>' +
+        y.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ' ') +
+        '<span style="font-weight:normal"> (' +
+        parseFloat(percentage.toFixed(1)) +
+        ' %)</span>'
+    )
+}
+
 export default function (series, colors) {
     return [
         {
@@ -9,14 +21,10 @@ export default function (series, colors) {
             dataLabels: {
                 enabled: true,
                 formatter: function () {
-                    return (
-                        '<span style="font-weight:normal">' +
-                        this.point.name +
-                        '</span><br/>' +
-                        this.y +
-                        '<span style="font-weight:normal"> (' +
-                        this.percentage.toFixed(1) +
-                        ' %)</span>'
+                    return formatDataLabel(
+                        this.point.name,
+                        this.y,
+                        this.percentage
                     )
                 },
             },

--- a/src/visualizations/config/adapters/dhis_highcharts/series/pie.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/pie.js
@@ -9,7 +9,7 @@ export const formatDataLabel = (name = '', y, percentage) => {
         value +
         '<span style="font-weight:normal"> (' +
         parseFloat(percentage.toFixed(1)) +
-        ' %)</span>'
+        '%)</span>'
     )
 }
 


### PR DESCRIPTION
Implements [DHIS2-16172](https://dhis2.atlassian.net/browse/DHIS2-16172)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/3093**

---

### Key features

1. export ’separateDigitGroups’ to be reused for pie
2. format pie data labels properly with thousand separator and decimal handling

---

### Description

The value now has a thousand separator, e.g. `1000` -> `1 000`. The decimals are intact for the value, e.g. `1000,01` -> `1 000,01`

The percentage now renders without a trailing zero, e.g. `100,0` -> `100`. This only affects zeros, so real decimal values will still be rendered (rounded to 1 decimal point), e.g. `100,12` -> `100,1`

---

### TODO

-   [x] Manual testing
-   [x] Fix bug with `1234.5678` outputting as `1 234.5 678`

---

### Screenshots


_before, no thousand separator for value, percentage has trailing zero_

![image](https://github.com/dhis2/analytics/assets/12590483/15c33dc0-5266-46ef-96d6-84038bb11f21)



_after, adds thousand separator for value, no percentage trailing zero_

![image](https://github.com/dhis2/analytics/assets/12590483/ecc704d3-7f77-4a1f-9c3d-908c4e7a69d0)



[DHIS2-16172]: https://dhis2.atlassian.net/browse/DHIS2-16172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ