### PR TITLE
fix: pivot table crashes when setting hide empty columns

### DIFF
--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -607,7 +607,9 @@ export class PivotTableEngine {
         return !this.data[row] || this.data[row].length === 0
     }
     columnIsEmpty(column) {
-        return !this.rowMap.some((row) => this.data[row][column])
+        return !this.rowMap.some(
+            (row) => this.data[row] && this.data[row][column]
+        )
     }
 
     getRawColumnHeader(column) {

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -607,9 +607,7 @@ export class PivotTableEngine {
         return !this.data[row] || this.data[row].length === 0
     }
     columnIsEmpty(column) {
-        return !this.rowMap.some(
-            (row) => this.data[row] && this.data[row][column]
-        )
+        return !this.rowMap.some((row) => !!this.data[row]?.[column])
     }
 
     getRawColumnHeader(column) {


### PR DESCRIPTION
Fixes [DHIS2-17876](https://dhis2.atlassian.net/browse/DHIS2-17876)

Check that data[row] exists before accessing it.

I think this is where the error was introduced: https://github.com/dhis2/analytics/pull/1567/files#diff-cecda9e65f89fb79253f45505c2d7587509d804de707bfd659ee82d97234daa9R573

[DHIS2-17876]: https://dhis2.atlassian.net/browse/DHIS2-17876?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ