### PR TITLE
chore: groups security and dev deps into single dependabot prs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,20 @@
 version: 2
 updates:
     - package-ecosystem: npm
-      directory: '/'
+      directory: /
       schedule:
           interval: weekly
-      open-pull-requests-limit: 10
-      target-branch: master
+      open-pull-requests-limit: 5
       versioning-strategy: increase
+      groups:
+          security:
+              applies-to: security-updates
+              update-types:
+                  - minor
+                  - patch
+          devDependencies:
+              applies-to: version-updates
+              dependency-type: development
+              update-types:
+                  - minor
+                  - patch


### PR DESCRIPTION
To reduce the amount of dependabot noise, group dev dependencies and security dependencies

This configuration is similar to what we have in dashboard. Just that I decided not to group regular dependencies since so many of the regular dependencies should probably get actual testing and therefore not be grouped (e.g highcharts, dnd-kit)