### PR TITLE
fix: ensure app link are formatted correctly (DHIS2-19270)

### DIFF
--- a/src/components/FileMenu/GetLinkDialog.js
+++ b/src/components/FileMenu/GetLinkDialog.js
@@ -14,12 +14,14 @@ import { styles } from './GetLinkDialog.styles.js'
 import { supportedFileTypes, appPathFor } from './utils.js'
 
 export const GetLinkDialog = ({ type, id, onClose }) => {
-    const { baseUrl } = useConfig()
+    const { apiVersion, baseUrl } = useConfig()
 
-    // TODO simply use href from the visualization object?
-    const appBaseUrl = new URL(baseUrl, self.location.href)
+    const appBaseUrl = new URL(
+        baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`,
+        self.location.href
+    ).href
 
-    const appUrl = new URL(appPathFor(type, id), appBaseUrl)
+    const appUrl = new URL(appPathFor(type, id, apiVersion), appBaseUrl).href
 
     return (
         <Modal onClose={onClose}>
@@ -27,13 +29,11 @@ export const GetLinkDialog = ({ type, id, onClose }) => {
             <ModalContent>
                 <p>{i18n.t('Open in this app')}</p>
                 <div className="link-container">
-                    <a href={appUrl.href}>{appUrl.href}</a>
+                    <a href={appUrl}>{appUrl}</a>
                     <Button
                         icon={<IconCopy24 />}
                         small
-                        onClick={() =>
-                            navigator.clipboard.writeText(appUrl.href)
-                        }
+                        onClick={() => navigator.clipboard.writeText(appUrl)}
                     />
                 </div>
             </ModalContent>

--- a/src/components/FileMenu/__tests__/GetLinkDialog.spec.js
+++ b/src/components/FileMenu/__tests__/GetLinkDialog.spec.js
@@ -76,24 +76,25 @@ describe('The FileMenu - GetLinkDialog component', () => {
         ).toHaveLength(1)
     })
 
-    tests.forEach((test) => {
-        it('renders a <a> tag containing the correct app path and id', () => {
+    test.each(tests)(
+        'renders a <a> tag containing the correct app path and id',
+        ({ apiVersion, baseUrl, type, id, expected }) => {
             mockUseConfig.mockReturnValueOnce({
-                apiVersion: test.apiVersion || 42,
-                baseUrl: test.baseUrl,
+                apiVersion: apiVersion || 42,
+                baseUrl,
             })
 
             const href = getGetLinkDialogComponent({
-                type: test.type,
-                id: test.id,
+                type,
+                id,
                 onClose,
             })
                 .find('a')
                 .prop('href')
 
-            expect(href).toMatch(test.expected)
-        })
-    })
+            expect(href).toMatch(expected)
+        }
+    )
 
     it('calls the onClose callback when the Close button is clicked', () => {
         getGetLinkDialogComponent({

--- a/src/components/FileMenu/utils.js
+++ b/src/components/FileMenu/utils.js
@@ -29,14 +29,17 @@ export const labelForFileType = (fileType) => {
     }
 }
 
-export const appPathFor = (fileType, id) => {
+export const appPathFor = (fileType, id, apiVersion) => {
     switch (fileType) {
         case FILE_TYPE_VISUALIZATION:
             return `dhis-web-data-visualizer/#/${id}`
         case FILE_TYPE_MAP:
-            return `dhis-web-maps/index.html?id=${id}`
+            return `dhis-web-maps/#/${id}`
         case FILE_TYPE_EVENT_VISUALIZATION:
-            return `api/apps/line-listing/#/${id}`
+            // TODO toggle on 42 for bundled path
+            return apiVersion >= 42
+                ? `dhis-web-line-listing/#/${id}`
+                : `api/apps/line-listing/#/${id}`
         default:
             return `${window.location.search}${window.location.hash}`
     }


### PR DESCRIPTION
Implements [DHIS2-19270](https://dhis2.atlassian.net/browse/DHIS2-19270)

---

### Key features

1. ensure app links to visualizations are correctly formatted and point to the right place

---

### Description

From 42 the `baseUrl` returned by the `useConfig` hook is always an absolute URL.
This caused the code in the `GetLinkDialog` component to return the wrong URL with missing path after the hostname.

---

### TODO

- [x] Tests added
- [ ] PRs for all affected apps created


[DHIS2-19270]: https://dhis2.atlassian.net/browse/DHIS2-19270?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ