### PR TITLE
fix: do not call period generator with non-4-digit year (DHIS2-17707)

### DIFF
--- a/src/components/PeriodDimension/PeriodTransfer.js
+++ b/src/components/PeriodDimension/PeriodTransfer.js
@@ -156,15 +156,18 @@ const PeriodTransfer = ({
 
     const onSelectFixedPeriods = (filter) => {
         setFixedFilter(filter)
-        setAllPeriods(
-            getFixedPeriodsOptionsById(
-                filter.periodType,
-                periodsSettings
-            ).getPeriods(
-                fixedPeriodConfig(Number(filter.year)),
-                periodsSettings
+
+        if (filter.year.match(/[0-9]{4}/)) {
+            setAllPeriods(
+                getFixedPeriodsOptionsById(
+                    filter.periodType,
+                    periodsSettings
+                ).getPeriods(
+                    fixedPeriodConfig(Number(filter.year)),
+                    periodsSettings
+                )
             )
-        )
+        }
     }
 
     const renderEmptySelection = () => (


### PR DESCRIPTION
Fixes [DHIS2-17707](https://dhis2.atlassian.net/browse/DHIS2-17707)

---

### Key features

1. avoid error in date validation with non 4-digit years

---

### Description

`multi-calendar-dates` assumes the date strings have a 4 digit year, if not, a validation error is thrown.
The fix ensures the period generator functions in `multi-calendar-dates` are only called if the year is a 4-digit number.

The error only shows a console.log in the app, but it's causing Cypress to fail due to the error overlay covering the app.

---

### Screenshots

Before:
<img width="811" alt="Screenshot 2024-07-12 at 12 26 12" src="https://github.com/user-attachments/assets/9beb3159-7cae-45a1-a888-89091575716a">

<img width="452" alt="Screenshot 2024-07-04 at 13 39 40" src="https://github.com/user-attachments/assets/d702839a-733c-4997-ac02-cc64df509c54">

After:
The error is not thrown and the list of periods remain unchanged:
<img width="811" alt="Screenshot 2024-07-12 at 12 26 12" src="https://github.com/user-attachments/assets/9beb3159-7cae-45a1-a888-89091575716a">


[DHIS2-17707]: https://dhis2.atlassian.net/browse/DHIS2-17707?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ