### PR TITLE
fix: fix sorting in PT when percentage of rows is used (DHIS2-5455)

### DIFF
--- a/src/__demo__/PivotTable.stories.js
+++ b/src/__demo__/PivotTable.stories.js
@@ -212,6 +212,25 @@ SimpleColumn.story = {
     name: 'simple - column %',
 }
 
+export const SimpleRow = (_, { pivotTableOptions }) => {
+    const visualization = {
+        ...diseaseWeeksVisualization,
+        ...visualizationReset,
+        ...pivotTableOptions,
+        numberType: NUMBER_TYPE_ROW_PERCENTAGE,
+    }
+
+    return (
+        <div style={{ width: 800, height: 600 }}>
+            <PivotTable data={diseaseWeeksData} visualization={visualization} />
+        </div>
+    )
+}
+
+SimpleRow.story = {
+    name: 'simple - row %',
+}
+
 export const SimpleDataAsFilter = (_, { pivotTableOptions }) => {
     const visualization = {
         ...simpleVisualization,

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -1297,12 +1297,19 @@ export class PivotTableEngine {
             }
 
             if (
+                // only numerically sort numeric values
+                // percentage values sorting doesn't work here
+                // for detecting that case numberType must be looked at
+                // default for it is "not set" (undefined) which is treated as "VALUE"
+                (!this.visualization.numberType ||
+                    this.visualization.numberType === NUMBER_TYPE_VALUE) &&
                 valueA.valueType === VALUE_TYPE_NUMBER &&
                 valueB.valueType === VALUE_TYPE_NUMBER
             ) {
                 return (valueA.rawValue - valueB.rawValue) * order
             }
             return (
+                // percentage values are strings and localCompare works fine for sorting them
                 valueA.renderedValue.localeCompare(valueB.renderedValue) * order
             )
         })

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -380,11 +380,11 @@ export class PivotTableEngine {
                 rawValue = parseValue(rawValue)
                 switch (this.visualization.numberType) {
                     case NUMBER_TYPE_ROW_PERCENTAGE:
-                        renderedValue =
+                        rawCell.pctValue = renderedValue =
                             rawValue / this.percentageTotals[row].value
                         break
                     case NUMBER_TYPE_COLUMN_PERCENTAGE:
-                        renderedValue =
+                        rawCell.pctValue = renderedValue =
                             rawValue / this.percentageTotals[column].value
                         break
                     default:
@@ -1315,17 +1315,13 @@ export class PivotTableEngine {
             }
 
             if (
-                // for percentage strings, use the renderedValue (percentage) and parse it to extract the number part to use for the comparison
+                // for percentage strings, use the pctValue (percentage value) in the sort comparison
                 [
                     NUMBER_TYPE_ROW_PERCENTAGE,
                     NUMBER_TYPE_COLUMN_PERCENTAGE,
                 ].includes(this.visualization.numberType)
             ) {
-                return (
-                    (parseFloat(valueA.renderedValue) -
-                        parseFloat(valueB.renderedValue)) *
-                    order
-                )
+                return (valueA.pctValue - valueB.pctValue) * order
             } else if (
                 valueA.valueType === VALUE_TYPE_NUMBER &&
                 valueB.valueType === VALUE_TYPE_NUMBER


### PR DESCRIPTION
Implements [DHIS2-5455](https://dhis2.atlassian.net/browse/DHIS2-5455)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/3380**

---

### Key features

1. fix sorting when percentage or rows option is enabled

---

### Description

The sorting always used the raw value.
This breaks the sorting when percentage of row is used because the rendered value is computed comparing cell values across rows, but the sorting is always by column.
For this scenario, the computed percentage value should be used in the sorting function instead.
This PR changes the sorting function to use the rendered value when percentage of rows/columns is enabled.
The PR also sets the cell's tooltip content to show the original value similarly to how it's done when cumulative values is used.
In both scenarios, the rendered value is a representation of the cell's value based on the values of other cells along the row.

---

### TODO

- [ ] Tests added N/A
- [x] PRs for all affected apps created
- [x] Storybook added
- [x] Tester approved

---

### Screenshots

Reference data (notice the ascending sorting on the 1st column):
<img width="256" alt="Screenshot 2025-04-11 at 15 50 30" src="https://github.com/user-attachments/assets/462740f5-7c08-4560-b33a-5749b9bc29a1" />

Before - the column is not sorted ascending and the tooltip shows the rendered value:
<img width="256" alt="Screenshot 2025-04-11 at 15 51 14" src="https://github.com/user-attachments/assets/2cf93a54-21b9-4c71-af36-e4eddf7b0f1a" />

After - the column is sorted ascending and the tooltip shows the original value:
<img width="258" alt="Screenshot 2025-04-11 at 15 50 12" src="https://github.com/user-attachments/assets/f66f994c-4fb2-4fe1-ad9c-bba33af60069" />



[DHIS2-5455]: https://dhis2.atlassian.net/browse/DHIS2-5455?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ