### PR TITLE
fix: add target and rel attributes to Markdown links (DHIS2-19274)

### DIFF
--- a/src/components/RichText/Parser/__tests__/MdParser.spec.js
+++ b/src/components/RichText/Parser/__tests__/MdParser.spec.js
@@ -68,6 +68,10 @@ describe('MdParser class', () => {
 
             // links
             [
+                '[Test link](https://host.tld/path/link)',
+                '<a href="https://host.tld/path/link" target="_blank" rel="noopener">Test link</a>',
+            ],
+            [
                 'example.com/path',
                 '<a href="http://example.com/path" target="_blank" rel="noopener">example.com/path</a>',
             ],

--- a/src/components/RichText/Parser/__tests__/MdParser.spec.js
+++ b/src/components/RichText/Parser/__tests__/MdParser.spec.js
@@ -69,7 +69,7 @@ describe('MdParser class', () => {
             // links
             [
                 'example.com/path',
-                '<a href="http://example.com/path">example.com/path</a>',
+                '<a href="http://example.com/path" target="_blank" rel="noopener">example.com/path</a>',
             ],
 
             // not recognized links with italic marker inside not converted
@@ -95,19 +95,19 @@ describe('MdParser class', () => {
             // italic marker inside links not converted
             [
                 'example.com/path_with_underscore',
-                '<a href="http://example.com/path_with_underscore">example.com/path_with_underscore</a>',
+                '<a href="http://example.com/path_with_underscore" target="_blank" rel="noopener">example.com/path_with_underscore</a>',
             ],
             [
                 '_italic_ and *bold* with a example.com/link_with_underscore',
-                '<em>italic</em> and <strong>bold</strong> with a <a href="http://example.com/link_with_underscore">example.com/link_with_underscore</a>',
+                '<em>italic</em> and <strong>bold</strong> with a <a href="http://example.com/link_with_underscore" target="_blank" rel="noopener">example.com/link_with_underscore</a>',
             ],
             [
                 'example.com/path with *bold* after :)',
-                '<a href="http://example.com/path">example.com/path</a> with <strong>bold</strong> after <span>\u{1F642}</span>',
+                '<a href="http://example.com/path" target="_blank" rel="noopener">example.com/path</a> with <strong>bold</strong> after <span>\u{1F642}</span>',
             ],
             [
                 '_before_ example.com/path_with_underscore *after* :)',
-                '<em>before</em> <a href="http://example.com/path_with_underscore">example.com/path_with_underscore</a> <strong>after</strong> <span>\u{1F642}</span>',
+                '<em>before</em> <a href="http://example.com/path_with_underscore" target="_blank" rel="noopener">example.com/path_with_underscore</a> <strong>after</strong> <span>\u{1F642}</span>',
             ],
 
             // italic/bold markers right after non-word characters


### PR DESCRIPTION
Implements [DHIS2-19274](https://dhis2.atlassian.net/browse/DHIS2-19274)

---

### Key features

1. add target="_blank" and rel="noopener" to Markdown links

---

### Description

This is needed to allow Markdown links and automatically generated links to open when the app is running in the global shell.

---

### TODO

- [x] Tests added
- [ ] PRs for all affected apps created
- [ ] Storybook added N/A


[DHIS2-19274]: https://dhis2.atlassian.net/browse/DHIS2-19274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ