### PR TITLE
fix: add AO TYPE for event chart and event report

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-06-26T14:09:30.876Z\n"
-"PO-Revision-Date: 2024-06-26T14:09:30.876Z\n"
+"POT-Creation-Date: 2024-08-27T11:29:09.031Z\n"
+"PO-Revision-Date: 2024-08-27T11:29:09.033Z\n"
 
 msgid "view only"
 msgstr "view only"
@@ -66,6 +66,12 @@ msgstr "About this line list"
 
 msgid "About this visualization"
 msgstr "About this visualization"
+
+msgid "About this event chart"
+msgstr "About this event chart"
+
+msgid "About this event report"
+msgstr "About this event report"
 
 msgid "This app could not retrieve required data."
 msgstr "This app could not retrieve required data."

--- a/src/components/AboutAOUnit/utils.js
+++ b/src/components/AboutAOUnit/utils.js
@@ -3,6 +3,8 @@ import i18n from '@dhis2/d2-i18n'
 export const AO_TYPE_VISUALIZATION = 'visualization'
 export const AO_TYPE_MAP = 'map'
 export const AO_TYPE_EVENT_VISUALIZATION = 'eventVisualization'
+export const AO_TYPE_EVENT_CHART = 'eventChart'
+export const AO_TYPE_EVENT_REPORT = 'eventReport'
 
 export const AOTypeMap = {
     [AO_TYPE_VISUALIZATION]: {
@@ -13,6 +15,12 @@ export const AOTypeMap = {
     },
     [AO_TYPE_EVENT_VISUALIZATION]: {
         apiEndpoint: 'eventVisualizations',
+    },
+    [AO_TYPE_EVENT_CHART]: {
+        apiEndpoint: 'eventCharts',
+    },
+    [AO_TYPE_EVENT_REPORT]: {
+        apiEndpoint: 'eventReports',
     },
 }
 
@@ -27,6 +35,12 @@ const texts = {
     },
     [AO_TYPE_VISUALIZATION]: {
         unitTitle: i18n.t('About this visualization'),
+    },
+    [AO_TYPE_EVENT_CHART]: {
+        unitTitle: i18n.t('About this event chart'),
+    },
+    [AO_TYPE_EVENT_REPORT]: {
+        unitTitle: i18n.t('About this event report'),
     },
     [NO_TYPE]: {
         unitTitle: i18n.t('About this visualization'),


### PR DESCRIPTION
Fixes [DHIS2-17943](https://dhis2.atlassian.net/browse/DHIS2-17943)

eventCharts and eventReports were missing in the list of AO_TYPES, causing the AboutAoUnit component to break.

Fixed
Uploading ev-er-interpretations.mov…



[DHIS2-17943]: https://dhis2.atlassian.net/browse/DHIS2-17943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ