### PR TITLE
fix: compute totals for numeric/boolean types respecting totalAggregationType (DHIS2-9155)

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-08-27T11:29:09.031Z\n"
-"PO-Revision-Date: 2024-08-27T11:29:09.033Z\n"
+"POT-Creation-Date: 2024-09-15T09:24:15.693Z\n"
+"PO-Revision-Date: 2024-09-15T09:24:15.694Z\n"
 
 msgid "view only"
 msgstr "view only"
@@ -1124,6 +1124,12 @@ msgstr "{{thresholdFactor}} × Z-score low"
 
 msgid "{{thresholdFactor}} × Z-score high"
 msgstr "{{thresholdFactor}} × Z-score high"
+
+msgid "Not applicable"
+msgstr "Not applicable"
+
+msgid "Value: {{value}}"
+msgstr "Value: {{value}}"
 
 msgid "Data"
 msgstr "Data"

--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-09-15T09:24:15.693Z\n"
-"PO-Revision-Date: 2024-09-15T09:24:15.694Z\n"
+"POT-Creation-Date: 2024-10-11T12:49:26.846Z\n"
+"PO-Revision-Date: 2024-10-11T12:49:26.847Z\n"
 
 msgid "view only"
 msgstr "view only"
@@ -855,6 +855,9 @@ msgstr "Financial Years"
 msgid "Years"
 msgstr "Years"
 
+msgid "Value: {{value}}"
+msgstr "Value: {{value}}"
+
 msgid "Bold text"
 msgstr "Bold text"
 
@@ -1127,9 +1130,6 @@ msgstr "{{thresholdFactor}} × Z-score high"
 
 msgid "Not applicable"
 msgstr "Not applicable"
-
-msgid "Value: {{value}}"
-msgstr "Value: {{value}}"
 
 msgid "Data"
 msgstr "Data"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     },
     "scripts": {
         "build": "d2-app-scripts build",
-        "postbuild": "yarn build-storybook",
         "build-storybook": "build-storybook",
         "start-storybook": "start-storybook --port 5000",
         "start": "yarn start-storybook",

--- a/src/components/PivotTable/PivotTableValueCell.js
+++ b/src/components/PivotTable/PivotTableValueCell.js
@@ -1,3 +1,4 @@
+import i18n from '@dhis2/d2-i18n'
 import PropTypes from 'prop-types'
 import React, { useRef } from 'react'
 import { applyLegendSet } from '../../modules/pivotTable/applyLegendSet.js'
@@ -74,7 +75,13 @@ export const PivotTableValueCell = ({
         <PivotTableCell
             key={column}
             classes={classes}
-            title={cellContent.titleValue ?? cellContent.renderedValue}
+            title={
+                cellContent.titleValue ??
+                i18n.t('Value: {{value}}', {
+                    value: cellContent.renderedValue,
+                    nsSeparator: '^^',
+                })
+            }
             style={style}
             onClick={isClickable ? onClick : undefined}
             ref={cellRef}

--- a/src/components/PivotTable/PivotTableValueCell.js
+++ b/src/components/PivotTable/PivotTableValueCell.js
@@ -74,7 +74,7 @@ export const PivotTableValueCell = ({
         <PivotTableCell
             key={column}
             classes={classes}
-            title={cellContent.renderedValue}
+            title={cellContent.titleValue ?? cellContent.renderedValue}
             style={style}
             onClick={isClickable ? onClick : undefined}
             ref={cellRef}

--- a/src/components/PivotTable/styles/PivotTable.style.js
+++ b/src/components/PivotTable/styles/PivotTable.style.js
@@ -158,6 +158,10 @@ export const cell = css`
     .TRUE_ONLY {
         text-align: right;
     }
+    .N_A {
+        color: ${colors.grey600};
+    }
+
     .clickable {
         cursor: pointer;
     }

--- a/src/components/PivotTable/styles/PivotTable.style.js
+++ b/src/components/PivotTable/styles/PivotTable.style.js
@@ -159,6 +159,7 @@ export const cell = css`
         text-align: right;
     }
     .N_A {
+        text-align: center;
         color: ${colors.grey600};
     }
 

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -1088,10 +1088,15 @@ export class PivotTableEngine {
                         column,
                     })
                     const valueType = dxDimension?.valueType || VALUE_TYPE_TEXT
+                    const totalAggregationType =
+                        dxDimension?.totalAggregationType
 
                     // only accumulate numeric (except for PERCENTAGE and UNIT_INTERVAL) and boolean values
                     // accumulating other value types like text values does not make sense
-                    if (isCumulativeValueType(valueType)) {
+                    if (
+                        isCumulativeValueType(valueType) &&
+                        totalAggregationType === AGGREGATE_TYPE_AVERAGE
+                    ) {
                         // initialise to 0 for cumulative types
                         // (||= is not transformed correctly in Babel with the current setup)
                         acc || (acc = 0)

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -42,6 +42,7 @@ import {
     NUMBER_TYPE_COLUMN_PERCENTAGE,
     NUMBER_TYPE_ROW_PERCENTAGE,
     NUMBER_TYPE_VALUE,
+    VALUE_TYPE_NA,
 } from './pivotTableConstants.js'
 
 const dataFields = [
@@ -755,7 +756,7 @@ export class PivotTableEngine {
 
             const previousValueType = totalCell.valueType
             if (previousValueType && currentValueType !== previousValueType) {
-                totalCell.valueType = AGGREGATE_TYPE_NA
+                totalCell.valueType = VALUE_TYPE_NA
             } else {
                 totalCell.valueType = currentValueType
             }
@@ -925,6 +926,11 @@ export class PivotTableEngine {
                     this.visualization
                 )
             )
+
+            // override valueType for styling cells with N/A value
+            if (totalCell.value === AGGREGATE_TYPE_NA) {
+                totalCell.valueType = VALUE_TYPE_NA
+            }
 
             this.adaptiveClippingController.add(
                 { row, column },

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -549,6 +549,11 @@ export class PivotTableEngine {
 
         const cellValue = this.data[row][column]
 
+        // empty cell
+        if (!cellValue) {
+            return undefined
+        }
+
         if (cellValue && !Array.isArray(cellValue)) {
             // This is a total cell
             return {

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -12,6 +12,7 @@ import {
     VALUE_TYPE_NUMBER,
     VALUE_TYPE_TEXT,
     isBooleanValueType,
+    isCumulativeValueType,
     isNumericValueType,
 } from '../valueTypes.js'
 import { AdaptiveClippingController } from './AdaptiveClippingController.js'
@@ -1029,9 +1030,9 @@ export class PivotTableEngine {
                     })
                     const valueType = dxDimension?.valueType || VALUE_TYPE_TEXT
 
-                    // only accumulate numeric values
-                    // accumulating text values does not make sense
-                    if (valueType === VALUE_TYPE_NUMBER) {
+                    // only accumulate numeric (except for PERCENTAGE and UNIT_INTERVAL) and boolean values
+                    // accumulating other value types like text values does not make sense
+                    if (isCumulativeValueType(valueType)) {
                         if (this.data[row] && this.data[row][column]) {
                             const dataRow = this.data[row][column]
 

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -403,7 +403,30 @@ export class PivotTableEngine {
             rawCell.renderedValue = renderedValue
         }
 
+        if (
+            [CELL_TYPE_TOTAL, CELL_TYPE_SUBTOTAL].includes(rawCell.cellType) &&
+            rawCell.rawValue === AGGREGATE_TYPE_NA
+        ) {
+            rawCell.titleValue = i18n.t('Not applicable')
+        }
+
         if (this.options.cumulativeValues) {
+            let titleValue
+
+            if (this.data[row] && this.data[row][column]) {
+                const dataRow = this.data[row][column]
+
+                const rawValue =
+                    cellType === CELL_TYPE_VALUE
+                        ? dataRow[this.dimensionLookup.dataHeaders.value]
+                        : dataRow.value
+
+                titleValue = i18n.t('Value: {{value}}', {
+                    value: renderValue(rawValue, valueType, this.visualization),
+                    nsSeparator: '^^',
+                })
+            }
+
             const cumulativeValue = this.getCumulative({
                 row,
                 column,
@@ -416,6 +439,7 @@ export class PivotTableEngine {
                         ? VALUE_TYPE_NUMBER
                         : valueType
                 rawCell.empty = false
+                rawCell.titleValue = titleValue
                 rawCell.rawValue = cumulativeValue
                 rawCell.renderedValue = renderValue(
                     cumulativeValue,

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -549,16 +549,7 @@ export class PivotTableEngine {
 
         const cellValue = this.data[row][column]
 
-        if (!cellValue) {
-            // Empty cell
-            // The cell still needs to get the valueType to render correctly 0 and cumulative values
-            return {
-                valueType: VALUE_TYPE_NUMBER,
-                totalAggregationType: AGGREGATE_TYPE_SUM,
-            }
-        }
-
-        if (!Array.isArray(cellValue)) {
+        if (cellValue && !Array.isArray(cellValue)) {
             // This is a total cell
             return {
                 valueType: cellValue.valueType,
@@ -1092,6 +1083,9 @@ export class PivotTableEngine {
                     // only accumulate numeric (except for PERCENTAGE and UNIT_INTERVAL) and boolean values
                     // accumulating other value types like text values does not make sense
                     if (isCumulativeValueType(valueType)) {
+                        // initialise to 0 for cumulative types
+                        acc ||= 0
+
                         if (this.data[row] && this.data[row][column]) {
                             const dataRow = this.data[row][column]
 
@@ -1109,7 +1103,7 @@ export class PivotTableEngine {
                     }
 
                     return acc
-                }, 0)
+                }, '')
             })
         } else {
             this.accumulators = { rows: {} }

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -1091,7 +1091,7 @@ export class PivotTableEngine {
 
                     // only accumulate numeric (except for PERCENTAGE and UNIT_INTERVAL) and boolean values
                     // accumulating other value types like text values does not make sense
-                    if (acc !== VALUE_NA && isCumulativeValueType(valueType)) {
+                    if (isCumulativeValueType(valueType)) {
                         // initialise to 0 for cumulative types
                         // (||= is not transformed correctly in Babel with the current setup)
                         acc || (acc = 0)
@@ -1108,13 +1108,9 @@ export class PivotTableEngine {
 
                             acc += parseValue(rawValue)
                         }
-                    } else {
-                        // show N/A from the first non-cumulative type and onwards
-                        // only if a previous value is present (this is to avoid filling empty rows with N/A)
-                        acc = acc ? VALUE_NA : ''
-                    }
 
-                    this.accumulators.rows[row][column] = acc
+                        this.accumulators.rows[row][column] = acc
+                    }
 
                     return acc
                 }, '')

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -1084,7 +1084,8 @@ export class PivotTableEngine {
                     // accumulating other value types like text values does not make sense
                     if (isCumulativeValueType(valueType)) {
                         // initialise to 0 for cumulative types
-                        acc ||= 0
+                        // (||= is not transformed correctly in Babel with the current setup)
+                        acc || (acc = 0)
 
                         if (this.data[row] && this.data[row][column]) {
                             const dataRow = this.data[row][column]

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -1095,7 +1095,7 @@ export class PivotTableEngine {
                     // accumulating other value types like text values does not make sense
                     if (
                         isCumulativeValueType(valueType) &&
-                        totalAggregationType === AGGREGATE_TYPE_AVERAGE
+                        totalAggregationType === AGGREGATE_TYPE_SUM
                     ) {
                         // initialise to 0 for cumulative types
                         // (||= is not transformed correctly in Babel with the current setup)

--- a/src/modules/pivotTable/pivotTableConstants.js
+++ b/src/modules/pivotTable/pivotTableConstants.js
@@ -9,6 +9,8 @@ export const AGGREGATE_TYPE_SUM = 'SUM'
 export const AGGREGATE_TYPE_AVERAGE = 'AVERAGE'
 export const AGGREGATE_TYPE_NA = 'N/A'
 
+export const VALUE_TYPE_NA = 'N_A' // this ends up as CSS class and / is problematic
+
 export const NUMBER_TYPE_VALUE = 'VALUE'
 export const NUMBER_TYPE_ROW_PERCENTAGE = 'ROW_PERCENTAGE'
 export const NUMBER_TYPE_COLUMN_PERCENTAGE = 'COLUMN_PERCENTAGE'

--- a/src/modules/pivotTable/pivotTableConstants.js
+++ b/src/modules/pivotTable/pivotTableConstants.js
@@ -37,3 +37,5 @@ export const WRAPPED_TEXT_JUSTIFY_BUFFER = 25
 export const WRAPPED_TEXT_LINE_HEIGHT = 1.0
 
 export const CLIPPED_AXIS_PARTITION_SIZE_PX = 1000
+
+export const VALUE_NA = 'N/A'

--- a/src/modules/valueTypes.js
+++ b/src/modules/valueTypes.js
@@ -36,5 +36,16 @@ const NUMERIC_VALUE_TYPES = [
 
 const BOOLEAN_VALUE_TYPES = [VALUE_TYPE_BOOLEAN, VALUE_TYPE_TRUE_ONLY]
 
+const CUMULATIVE_VALUE_TYPES = [
+    VALUE_TYPE_NUMBER,
+    VALUE_TYPE_INTEGER,
+    VALUE_TYPE_INTEGER_POSITIVE,
+    VALUE_TYPE_INTEGER_NEGATIVE,
+    VALUE_TYPE_INTEGER_ZERO_OR_POSITIVE,
+    ...BOOLEAN_VALUE_TYPES,
+]
+
+export const isCumulativeValueType = (type) =>
+    CUMULATIVE_VALUE_TYPES.includes(type)
 export const isNumericValueType = (type) => NUMERIC_VALUE_TYPES.includes(type)
 export const isBooleanValueType = (type) => BOOLEAN_VALUE_TYPES.includes(type)


### PR DESCRIPTION
Implements [DHIS2-9155](https://dhis2.atlassian.net/browse/DHIS2-9155)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/3194**

---

### Key features

1. fix subtotals/totals to avoid `undefined` and show `N/A` when a sum cannot be computed due to different `totalAggregationType` along rows
2. include booleans and all numeric types besides `PERCENTAGE` and `UNIT_INTERVAL` when computing cumulative values

---

### Description

With these changes, all numeric and boolean types are used when computing totals, the calculation also respects `totalAggregationType`.
If the `totalAggregationType` changes along a row, the total cannot be computed and `N/A` is shown instead.
Along columns, the total should work and use the correct calculation based on the `totalAggregationType` of the data element (ie. `SUM` or `AVERAGE`), it's therefore possible to have different calculations on different column totals, depending on the PT layout.

There can still be cases where the api returns inconsistent metadata for certain data elements, where the `totalAggregationType` is not correct for the `valueType`.
This inconsistencies can cause the totals to be calculated wrongly in certain scenarios with mixed valueTypes (ie. a data element with `PERCENTAGE` valueType has `SUM` in `totalAggregationType` and its value will be included in the total calculation).
This is likely a problem along rows.


Before cumulative values only considered data elements with valueType `NUMBER`.
Now all values of data elements with numeric and boolean types except `PERCENTAGE` and `UNIT_INTERVAL` are used.
The other required condition is that the totalAggregationType for the value is `SUM`.
Depending on the PT layout, some tables can be a bit unclear, as some columns might be "skipped" in the calculation.

---

### Screenshots

Totals with mixed numeric and boolean types (except PERCENTAGE and UNIT_INTERVAL):
<img width="763" alt="Screenshot 2024-09-12 at 15 34 12" src="https://github.com/user-attachments/assets/74c59609-d6eb-4b2b-b04e-7fad0d22ade2">

Totals with mixed numeric and non-numeric types:
<img width="309" alt="Screenshot 2024-09-12 at 15 37 34" src="https://github.com/user-attachments/assets/b024038e-d4dd-4d03-b399-bcea8b69b042">
 
<img width="471" alt="Screenshot 2024-09-12 at 15 39 05" src="https://github.com/user-attachments/assets/2cad0a82-002b-4ed3-a3de-dd809334efab">

Subtotals and totals with mixed numeric and non-numeric types:
<img width="335" alt="Screenshot 2024-09-12 at 15 37 49" src="https://github.com/user-attachments/assets/56d05073-5dcb-4bfa-a2cf-acb775f0da66">

Cumulative values with mixed numeric and non-numeric types:
<img width="356" alt="Screenshot 2024-09-12 at 15 40 21" src="https://github.com/user-attachments/assets/13ce1b4e-0cd7-4f4c-9b20-ddd27159f56e">
<img width="356" alt="Screenshot 2024-09-12 at 15 40 32" src="https://github.com/user-attachments/assets/dc40c13f-bf2e-4184-b6d4-2b3c0a7867f9">

Cumulative values with mixed numeric, boolean and non-numeric types:
<img width="353" alt="Screenshot 2024-09-12 at 15 47 18" src="https://github.com/user-attachments/assets/36235092-5d5a-43ab-87cc-99aa37e529af">

Cumulative values with mixed numeric, boolean, and non-numeric types (PERCENTAGE is ignored):
<img width="437" alt="Screenshot 2024-09-12 at 15 50 39" src="https://github.com/user-attachments/assets/00a41b38-3b8e-47a6-8fd9-d1df437377b1">

[DHIS2-9155]: https://dhis2.atlassian.net/browse/DHIS2-9155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ