### PR TITLE
fix: remove duplicate @dhis2/multi-calendar-dates dependency

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2454,16 +2454,7 @@
     i18next "^10.3"
     moment "^2.24.0"
 
-"@dhis2/multi-calendar-dates@^1.1.1":
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/@dhis2/multi-calendar-dates/-/multi-calendar-dates-1.2.1.tgz#d31ac037302879ae624d72d2373ac455b7e357e8"
-  integrity sha512-lIYwpDbHXKnquvkMDuT2E+V/MwjPDIPIfLi9xfWq5SkuZE3zSl0g65echWYySeZ7EzgRhrtYwA3nuWwuGfcV5Q==
-  dependencies:
-    "@dhis2/d2-i18n" "^1.1.3"
-    "@js-temporal/polyfill" "0.4.3"
-    classnames "^2.3.2"
-
-"@dhis2/multi-calendar-dates@^1.2.2":
+"@dhis2/multi-calendar-dates@^1.1.1", "@dhis2/multi-calendar-dates@^1.2.2":
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/@dhis2/multi-calendar-dates/-/multi-calendar-dates-1.2.2.tgz#c34e5172474ddc73ad829515ed4c489fb8023669"
   integrity sha512-Bl4y2+oDMJLZwtQ1Djfd+wJxOkGixBl6SCuLNH08B3RJSTwF/HcwgtY0vv7tcKUs63SwS7fK6ittXphyB4HJjQ==


### PR DESCRIPTION
Just removing a duplicate dep from yarn.lock