### PR TITLE
fix(OpenFileDialog): respect filterVisTypes prop when All types is selected

### DIFF
--- a/src/__demo__/OpenFileDialog.stories.js
+++ b/src/__demo__/OpenFileDialog.stories.js
@@ -54,6 +54,28 @@ ListOfVisualizationsWithVisTypeFilterAndDividerNoDefaultVisType.story = {
     name: 'List of visualizations with vis type filter and divider (no default vis type)',
 }
 
+const filterVisTypesWithGroups = [
+    { type: VIS_TYPE_GROUP_ALL },
+    { type: VIS_TYPE_GROUP_CHARTS },
+]
+
+export const ListOfVisualizationsWithVisTypeGroupFilterNoDefaultVisType =
+    () => (
+        <OpenFileDialog
+            type="visualization"
+            filterVisTypes={filterVisTypesWithGroups}
+            onClose={Function.prototype}
+            onFileSelect={onFileSelect}
+            onNew={Function.prototype}
+            open={true}
+            currentUser={user}
+        />
+    )
+
+ListOfVisualizationsWithVisTypeGroupFilterNoDefaultVisType.story = {
+    name: 'List of visualizations with only vis type group filter (no default vis type)',
+}
+
 export const ListOfMapsNoVisTypeFilter = () => (
     <OpenFileDialog
         type="map"

--- a/src/components/OpenFileDialog/CreatedByFilter.js
+++ b/src/components/OpenFileDialog/CreatedByFilter.js
@@ -9,6 +9,14 @@ export const CREATED_BY_ALL = 'all'
 export const CREATED_BY_ALL_BUT_CURRENT_USER = 'allButCurrentUser'
 export const CREATED_BY_CURRENT_USER = 'currentUser'
 
+export const formatUserFilter = (createdBy, userId) => {
+    if (createdBy === CREATED_BY_ALL_BUT_CURRENT_USER) {
+        return `user.id:!eq:${userId}`
+    } else if (createdBy === CREATED_BY_CURRENT_USER) {
+        return `user.id:eq:${userId}`
+    }
+}
+
 export const CreatedByFilter = ({ selected, onChange }) => (
     <SingleSelect
         selected={selected}

--- a/src/components/OpenFileDialog/OpenFileDialog.js
+++ b/src/components/OpenFileDialog/OpenFileDialog.js
@@ -117,6 +117,20 @@ export const OpenFileDialog = ({
         if (filters.visType) {
             switch (filters.visType) {
                 case VIS_TYPE_GROUP_ALL:
+                    if (Array.isArray(filterVisTypes)) {
+                        queryFilters.push(
+                            `type:in:[${filterVisTypes
+                                .filter(
+                                    ({ type }) =>
+                                        ![
+                                            VIS_TYPE_GROUP_ALL,
+                                            VIS_TYPE_GROUP_CHARTS,
+                                        ].includes(type)
+                                )
+                                .map(({ type }) => type)
+                                .join(',')}]`
+                        )
+                    }
                     break
                 case VIS_TYPE_GROUP_CHARTS:
                     queryFilters.push('type:!eq:PIVOT_TABLE')
@@ -132,7 +146,7 @@ export const OpenFileDialog = ({
         }
 
         return queryFilters
-    }, [currentUser, filters])
+    }, [currentUser, filters, filterVisTypes])
 
     const formatSortDirection = useCallback(() => {
         if (sortField === 'displayName' && sortDirection !== 'default') {

--- a/src/components/OpenFileDialog/OpenFileDialog.js
+++ b/src/components/OpenFileDialog/OpenFileDialog.js
@@ -71,16 +71,14 @@ const getQuery = (type) => ({
 export const formatFilters = (currentUser, filters, filterVisTypes) => {
     const queryFilters = []
 
-    switch (filters.createdBy) {
-        case CREATED_BY_ALL_BUT_CURRENT_USER:
-            queryFilters.push(`user.id:!eq:${currentUser.id}`)
-            break
-        case CREATED_BY_CURRENT_USER:
-            queryFilters.push(`user.id:eq:${currentUser.id}`)
-            break
-        case CREATED_BY_ALL:
-        default:
-            break
+    if (filters.searchTerm) {
+        queryFilters.push(`identifiable:token:${filters.searchTerm}`)
+    }
+
+    if (filters.createdBy === CREATED_BY_ALL_BUT_CURRENT_USER) {
+        queryFilters.push(`user.id:!eq:${currentUser.id}`)
+    } else if (filters.createdBy === CREATED_BY_CURRENT_USER) {
+        queryFilters.push(`user.id:eq:${currentUser.id}`)
     }
 
     const defaultFilterTypes = []
@@ -133,10 +131,6 @@ export const formatFilters = (currentUser, filters, filterVisTypes) => {
         }
     } else if (defaultTypeFilter) {
         queryFilters.push(defaultTypeFilter)
-    }
-
-    if (filters.searchTerm) {
-        queryFilters.push(`identifiable:token:${filters.searchTerm}`)
     }
 
     return queryFilters

--- a/src/components/OpenFileDialog/OpenFileDialog.js
+++ b/src/components/OpenFileDialog/OpenFileDialog.js
@@ -25,22 +25,16 @@ import React, {
     useState,
 } from 'react'
 import {
-    VIS_TYPE_GROUP_ALL,
-    VIS_TYPE_GROUP_CHARTS,
-    VIS_TYPE_PIVOT_TABLE,
-} from '../../modules/visTypes.js'
-import {
     CreatedByFilter,
+    formatUserFilter,
     CREATED_BY_ALL,
-    CREATED_BY_ALL_BUT_CURRENT_USER,
-    CREATED_BY_CURRENT_USER,
 } from './CreatedByFilter.js'
 import { FileList } from './FileList.js'
 import { NameFilter } from './NameFilter.js'
 import { styles } from './OpenFileDialog.styles.js'
 import { PaginationControls } from './PaginationControls.js'
 import { getTranslatedString, AOTypeMap } from './utils.js'
-import { VisTypeFilter } from './VisTypeFilter.js'
+import { VisTypeFilter, formatTypeFilter } from './VisTypeFilter.js'
 
 const getQuery = (type) => ({
     files: {
@@ -71,67 +65,14 @@ const getQuery = (type) => ({
 export const formatFilters = (currentUser, filters, filterVisTypes) => {
     const queryFilters = []
 
-    if (filters.searchTerm) {
+    filters.searchTerm &&
         queryFilters.push(`identifiable:token:${filters.searchTerm}`)
-    }
 
-    if (filters.createdBy === CREATED_BY_ALL_BUT_CURRENT_USER) {
-        queryFilters.push(`user.id:!eq:${currentUser.id}`)
-    } else if (filters.createdBy === CREATED_BY_CURRENT_USER) {
-        queryFilters.push(`user.id:eq:${currentUser.id}`)
-    }
+    const userFilter = formatUserFilter(filters.createdBy, currentUser.id)
+    userFilter && queryFilters.push(userFilter)
 
-    const defaultFilterTypes = []
-
-    let defaultTypeFilter
-
-    if (Array.isArray(filterVisTypes)) {
-        // console.log(filterVisTypes)
-        defaultFilterTypes.push(
-            ...filterVisTypes
-                .filter(
-                    ({ type, disabled }) =>
-                        !(
-                            disabled ||
-                            [
-                                VIS_TYPE_GROUP_ALL,
-                                VIS_TYPE_GROUP_CHARTS,
-                            ].includes(type)
-                        )
-                )
-                .map(({ type }) => type)
-        )
-
-        if (defaultFilterTypes.length) {
-            defaultTypeFilter = `type:in:[${defaultFilterTypes.join(',')}]`
-        }
-    }
-
-    if (filters.visType) {
-        switch (filters.visType) {
-            case VIS_TYPE_GROUP_ALL:
-                if (defaultTypeFilter) {
-                    queryFilters.push(defaultTypeFilter)
-                }
-                break
-            case VIS_TYPE_GROUP_CHARTS:
-                if (defaultFilterTypes.length) {
-                    queryFilters.push(
-                        `type:in:[${defaultFilterTypes
-                            .filter((item) => item !== VIS_TYPE_PIVOT_TABLE)
-                            .join(',')}]`
-                    )
-                } else {
-                    queryFilters.push(`type:!eq:${VIS_TYPE_PIVOT_TABLE}`)
-                }
-                break
-            default:
-                queryFilters.push(`type:eq:${filters.visType}`)
-                break
-        }
-    } else if (defaultTypeFilter) {
-        queryFilters.push(defaultTypeFilter)
-    }
+    const typeFilter = formatTypeFilter(filterVisTypes, filters.visType)
+    typeFilter && queryFilters.push(typeFilter)
 
     return queryFilters
 }

--- a/src/components/OpenFileDialog/VisTypeFilter.js
+++ b/src/components/OpenFileDialog/VisTypeFilter.js
@@ -5,9 +5,61 @@ import React from 'react'
 import {
     getDisplayNameByVisType,
     visTypeIcons,
+    VIS_TYPE_GROUP_ALL,
+    VIS_TYPE_GROUP_CHARTS,
+    VIS_TYPE_PIVOT_TABLE,
 } from '../../modules/visTypes.js'
 import { VisTypeIcon } from '../VisTypeIcon.js'
 import { CustomSelectOption } from './CustomSelectOption.js'
+
+export const formatTypeFilter = (filterVisTypes, visType) => {
+    const defaultFilterTypes = []
+
+    let defaultTypeFilter
+
+    if (Array.isArray(filterVisTypes)) {
+        defaultFilterTypes.push(
+            ...filterVisTypes
+                .filter(
+                    ({ type, disabled }) =>
+                        !(
+                            disabled ||
+                            [
+                                VIS_TYPE_GROUP_ALL,
+                                VIS_TYPE_GROUP_CHARTS,
+                            ].includes(type)
+                        )
+                )
+                .map(({ type }) => type)
+        )
+
+        if (defaultFilterTypes.length) {
+            defaultTypeFilter = `type:in:[${defaultFilterTypes.join(',')}]`
+        }
+    }
+
+    switch (visType) {
+        case VIS_TYPE_GROUP_ALL: {
+            return defaultTypeFilter
+        }
+        case VIS_TYPE_GROUP_CHARTS: {
+            if (defaultFilterTypes.length) {
+                return `type:in:[${defaultFilterTypes
+                    .filter((item) => item !== VIS_TYPE_PIVOT_TABLE)
+                    .join(',')}]`
+            } else {
+                return `type:!eq:${VIS_TYPE_PIVOT_TABLE}`
+            }
+        }
+        default: {
+            if (visType) {
+                return `type:eq:${visType}`
+            } else if (defaultTypeFilter) {
+                return defaultTypeFilter
+            }
+        }
+    }
+}
 
 export const VisTypeFilter = ({ visTypes, selected, onChange }) => (
     <SingleSelect

--- a/src/components/OpenFileDialog/__tests__/OpenFileDialog.spec.js
+++ b/src/components/OpenFileDialog/__tests__/OpenFileDialog.spec.js
@@ -95,9 +95,9 @@ describe('OpenFileDialog - formatFilters', () => {
                 [{ type: VIS_TYPE_LINE_LIST }, { type: VIS_TYPE_PIVOT_TABLE }]
             )
         ).toEqual([
+            `identifiable:token:test`,
             `user.id:eq:${currentUser.id}`,
             `type:in:[${VIS_TYPE_LINE_LIST},${VIS_TYPE_PIVOT_TABLE}]`,
-            `identifiable:token:test`,
         ])
     })
 })

--- a/src/components/OpenFileDialog/__tests__/OpenFileDialog.spec.js
+++ b/src/components/OpenFileDialog/__tests__/OpenFileDialog.spec.js
@@ -1,0 +1,103 @@
+import {
+    VIS_TYPE_COLUMN,
+    VIS_TYPE_GROUP_ALL,
+    VIS_TYPE_GROUP_CHARTS,
+    VIS_TYPE_LINE_LIST,
+    VIS_TYPE_PIVOT_TABLE,
+} from '../../../modules/visTypes.js'
+import {
+    CREATED_BY_ALL,
+    CREATED_BY_ALL_BUT_CURRENT_USER,
+    CREATED_BY_CURRENT_USER,
+} from '../CreatedByFilter.js'
+import { formatFilters } from '../OpenFileDialog.js'
+
+describe('OpenFileDialog - formatFilters', () => {
+    const currentUser = { id: 'test-user' }
+
+    const createdByTestCases = [
+        [CREATED_BY_ALL, []],
+        [CREATED_BY_CURRENT_USER, [`user.id:eq:${currentUser.id}`]],
+        [CREATED_BY_ALL_BUT_CURRENT_USER, [`user.id:!eq:${currentUser.id}`]],
+    ]
+
+    test.each(createdByTestCases)(
+        'formats the createdBy filter given %p',
+        (createdBy, expected) =>
+            expect(formatFilters(currentUser, { createdBy })).toEqual(expected)
+    )
+
+    test('formats the searchTerm filter', () => {
+        const testSearchTerm = 'test search term'
+
+        expect(
+            formatFilters(currentUser, { searchTerm: testSearchTerm })
+        ).toEqual([`identifiable:token:${testSearchTerm}`])
+    })
+
+    const typeTestCases = [
+        // no type filter when no visType nor filterVisTypes
+        [undefined, undefined, []],
+        // no type filter because VIS_TYPE_GROUP_ALL is selected
+        [undefined, VIS_TYPE_GROUP_ALL, []],
+        // only VIS_TYPE_PIVOT_TABLE ignored because no filterVisTypes is passed and VIS_TYPE_GROUP_CHARTS is selected
+        [
+            undefined,
+            VIS_TYPE_GROUP_CHARTS,
+            [`type:!eq:${VIS_TYPE_PIVOT_TABLE}`],
+        ],
+        // no filterVisTypes and VIS_TYPE_PIVOT_TABLE selected
+        [undefined, VIS_TYPE_PIVOT_TABLE, [`type:eq:${VIS_TYPE_PIVOT_TABLE}`]],
+        // group types are ignored
+        [
+            [VIS_TYPE_PIVOT_TABLE, VIS_TYPE_GROUP_ALL, VIS_TYPE_GROUP_CHARTS],
+            VIS_TYPE_GROUP_ALL,
+            [`type:in:[${VIS_TYPE_PIVOT_TABLE}]`],
+        ],
+        // VIS_TYPE_PIVOT_TABLE is ignored because VIS_TYPE_GROUP_CHARTS is selected
+        [
+            [VIS_TYPE_PIVOT_TABLE, VIS_TYPE_COLUMN, VIS_TYPE_GROUP_CHARTS],
+            VIS_TYPE_GROUP_CHARTS,
+            [`type:in:[${VIS_TYPE_COLUMN}]`],
+        ],
+        // when filterVisTypes is passed the default type filter only include those
+        [[VIS_TYPE_PIVOT_TABLE], '', [`type:in:[${VIS_TYPE_PIVOT_TABLE}]`]],
+        [
+            [VIS_TYPE_LINE_LIST, VIS_TYPE_PIVOT_TABLE],
+            '',
+            [`type:in:[${VIS_TYPE_LINE_LIST},${VIS_TYPE_PIVOT_TABLE}]`],
+        ],
+    ]
+
+    test.each(typeTestCases)(
+        'formats the type filter given %p and %p',
+        (types, visType, expected) =>
+            expect(
+                formatFilters(
+                    currentUser,
+                    { visType },
+                    types?.map((type) => ({
+                        type,
+                    }))
+                )
+            ).toEqual(expected)
+    )
+
+    test('combined filters', () => {
+        expect(
+            formatFilters(
+                currentUser,
+                {
+                    createdBy: CREATED_BY_CURRENT_USER,
+                    searchTerm: 'test',
+                    visType: VIS_TYPE_GROUP_ALL,
+                },
+                [{ type: VIS_TYPE_LINE_LIST }, { type: VIS_TYPE_PIVOT_TABLE }]
+            )
+        ).toEqual([
+            `user.id:eq:${currentUser.id}`,
+            `type:in:[${VIS_TYPE_LINE_LIST},${VIS_TYPE_PIVOT_TABLE}]`,
+            `identifiable:token:test`,
+        ])
+    })
+})


### PR DESCRIPTION
**Relates to https://github.com/dhis2/event-visualizer-app/pull/38**

---

### Key features

1. respect `filterVisTypes` prop when "All types" is selected

---

### Description

If a `filtersVisTypes` prop is passed, the `ALL` (All types) selection should use it to compute the correct filter for the request.
For example if `filtersVisTypes` only allows LL and PT, the ALL selection should only list LL and PT. ALL is relative to the `filterVisTypes` prop when present.

This is needed in the EVER app where only LL and PT are supported in the first version.
Without this fix, the list of visualizations in the OpenFileDialog shows all visualization including all the chart ones.

---

### TODO

- [x] Tests added
- [x] PRs for all affected apps created

---

### Screenshots

Open file dialog in the EVER app:
<img width="816" height="617" alt="Screenshot 2025-08-29 at 16 41 45" src="https://github.com/user-attachments/assets/65273b14-6b59-4565-9647-d804e61b60e6" />

Example request when the dialog is opened with the "All types" default selection:
<img width="594" height="194" alt="Screenshot 2025-08-29 at 16 41 54" src="https://github.com/user-attachments/assets/86371725-8462-4adc-b84e-6557efba283a" />

