### PR TITLE
fix: add translucent prop to CachedDataQueryProvider

### DIFF
--- a/src/components/CachedDataQueryProvider.js
+++ b/src/components/CachedDataQueryProvider.js
@@ -6,7 +6,12 @@ import React, { createContext, useContext } from 'react'
 
 const CachedDataQueryCtx = createContext({})
 
-const CachedDataQueryProvider = ({ query, dataTransformation, children }) => {
+const CachedDataQueryProvider = ({
+    query,
+    dataTransformation,
+    children,
+    translucent = true,
+}) => {
     const { data: rawData, ...rest } = useDataQuery(query)
     const { error, loading } = rest
     const data =
@@ -14,7 +19,7 @@ const CachedDataQueryProvider = ({ query, dataTransformation, children }) => {
 
     if (loading) {
         return (
-            <Layer translucent>
+            <Layer translucent={translucent}>
                 <CenteredContent>
                     <CircularLoader />
                 </CenteredContent>
@@ -43,6 +48,7 @@ CachedDataQueryProvider.propTypes = {
     children: PropTypes.node.isRequired,
     query: PropTypes.object.isRequired,
     dataTransformation: PropTypes.func,
+    translucent: PropTypes.bool,
 }
 
 const useCachedDataQuery = () => useContext(CachedDataQueryCtx)


### PR DESCRIPTION
Implements [DHIS2-18029](https://dhis2.atlassian.net/browse/DHIS2-18029)

**Relates to https://github.com/dhis2/maps-app/pull/3327**

---

### Key features

1. add translucent prop to CachedDataQueryProvider

---

### Description

Allow passing `translucent` prop to CachedDataQueryProvider to enable (= default = usual behavior) or disable the grey background in the children Layer @dhis2/ui component.


[DHIS2-18029]: https://dhis2.atlassian.net/browse/DHIS2-18029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ