### PR TITLE
fix(pivot-table): use scoped styles instead of global styles

### DIFF
--- a/src/components/PivotTable/styles/PivotTable.style.js
+++ b/src/components/PivotTable/styles/PivotTable.style.js
@@ -10,14 +10,14 @@ import {
     FONT_SIZE_LARGE,
 } from '../../../modules/pivotTable/pivotTableConstants.js'
 
-export const table = css.global`
+export const table = css`
     div.pivot-table-container {
         font-family: 'Roboto', Arial, sans-serif;
         overflow: auto;
         color: ${colors.grey900};
     }
 
-    table {
+    div.pivot-table-container :global(table) {
         border-spacing: 0;
         white-space: nowrap;
         box-sizing: border-box;
@@ -26,35 +26,37 @@ export const table = css.global`
         border-width: 1px 1px 0 0;
     }
 
-    table.fixed-headers {
+    div.pivot-table-container :global(table.fixed-headers) {
         border-width: 0 0 0 1px;
     }
 
-    table.fixed-headers tr th,
-    table.fixed-headers tr td {
+    div.pivot-table-container :global(table.fixed-headers tr th),
+    div.pivot-table-container :global(table.fixed-headers tr td) {
         border-width: 0 1px 1px 0;
     }
 
-    table.fixed-column-headers {
+    div.pivot-table-container :global(table.fixed-column-headers) {
         border-width: 0 1px 0 0;
     }
 
-    table.fixed-column-headers tr th,
-    table.fixed-column-headers tr td {
+    div.pivot-table-container :global(table.fixed-column-headers tr th),
+    div.pivot-table-container :global(table.fixed-column-headers tr td) {
         border-width: 0 0 1px 1px;
     }
 
-    table.fixed-headers thead tr:first-of-type th,
-    table.fixed-column-headers thead tr:first-of-type th {
+    div.pivot-table-container
+        :global(table.fixed-headers thead tr:first-of-type th),
+    div.pivot-table-container
+        :global(table.fixed-column-headers thead tr:first-of-type th) {
         border-top: 1px solid ${BORDER_COLOR};
     }
 
-    table.fixed-row-headers {
+    div.pivot-table-container :global(table.fixed-row-headers) {
         border-width: 0 0 1px 1px;
     }
 
-    table.fixed-row-headers tr th,
-    table.fixed-row-headers tr td {
+    div.pivot-table-container :global(table.fixed-row-headers tr th),
+    div.pivot-table-container :global(table.fixed-row-headers tr td) {
         border-width: 1px 1px 0 0;
     }
 `


### PR DESCRIPTION
Implements [DHIS2-14028](https://dhis2.atlassian.net/browse/DHIS2-14028)

---

### Key features

1. PivotTable now uses scoped styles which will not bleed out of the component

---

### Description

The styles were probably originally declared using `css.global` because they should in fact affect nested components, and this doesn't happen normally because each component has its own CSS scope. But by making the entire style block global, plus using a generic CSS selector like `table`, the risk of these styles affecting other parts of the page becomes very significant.

What we need is "global" styles that impact sub-components but do not bleed out to sibling and parent components. In `@dhis2/ui` we have had to deal with this type of situation a lot and the most convenient pattern we established is the one I've applied here:
- The styles themselves are scoped (i.e. using styled-jsx's `css` and not `css.global`)
- Each selector starts with a scoped one that targets the container component element. NB: this is a div that is rendered by the `PivotTableContainer` component which imports these styles.
- Each selector is then followed by a global selector which means it does affect sub-components too

---

### Test instructions

This fix can actually be verified without installing this analytics bundle into DV. You can just use the storybook to test things out.

---

### Screenshots

_Before_
<img width="383" alt="Screenshot 2024-06-13 at 13 44 01" src="https://github.com/dhis2/analytics/assets/353236/fd4ce00f-471c-4449-bd5d-2070dce7be60">


_After_
<img width="380" alt="Screenshot 2024-06-13 at 13 44 42" src="https://github.com/dhis2/analytics/assets/353236/dbf7963d-c026-4df2-b833-598097b969d1">


[DHIS2-14028]: https://dhis2.atlassian.net/browse/DHIS2-14028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ