### PR TITLE
chore: new github workflow that copies build of all non-prod branches to d2-ci [24.x]

### DIFF
--- a/.github/workflows/copy-build-to-d2-ci.yml
+++ b/.github/workflows/copy-build-to-d2-ci.yml
@@ -27,7 +27,7 @@ jobs:
             - name: Set up Node.js
               uses: actions/setup-node@v1
               with:
-                  node-version: '16.x'
+                  node-version: 12.x
 
             - name: Install dependencies
               run: yarn install --frozen-lockfile

--- a/.github/workflows/copy-build-to-d2-ci.yml
+++ b/.github/workflows/copy-build-to-d2-ci.yml
@@ -1,0 +1,45 @@
+name: Copy build to d2-ci
+
+on:
+    push:
+        branches-ignore:
+            - master
+            - next
+            - next-major
+            - alpha
+            - beta
+            - '[0-9]+.x'
+            - '[0-9]+.x.x'
+            - '[0-9]+.[0-9]+.x'
+
+env:
+    GH_TOKEN: ${{secrets.DHIS2_BOT_GITHUB_TOKEN}}
+
+jobs:
+    copy-to-d2-ci:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+              with:
+                  token: ${{env.GH_TOKEN}}
+
+            - name: Set up Node.js
+              uses: actions/setup-node@v1
+              with:
+                  node-version: '16.x'
+
+            - name: Install dependencies
+              run: yarn install --frozen-lockfile
+
+            - name: Build package
+              run: yarn build
+
+            - name: Pack and unpack the build to a directory named 'package'
+              run: yarn pack --filename output.tgz && tar -xzf output.tgz
+
+            - name: Copy package to d2-ci
+              uses: dhis2/deploy-build@master
+              with:
+                  build-dir: package
+                  github-token: ${{env.GH_TOKEN}}

--- a/README.md
+++ b/README.md
@@ -3,23 +3,8 @@
 **master**
 [![Test](https://github.com/dhis2/analytics/actions/workflows/node-test.yml/badge.svg)](https://github.com/dhis2/analytics/actions/workflows/node-test.yml) [![DHIS2: Release](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml/badge.svg)](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml)
 
-**21.x**
-[![Test](https://github.com/dhis2/analytics/actions/workflows/node-test.yml/badge.svg?branch=21.x)](https://github.com/dhis2/analytics/actions/workflows/node-test.yml) [![DHIS2: Release](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml/badge.svg?branch=21.x)](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml)
-
-**20.x**
-[![Test](https://github.com/dhis2/analytics/actions/workflows/node-test.yml/badge.svg?branch=20.x)](https://github.com/dhis2/analytics/actions/workflows/node-test.yml) [![DHIS2: Release](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml/badge.svg?branch=20.x)](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml)
-
-**16.x**
-[![Test](https://github.com/dhis2/analytics/actions/workflows/node-test.yml/badge.svg?branch=16.x)](https://github.com/dhis2/analytics/actions/workflows/node-test.yml) [![DHIS2: Release](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml/badge.svg?branch=16.x)](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml)
-
-**11.0.x**
-[![Test](https://github.com/dhis2/analytics/actions/workflows/node-test.yml/badge.svg?branch=11.0.x)](https://github.com/dhis2/analytics/actions/workflows/node-test.yml) [![DHIS2: Release](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml/badge.svg?branch=11.0.x)](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml)
-
-**4.x**
-[![Test](https://github.com/dhis2/analytics/actions/workflows/node-test.yml/badge.svg?branch=4.x)](https://github.com/dhis2/analytics/actions/workflows/node-test.yml) [![DHIS2: Release](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml/badge.svg?branch=4.x)](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml)
-
-**2.4.x**
-[![Test](https://github.com/dhis2/analytics/actions/workflows/node-test.yml/badge.svg?branch=2.4.x)](https://github.com/dhis2/analytics/actions/workflows/node-test.yml) [![DHIS2: Release](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml/badge.svg?branch=2.4.x)](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml)
+**24.x**
+[![Test](https://github.com/dhis2/analytics/actions/workflows/node-test.yml/badge.svg?branch=24.x)](https://github.com/dhis2/analytics/actions/workflows/node-test.yml) [![DHIS2: Release](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml/badge.svg?branch=24.x)](https://github.com/dhis2/analytics/actions/workflows/node-publish.yml)
 
 ## Overview
 
@@ -28,6 +13,7 @@ The analytics library contains components and modules that are used in DHIS 2 an
 -   [dhis2/dashboards-app](https://github.com/dhis2/dashboards-app)
 -   [dhis2/data-visualizer-app](https://github.com/dhis2/data-visualizer-app)
 -   [dhis2/maps-app](https://github.com/dhis2/maps-app)
+-   [dhis2/line-listing-app](https://github.com/dhis2/line-listing-app)
 
 [Module layout documentation](./docs/module-layout.md)
 
@@ -35,7 +21,7 @@ The analytics library contains components and modules that are used in DHIS 2 an
 
 The analytics package is published to npm as @dhis2/analytics.
 
-To publish, simply mark the commit using [semantic release terminology](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) (see notes below for branch-specific restrictions). Once committed, github actions will take care of publishing the new version to npm.
+To publish, mark the commit using [semantic release terminology](https://github.com/angular/angular.js/blob/master/DEVELOPERS.md#-git-commit-guidelines) (see notes below for branch-specific restrictions). Once committed, github actions will take care of publishing the new version to npm.
 
 ### master branch
 
@@ -43,7 +29,31 @@ The master branch follows semantic versioning according to spec.
 
 ### .x branches
 
-Commits to .x branches (e.g. 16.x) cannot trigger a major version bump, even if it is technically a breaking change. This is because the next version has already been published. Additionally, branches that use .x for the patch version (e.g. 11.0.x, 2.4.x), cannot trigger a minor version bump. In the unlikely case that you need to commit a change that would trigger a version bump that's not possible, you will have to mark it to only trigger a patch or minor bump respectively, then make sure to update the apps that are locked to the .x version of analytics
+Commits to .x branches (e.g. 24.x) cannot trigger a major version bump, even if it is technically a breaking change. This is because the next version has already been published. Additionally, branches that use .x for the patch version (e.g. 11.0.x, 2.4.x), cannot trigger a minor version bump. In the unlikely case that you need to commit a change that would trigger a version bump that's not possible, you will have to mark it to only trigger a patch or minor bump respectively, then make sure to update the apps that are locked to the .x version of analytics
+
+## Publishing pre-release versions during app development
+
+Builds for all non-production branches are automatically copied to [d2-ci/analytics](https://github.com/d2-ci/analytics) for use during development and testing, prior to production release.
+
+To test changes in a development branch, change the analytics dependency of package.json of the app you are testing with. There are a few options:
+
+1. point to a specific commit:
+
+```
+"dependencies": {
+        "@dhis2/analytics": "git+https://github.com/d2-ci/analytics.git#70249ebe8be39051fa10142f850de449e1ec488c",
+        ...
+}
+```
+
+2. point to a branch:
+
+```
+"dependencies": {
+        "@dhis2/analytics": "git+https://github.com/d2-ci/analytics.git#chore/some-chore",
+        ...
+}
+```
 
 ## Report an issue
 


### PR DESCRIPTION
Backport of https://github.com/dhis2/analytics/pull/1676

Slightly related to: https://dhis2.atlassian.net/browse/DHIS2-17300

Every branch that is not listed as one of the prod branches (from node-publish.yml)
will now have it's build pushed to d2-ci for every pushed commit.
We can then use these builds during development and testing.

Changes to README

*remove build badges for versions that are no longer supported
*add docs about how to use the build

New gh workflow file

After building the lib, use yarn pack to create the correct structure of the packaged lib.
Then unzip the result and push that to d2-ci, which can then be installed by the consuming apps.