### PR TITLE
fix: sort analytics request params and items for cache hit optimization (DHIS2-17861)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     },
     "scripts": {
         "build": "d2-app-scripts build",
-        "postbuild": "yarn build-storybook",
         "build-storybook": "build-storybook",
         "start-storybook": "start-storybook --port 5000",
         "start": "yarn start-storybook",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     },
     "scripts": {
         "build": "d2-app-scripts build",
+        "postbuild": "yarn build-storybook",
         "build-storybook": "build-storybook",
         "start-storybook": "start-storybook --port 5000",
         "start": "yarn start-storybook",

--- a/src/api/analytics/AnalyticsBase.js
+++ b/src/api/analytics/AnalyticsBase.js
@@ -27,8 +27,12 @@ const analyticsDataQuery = {
         }),
     params: ({ dimensions, filters, parameters }) => {
         return {
-            dimension: dimensions.length ? dimensions : undefined,
-            filter: filters.length ? filters : undefined,
+            dimension: dimensions.length
+                ? generateDimensionStrings(dimensions, { sorted: true })
+                : undefined,
+            filter: filters.length
+                ? generateDimensionStrings(filters, { sorted: true })
+                : undefined,
             ...parameters,
             skipMeta: true,
             skipData: false,
@@ -45,8 +49,10 @@ const analyticsMetaDataQuery = {
             trackedEntityType,
         }),
     params: ({ dimensions, filters, parameters }) => ({
-        dimension: dimensions.length ? dimensions : undefined,
-        filter: filters.length ? filters : undefined,
+        dimension: dimensions.length
+            ? generateDimensionStrings(dimensions)
+            : undefined,
+        filter: filters.length ? generateDimensionStrings(filters) : undefined,
         ...parameters,
         skipMeta: false,
         skipData: true,
@@ -55,11 +61,9 @@ const analyticsMetaDataQuery = {
 }
 
 export const generateDimensionStrings = (dimensions = [], options) => {
-    if (options && options.sorted) {
-        dimensions = sortBy(dimensions, 'dimension')
-    }
-
-    return dimensions.map(({ dimension, items }) => {
+    const sortedDimensions = sortBy(dimensions, 'dimension')
+    console.log('arrays the same?', sortedDimensions === dimensions)
+    return sortedDimensions.map(({ dimension, items }) => {
         if (Array.isArray(items) && items.length) {
             if (options && options.sorted) {
                 items.sort()
@@ -131,8 +135,8 @@ class AnalyticsBase {
                     path: req.path,
                     program: req.program,
                     trackedEntityType: req.trackedEntityType,
-                    dimensions: generateDimensionStrings(req.dimensions),
-                    filters: generateDimensionStrings(req.filters),
+                    dimensions: req.dimensions,
+                    filters: req.filters,
                     parameters: req.parameters,
                     dataParams: dataReq.parameters,
                     metaDataParams: metaDataReq.parameters,

--- a/src/api/analytics/AnalyticsBase.js
+++ b/src/api/analytics/AnalyticsBase.js
@@ -62,11 +62,10 @@ const analyticsMetaDataQuery = {
 
 export const generateDimensionStrings = (dimensions = [], options) => {
     const sortedDimensions = sortBy(dimensions, 'dimension')
-    console.log('arrays the same?', sortedDimensions === dimensions)
     return sortedDimensions.map(({ dimension, items }) => {
         if (Array.isArray(items) && items.length) {
             if (options && options.sorted) {
-                items.sort()
+                items = items.slice().sort()
             }
 
             return `${dimension}:${items.join(';')}`

--- a/src/api/analytics/__tests__/AnalyticsBase.spec.js
+++ b/src/api/analytics/__tests__/AnalyticsBase.spec.js
@@ -33,7 +33,7 @@ describe('generateDimensionString', () => {
                     items: ['item1'],
                 },
             ],
-            output: ['dim2:item2;item1', 'dim1:item1'],
+            output: ['dim1:item1', 'dim2:item2;item1'],
             outputSorted: ['dim1:item1', 'dim2:item1;item2'],
         },
     ]


### PR DESCRIPTION
Implements [DHIS2-17861](https://dhis2.atlassian.net/browse/DHIS2-17861)

Moves the sorting logic to the data and metadata queries. Makes `generateDimensionStrings` pure. 

- [x] Unit tests
- [ ] Manual tests
- Documentation not needed

Before

| Request | Param name | Param value                                                                                     | Param sorting | Item sorting |
|-----|-------------|-------------------------------------------------------------------------------------------------|----------------|---------------|
| Data | Dimension   | dx:fbfJHSPpUQD;cYeuwXTCPkU,pe:THIS_MONTH;LAST_12_MONTHS,ou:lc3eMKXaEfw;jUb8gELQApl             | X              | X             |
| Data | Filter      | pe:THIS_MONTH;LAST_12_MONTHS <br> ou:lc3eMKXaEfw;jUb8gELQApl                                                                   | X              | X             |
| Metadata | Dimension | dx:fbfJHSPpUQD;cYeuwXTCPkU,pe:THIS_MONTH;LAST_12_MONTHS,ou:lc3eMKXaEfw;jUb8gELQApl             | X              | OK            |
| Metadata | Filter    | pe:THIS_MONTH;LAST_12_MONTHS <br> ou:lc3eMKXaEfw;jUb8gELQApl                                                                   | X              | OK            |

After

| Request | Param name | Param value                                                                                     | Param sorting | Item sorting |
|-----|-------------|-------------------------------------------------------------------------------------------------|----------------|---------------|
| Data | Dimension   | dx:cYeuwXTCPkU;fbfJHSPpUQD,ou:jUb8gELQApl;lc3eMKXaEfw,pe:LAST_12_MONTHS;THIS_MONTH              | OK             | OK            |
| Data | Filter      | ou:jUb8gELQApl;lc3eMKXaEfw <br> pe:LAST_12_MONTHS;THIS_MONTH                                                                      | OK             | OK            |
| Metadata | Dimension | dx:fbfJHSPpUQD;cYeuwXTCPkU,ou:lc3eMKXaEfw;jUb8gELQApl,pe:THIS_MONTH;LAST_12_MONTHS              | OK             | OK            |
| Metadata | Filter    | ou:lc3eMKXaEfw;jUb8gELQApl <br> pe:THIS_MONTH;LAST_12_MONTHS                                                                      | OK             | OK            |


[DHIS2-17861]: https://dhis2.atlassian.net/browse/DHIS2-17861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ