### PR TITLE
fix: do not fetch subscribers as that should be fetched already

### DIFF
--- a/src/components/FileMenu/__tests__/utils.spec.js
+++ b/src/components/FileMenu/__tests__/utils.spec.js
@@ -91,19 +91,6 @@ describe('utils', () => {
     })
 
     describe('preparePayloadForSave', () => {
-        it('fetches subscribers and adds them to the visualization', () => {
-            const visualization = {
-                id: '123',
-                type: 'BAR',
-                name: 'Existing Name',
-                description: 'Existing Description',
-            }
-
-            const result = preparePayloadForSave({
-                visualization,
-            })
-        })
-
         it('sets the name to the provided name', () => {
             const visualization = {
                 id: '123',

--- a/src/components/FileMenu/__tests__/utils.spec.js
+++ b/src/components/FileMenu/__tests__/utils.spec.js
@@ -90,7 +90,7 @@ describe('utils', () => {
         })
     })
 
-    describe('preparePayloadForSave', () => {
+    describe.skip('preparePayloadForSave', () => {
         const mockEngine = {
             query: jest.fn(),
         }

--- a/src/components/FileMenu/__tests__/utils.spec.js
+++ b/src/components/FileMenu/__tests__/utils.spec.js
@@ -90,16 +90,8 @@ describe('utils', () => {
         })
     })
 
-    describe.skip('preparePayloadForSave', () => {
-        const mockEngine = {
-            query: jest.fn(),
-        }
-
-        beforeEach(() => {
-            jest.clearAllMocks()
-        })
-
-        it('fetches subscribers and adds them to the visualization', async () => {
+    describe('preparePayloadForSave', () => {
+        it('fetches subscribers and adds them to the visualization', () => {
             const visualization = {
                 id: '123',
                 type: 'BAR',
@@ -107,29 +99,12 @@ describe('utils', () => {
                 description: 'Existing Description',
             }
 
-            mockEngine.query.mockResolvedValue({
-                ao: { subscribers: ['user1', 'user2'] },
-            })
-
-            const result = await preparePayloadForSave({
+            const result = preparePayloadForSave({
                 visualization,
-                engine: mockEngine,
             })
-
-            expect(mockEngine.query).toHaveBeenCalledWith(
-                {
-                    ao: {
-                        resource: 'visualizations',
-                        id: expect.any(Function),
-                        params: { fields: 'subscribers' },
-                    },
-                },
-                { variables: { id: '123' } }
-            )
-            expect(result.subscribers).toEqual(['user1', 'user2'])
         })
 
-        it('sets the name to the provided name', async () => {
+        it('sets the name to the provided name', () => {
             const visualization = {
                 id: '123',
                 type: 'MAP',
@@ -137,48 +112,33 @@ describe('utils', () => {
             }
             const name = 'New Name'
 
-            mockEngine.query.mockResolvedValue({
-                ao: { subscribers: [] },
-            })
-
-            const result = await preparePayloadForSave({
+            const result = preparePayloadForSave({
                 visualization,
                 name,
-                engine: mockEngine,
             })
 
             expect(result.name).toBe(name)
         })
 
-        it('sets the name to the existing name if no new name is provided', async () => {
+        it('sets the name to the existing name if no new name is provided', () => {
             const visualization = {
                 id: '123',
                 type: 'LINE_LIST',
                 name: 'Existing Name',
             }
 
-            mockEngine.query.mockResolvedValue({
-                ao: { subscribers: [] },
-            })
-
-            const result = await preparePayloadForSave({
+            const result = preparePayloadForSave({
                 visualization,
-                engine: mockEngine,
             })
 
             expect(result.name).toBe('Existing Name')
         })
 
-        it('sets the name to a default value if no name is provided', async () => {
+        it('sets the name to a default value if no name is provided', () => {
             const visualization = { id: '123', type: 'BAR' }
 
-            mockEngine.query.mockResolvedValue({
-                ao: { subscribers: [] },
-            })
-
-            const result = await preparePayloadForSave({
+            const result = preparePayloadForSave({
                 visualization,
-                engine: mockEngine,
             })
 
             const expectedName = `Untitled Bar, ${new Date().toLocaleDateString(
@@ -193,7 +153,7 @@ describe('utils', () => {
             expect(result.name).toBe(expectedName)
         })
 
-        it('sets the description to the provided description', async () => {
+        it('sets the description to the provided description', () => {
             const visualization = {
                 id: '123',
                 type: 'YEAR_OVER_YEAR_LINE',
@@ -201,48 +161,33 @@ describe('utils', () => {
             }
             const description = 'New Description'
 
-            mockEngine.query.mockResolvedValue({
-                ao: { subscribers: [] },
-            })
-
-            const result = await preparePayloadForSave({
+            const result = preparePayloadForSave({
                 visualization,
                 description,
-                engine: mockEngine,
             })
 
             expect(result.description).toBe(description)
         })
 
-        it('keeps the existing description if no new description is provided', async () => {
+        it('keeps the existing description if no new description is provided', () => {
             const visualization = {
                 id: '123',
                 type: 'COLUMN',
                 description: 'Existing Description',
             }
 
-            mockEngine.query.mockResolvedValue({
-                ao: { subscribers: [] },
-            })
-
-            const result = await preparePayloadForSave({
+            const result = preparePayloadForSave({
                 visualization,
-                engine: mockEngine,
             })
 
             expect(result.description).toBe('Existing Description')
         })
 
-        it('sets the description to undefined if no description is provided and none exists', async () => {
+        it('sets the description to undefined if no description is provided and none exists', () => {
             const visualization = { id: '123', type: 'BAR' }
 
-            mockEngine.query.mockResolvedValue({
-                ao: { subscribers: [] },
-            })
-
-            const result = await preparePayloadForSave({
+            const result = preparePayloadForSave({
                 visualization,
-                engine: mockEngine,
             })
 
             expect(result.description).toBeUndefined()

--- a/src/components/FileMenu/utils.js
+++ b/src/components/FileMenu/utils.js
@@ -1,8 +1,5 @@
 import i18n from '@dhis2/d2-i18n'
-import {
-    getDisplayNameByVisType,
-    getApiEndpointByVisType,
-} from '../../modules/visTypes.js'
+import { getDisplayNameByVisType } from '../../modules/visTypes.js'
 
 export const FILE_TYPE_EVENT_REPORT = 'eventReport'
 export const FILE_TYPE_VISUALIZATION = 'visualization'
@@ -77,34 +74,7 @@ export const preparePayloadForSaveAs = ({
     return visualization
 }
 
-const getSubscriberQuery = (type) => ({
-    ao: {
-        resource: getApiEndpointByVisType(type),
-        id: ({ id }) => id,
-        params: {
-            fields: 'subscribers',
-        },
-    },
-})
-
-const apiFetchAOSubscribers = (dataEngine, id, type) => {
-    return dataEngine.query(getSubscriberQuery(type), {
-        variables: { id },
-    })
-}
-
-export const preparePayloadForSave = async ({
-    visualization,
-    name,
-    description,
-    engine,
-}) => {
-    const { ao } = await apiFetchAOSubscribers(
-        engine,
-        visualization.id,
-        visualization.type
-    )
-    visualization.subscribers = ao.subscribers
+export const preparePayloadForSave = ({ visualization, name, description }) => {
     visualization.name =
         name ||
         visualization.name ||

--- a/src/components/FileMenu/utils.js
+++ b/src/components/FileMenu/utils.js
@@ -90,5 +90,8 @@ export const preparePayloadForSave = ({ visualization, name, description }) => {
     visualization.description =
         description !== undefined ? description : visualization.description
 
+    delete visualization.displayName
+    delete visualization.displayDescription
+
     return visualization
 }


### PR DESCRIPTION
Implements [DHIS2-19506](https://dhis2.atlassian.net/browse/DHIS2-19506)

Needed by:
https://github.com/dhis2/maps-app/pull/3520
https://github.com/dhis2/data-visualizer-app/pull/3386
https://github.com/dhis2/line-listing-app/pull/681

### Description

BREAKING CHANGE:

As a quick workaround for renaming bugs, a solution was implemented where the `preparePayloadForSave` function would fetch the `subscribers` property so that it would not be overwritten during a rename. It was subsequently realized (duh) that any property of the visualization might be newer than what was shown in the app, due to a different user having saved changes.

The best solution to deal with the lack of a PATCH is that each app fetches the entire visualization object prior to rename. Thus, the only job for the `preparePayloadForSave` function is to handle name and description changes.

### TODO

- [x] Tests added
- [x] PRs for all affected apps created
- [ ] Storybook added N/A


[DHIS2-19506]: https://dhis2.atlassian.net/browse/DHIS2-19506?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ