### PR TITLE
fix: fix hyperlinks to work in global shell (DHIS2-19274)

### DIFF
--- a/src/components/FileMenu/GetLinkDialog.js
+++ b/src/components/FileMenu/GetLinkDialog.js
@@ -14,12 +14,14 @@ import { styles } from './GetLinkDialog.styles.js'
 import { supportedFileTypes, appPathFor } from './utils.js'
 
 export const GetLinkDialog = ({ type, id, onClose }) => {
-    const { baseUrl } = useConfig()
+    const { apiVersion, baseUrl } = useConfig()
 
-    // TODO simply use href from the visualization object?
-    const appBaseUrl = new URL(baseUrl, self.location.href)
+    const appBaseUrl = new URL(
+        baseUrl.endsWith('/') ? baseUrl : `${baseUrl}/`,
+        self.location.href
+    ).href
 
-    const appUrl = new URL(appPathFor(type, id), appBaseUrl)
+    const appUrl = new URL(appPathFor(type, id, apiVersion), appBaseUrl).href
 
     return (
         <Modal onClose={onClose}>
@@ -27,13 +29,11 @@ export const GetLinkDialog = ({ type, id, onClose }) => {
             <ModalContent>
                 <p>{i18n.t('Open in this app')}</p>
                 <div className="link-container">
-                    <a href={appUrl.href}>{appUrl.href}</a>
+                    <a href={appUrl}>{appUrl}</a>
                     <Button
                         icon={<IconCopy24 />}
                         small
-                        onClick={() =>
-                            navigator.clipboard.writeText(appUrl.href)
-                        }
+                        onClick={() => navigator.clipboard.writeText(appUrl)}
                     />
                 </div>
             </ModalContent>

--- a/src/components/FileMenu/__tests__/GetLinkDialog.spec.js
+++ b/src/components/FileMenu/__tests__/GetLinkDialog.spec.js
@@ -76,24 +76,25 @@ describe('The FileMenu - GetLinkDialog component', () => {
         ).toHaveLength(1)
     })
 
-    tests.forEach((test) => {
-        it('renders a <a> tag containing the correct app path and id', () => {
+    test.each(tests)(
+        'renders a <a> tag containing the correct app path and id',
+        ({ apiVersion, baseUrl, type, id, expected }) => {
             mockUseConfig.mockReturnValueOnce({
-                apiVersion: test.apiVersion || 42,
-                baseUrl: test.baseUrl,
+                apiVersion: apiVersion || 42,
+                baseUrl,
             })
 
             const href = getGetLinkDialogComponent({
-                type: test.type,
-                id: test.id,
+                type,
+                id,
                 onClose,
             })
                 .find('a')
                 .prop('href')
 
-            expect(href).toMatch(test.expected)
-        })
-    })
+            expect(href).toMatch(expected)
+        }
+    )
 
     it('calls the onClose callback when the Close button is clicked', () => {
         getGetLinkDialogComponent({

--- a/src/components/FileMenu/utils.js
+++ b/src/components/FileMenu/utils.js
@@ -29,14 +29,17 @@ export const labelForFileType = (fileType) => {
     }
 }
 
-export const appPathFor = (fileType, id) => {
+export const appPathFor = (fileType, id, apiVersion) => {
     switch (fileType) {
         case FILE_TYPE_VISUALIZATION:
             return `dhis-web-data-visualizer/#/${id}`
         case FILE_TYPE_MAP:
-            return `dhis-web-maps/index.html?id=${id}`
+            return `dhis-web-maps/#/${id}`
         case FILE_TYPE_EVENT_VISUALIZATION:
-            return `api/apps/line-listing/#/${id}`
+            // TODO toggle on 42 for bundled path
+            return apiVersion >= 42
+                ? `dhis-web-line-listing/#/${id}`
+                : `api/apps/line-listing/#/${id}`
         default:
             return `${window.location.search}${window.location.hash}`
     }

--- a/src/components/FileMenu/utils.js
+++ b/src/components/FileMenu/utils.js
@@ -36,7 +36,7 @@ export const appPathFor = (fileType, id, apiVersion) => {
         case FILE_TYPE_MAP:
             return `dhis-web-maps/#/${id}`
         case FILE_TYPE_EVENT_VISUALIZATION:
-            // TODO toggle on 42 for bundled path
+            // VERSION-TOGGLE: remove when 42 is the lowest supported version
             return apiVersion >= 42
                 ? `dhis-web-line-listing/#/${id}`
                 : `api/apps/line-listing/#/${id}`

--- a/src/components/RichText/Parser/MdParser.js
+++ b/src/components/RichText/Parser/MdParser.js
@@ -107,7 +107,7 @@ export class MdParser {
         md.renderer.rules.link_open = (tokens, idx, options, env, self) => {
             // Add a new 'target' and 'rel' attributes, or replace the value of the existing ones.
             tokens[idx].attrSet('target', '_blank')
-            tokens[idx].attrSet('rel', 'noopener')
+            tokens[idx].attrSet('rel', 'noreferrer')
 
             // Pass the token to the default renderer.
             return defaultRender(tokens, idx, options, env, self)

--- a/src/components/RichText/Parser/__tests__/MdParser.spec.js
+++ b/src/components/RichText/Parser/__tests__/MdParser.spec.js
@@ -68,6 +68,10 @@ describe('MdParser class', () => {
 
             // links
             [
+                '[Test link](https://host.tld/path/link)',
+                '<a href="https://host.tld/path/link" target="_blank" rel="noopener">Test link</a>',
+            ],
+            [
                 'example.com/path',
                 '<a href="http://example.com/path" target="_blank" rel="noopener">example.com/path</a>',
             ],

--- a/src/components/RichText/Parser/__tests__/MdParser.spec.js
+++ b/src/components/RichText/Parser/__tests__/MdParser.spec.js
@@ -69,7 +69,7 @@ describe('MdParser class', () => {
             // links
             [
                 'example.com/path',
-                '<a href="http://example.com/path">example.com/path</a>',
+                '<a href="http://example.com/path" target="_blank" rel="noopener">example.com/path</a>',
             ],
 
             // not recognized links with italic marker inside not converted
@@ -95,19 +95,19 @@ describe('MdParser class', () => {
             // italic marker inside links not converted
             [
                 'example.com/path_with_underscore',
-                '<a href="http://example.com/path_with_underscore">example.com/path_with_underscore</a>',
+                '<a href="http://example.com/path_with_underscore" target="_blank" rel="noopener">example.com/path_with_underscore</a>',
             ],
             [
                 '_italic_ and *bold* with a example.com/link_with_underscore',
-                '<em>italic</em> and <strong>bold</strong> with a <a href="http://example.com/link_with_underscore">example.com/link_with_underscore</a>',
+                '<em>italic</em> and <strong>bold</strong> with a <a href="http://example.com/link_with_underscore" target="_blank" rel="noopener">example.com/link_with_underscore</a>',
             ],
             [
                 'example.com/path with *bold* after :)',
-                '<a href="http://example.com/path">example.com/path</a> with <strong>bold</strong> after <span>\u{1F642}</span>',
+                '<a href="http://example.com/path" target="_blank" rel="noopener">example.com/path</a> with <strong>bold</strong> after <span>\u{1F642}</span>',
             ],
             [
                 '_before_ example.com/path_with_underscore *after* :)',
-                '<em>before</em> <a href="http://example.com/path_with_underscore">example.com/path_with_underscore</a> <strong>after</strong> <span>\u{1F642}</span>',
+                '<em>before</em> <a href="http://example.com/path_with_underscore" target="_blank" rel="noopener">example.com/path_with_underscore</a> <strong>after</strong> <span>\u{1F642}</span>',
             ],
 
             // italic/bold markers right after non-word characters

--- a/src/components/RichText/Parser/__tests__/MdParser.spec.js
+++ b/src/components/RichText/Parser/__tests__/MdParser.spec.js
@@ -69,11 +69,11 @@ describe('MdParser class', () => {
             // links
             [
                 '[Test link](https://host.tld/path/link)',
-                '<a href="https://host.tld/path/link" target="_blank" rel="noopener">Test link</a>',
+                '<a href="https://host.tld/path/link" target="_blank" rel="noreferrer">Test link</a>',
             ],
             [
                 'example.com/path',
-                '<a href="http://example.com/path" target="_blank" rel="noopener">example.com/path</a>',
+                '<a href="http://example.com/path" target="_blank" rel="noreferrer">example.com/path</a>',
             ],
 
             // not recognized links with italic marker inside not converted
@@ -99,19 +99,19 @@ describe('MdParser class', () => {
             // italic marker inside links not converted
             [
                 'example.com/path_with_underscore',
-                '<a href="http://example.com/path_with_underscore" target="_blank" rel="noopener">example.com/path_with_underscore</a>',
+                '<a href="http://example.com/path_with_underscore" target="_blank" rel="noreferrer">example.com/path_with_underscore</a>',
             ],
             [
                 '_italic_ and *bold* with a example.com/link_with_underscore',
-                '<em>italic</em> and <strong>bold</strong> with a <a href="http://example.com/link_with_underscore" target="_blank" rel="noopener">example.com/link_with_underscore</a>',
+                '<em>italic</em> and <strong>bold</strong> with a <a href="http://example.com/link_with_underscore" target="_blank" rel="noreferrer">example.com/link_with_underscore</a>',
             ],
             [
                 'example.com/path with *bold* after :)',
-                '<a href="http://example.com/path" target="_blank" rel="noopener">example.com/path</a> with <strong>bold</strong> after <span>\u{1F642}</span>',
+                '<a href="http://example.com/path" target="_blank" rel="noreferrer">example.com/path</a> with <strong>bold</strong> after <span>\u{1F642}</span>',
             ],
             [
                 '_before_ example.com/path_with_underscore *after* :)',
-                '<em>before</em> <a href="http://example.com/path_with_underscore" target="_blank" rel="noopener">example.com/path_with_underscore</a> <strong>after</strong> <span>\u{1F642}</span>',
+                '<em>before</em> <a href="http://example.com/path_with_underscore" target="_blank" rel="noreferrer">example.com/path_with_underscore</a> <strong>after</strong> <span>\u{1F642}</span>',
             ],
 
             // italic/bold markers right after non-word characters


### PR DESCRIPTION
Fixes [DHIS2-19274](https://dhis2.atlassian.net/browse/DHIS2-19274)

---

### Key features

1. add `target="_blank"` and `rel="noreferrer"` to Markdown links
2. ensure app links to visualizations are correctly formatted and point to the right place

---

### Description

1. This is needed to allow Markdown links and automatically generated links to open when the app is running in the global shell.
2. From 42 the `baseUrl` returned by the `useConfig` hook is always an absolute URL.
This caused the code in the `GetLinkDialog` component to return the wrong URL with missing path after the hostname.
 
---

### TODO

- [x] Tests added
- [x] PRs for all affected apps created
- [ ] Storybook added N/A


[DHIS2-19274]: https://dhis2.atlassian.net/browse/DHIS2-19274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ