### PR TITLE
fix: support flexible style for dimension items (DHIS2-19818)

### DIFF
--- a/src/__demo__/data/event/boolean.data.json
+++ b/src/__demo__/data/event/boolean.data.json
@@ -84,7 +84,13 @@
                 "name": "Yes"
             },
             "": {
-                "name": "No value"
+                "name": "No value",
+                "style": {
+                    "fontStyle": "italic",
+                    "color": "#6C7787",
+                    "fontFamily": "monospace",
+                    "letterSpacing": "-0.3px"
+                }
             }
         },
         "dimensions": {

--- a/src/__demo__/data/event/date.data.json
+++ b/src/__demo__/data/event/date.data.json
@@ -114,7 +114,13 @@
                 "name": "1993-12-02"
             },
             "": {
-                "name": "No value"
+                "name": "No value",
+                "style": {
+                    "fontStyle": "italic",
+                    "color": "#6C7787",
+                    "fontFamily": "monospace",
+                    "letterSpacing": "-0.3px"
+                }
             }
         },
         "dimensions": {

--- a/src/__demo__/data/event/datetime.data.json
+++ b/src/__demo__/data/event/datetime.data.json
@@ -117,7 +117,13 @@
                 "name": "E2E - Date & Time"
             },
             "": {
-                "name": "No value"
+                "name": "No value",
+                "style": {
+                    "fontStyle": "italic",
+                    "color": "#6C7787",
+                    "fontFamily": "monospace",
+                    "letterSpacing": "-0.3px"
+                }
             }
         },
         "dimensions": {

--- a/src/__demo__/data/event/email.data.json
+++ b/src/__demo__/data/event/email.data.json
@@ -108,7 +108,13 @@
                 "name": "test@pmail.com"
             },
             "": {
-                "name": "No value"
+                "name": "No value",
+                "style": {
+                    "fontStyle": "italic",
+                    "color": "#6C7787",
+                    "fontFamily": "monospace",
+                    "letterSpacing": "-0.3px"
+                }
             }
         },
         "dimensions": {

--- a/src/__demo__/data/event/integer.data.json
+++ b/src/__demo__/data/event/integer.data.json
@@ -102,7 +102,13 @@
                 "name": "10"
             },
             "": {
-                "name": "No value"
+                "name": "No value",
+                "style": {
+                    "fontStyle": "italic",
+                    "color": "#6C7787",
+                    "fontFamily": "monospace",
+                    "letterSpacing": "-0.3px"
+                }
             }
         },
         "dimensions": {

--- a/src/__demo__/data/event/legendset.data.json
+++ b/src/__demo__/data/event/legendset.data.json
@@ -97,7 +97,13 @@
                 "name": "Last 3 months"
             },
             "": {
-                "name": "No value"
+                "name": "No value",
+                "style": {
+                    "fontStyle": "italic",
+                    "color": "#6C7787",
+                    "fontFamily": "monospace",
+                    "letterSpacing": "-0.3px"
+                }
             }
         },
         "dimensions": {

--- a/src/__demo__/data/event/optionset.data.json
+++ b/src/__demo__/data/event/optionset.data.json
@@ -95,7 +95,13 @@
                 "name": "Last 3 months"
             },
             "": {
-                "name": "No value"
+                "name": "No value",
+                "style": {
+                    "fontStyle": "italic",
+                    "color": "#6C7787",
+                    "fontFamily": "monospace",
+                    "letterSpacing": "-0.3px"
+                }
             }
         },
         "dimensions": {

--- a/src/__demo__/data/event/time.data.json
+++ b/src/__demo__/data/event/time.data.json
@@ -117,7 +117,13 @@
                 "name": "Period"
             },
             "": {
-                "name": "No value"
+                "name": "No value",
+                "style": {
+                    "fontStyle": "italic",
+                    "color": "#6C7787",
+                    "fontFamily": "monospace",
+                    "letterSpacing": "-0.3px"
+                }
             }
         },
         "dimensions": {

--- a/src/__demo__/data/event/yesonly.data.json
+++ b/src/__demo__/data/event/yesonly.data.json
@@ -93,7 +93,13 @@
                 "name": "Yes"
             },
             "": {
-                "name": "No value"
+                "name": "No value",
+                "style": {
+                    "fontStyle": "italic",
+                    "color": "#6C7787",
+                    "fontFamily": "monospace",
+                    "letterSpacing": "-0.3px"
+                }
             }
         },
         "dimensions": {

--- a/src/components/PivotTable/PivotTableColumnHeaderCell.js
+++ b/src/components/PivotTable/PivotTableColumnHeaderCell.js
@@ -61,7 +61,6 @@ export const PivotTableColumnHeaderCell = ({
                             header.label !== 'Subtotal' // TODO: Actually look up the column type!
                                 ? 'column-header'
                                 : 'empty-header',
-                            header.isNaData && 'nadata-header',
                             {
                                 'fixed-header': engine.options.fixColumnHeaders,
                             },
@@ -78,6 +77,7 @@ export const PivotTableColumnHeaderCell = ({
                             <span
                                 className="column-header-label"
                                 data-test="visualization-column-header"
+                                style={{ ...header.style }}
                             >
                                 {header.label}
                             </span>

--- a/src/components/PivotTable/PivotTableRowHeaderCell.js
+++ b/src/components/PivotTable/PivotTableRowHeaderCell.js
@@ -32,7 +32,6 @@ export const PivotTableRowHeaderCell = ({
                         header.label !== 'Subtotal'
                             ? 'row-header'
                             : 'empty-header',
-                        header.isNaData && 'nadata-header',
                         header.includesHierarchy && 'row-header-hierarchy',
                         {
                             'fixed-header': engine.options.fixRowHeaders,
@@ -50,6 +49,7 @@ export const PivotTableRowHeaderCell = ({
                                       .slice(0, rowLevel)
                                       .reduce((width, acc) => (acc += width), 0)
                                 : 0,
+                        ...header.style,
                     }}
                     dataTest="visualization-row-header"
                 >

--- a/src/components/PivotTable/styles/PivotTable.style.js
+++ b/src/components/PivotTable/styles/PivotTable.style.js
@@ -140,9 +140,6 @@ export const cell = css`
     .empty-header {
         background-color: #cddaed;
     }
-    .nadata-header {
-        color: ${colors.grey600};
-    }
     .total-header {
         background-color: #bac6d8;
     }

--- a/src/modules/pivotTable/AdaptiveClippingController.js
+++ b/src/modules/pivotTable/AdaptiveClippingController.js
@@ -92,6 +92,7 @@ export class AdaptiveClippingController {
                                       axis.sizes[index]?.size || 0
                                   )
                                 : 0,
+                            ...header.style,
                         })
                         this.addSize(
                             { row: -headerStack.length + level, column: index },

--- a/src/modules/pivotTable/PivotTableEngine.js
+++ b/src/modules/pivotTable/PivotTableEngine.js
@@ -114,13 +114,8 @@ const buildDimensionLookup = (visualization, metadata, headers) => {
         meta: metadata.items[row.dimension],
         count: metadata.dimensions[row.dimension].length,
         itemIds: metadata.dimensions[row.dimension],
-        items: metadata.dimensions[row.dimension].map((item) =>
-            item === ''
-                ? {
-                      ...metadata.items[item],
-                      isNaData: true,
-                  }
-                : metadata.items[item]
+        items: metadata.dimensions[row.dimension].map(
+            (item) => metadata.items[item]
         ),
         isDxDimension: isDxDimension(metadata.items[row.dimension]),
         position: 'row',
@@ -131,13 +126,8 @@ const buildDimensionLookup = (visualization, metadata, headers) => {
         meta: metadata.items[column.dimension],
         count: metadata.dimensions[column.dimension].length,
         itemIds: metadata.dimensions[column.dimension],
-        items: metadata.dimensions[column.dimension].map((item) =>
-            item === ''
-                ? {
-                      ...metadata.items[item],
-                      isNaData: true,
-                  }
-                : metadata.items[item]
+        items: metadata.dimensions[column.dimension].map(
+            (item) => metadata.items[item]
         ),
         isDxDimension: isDxDimension(metadata.items[column.dimension]),
         position: 'column',

--- a/src/modules/pivotTable/getHeaderForDisplay.js
+++ b/src/modules/pivotTable/getHeaderForDisplay.js
@@ -38,12 +38,10 @@ export const getHeaderForDisplay = ({
         ? currentHeader.hierarchy.join(' / ')
         : currentHeader?.name
 
-    const isNaData = currentHeader.isNaData
-
     return {
         span,
         label,
         includesHierarchy,
-        isNaData,
+        ...(currentHeader.style ? { style: currentHeader.style } : {}),
     }
 }

--- a/src/modules/pivotTable/measureText.js
+++ b/src/modules/pivotTable/measureText.js
@@ -6,19 +6,22 @@ import {
 
 let canvas
 
-const getContext = (fontSize) => {
+const getContext = (
+    fontSize = 11,
+    fontFamily = 'Roboto, Arial, sans-serif'
+) => {
     if (!canvas) {
         canvas = document.createElement('canvas')
     }
 
     const ctx = canvas.getContext('2d')
-    ctx.font = `${fontSize}px Roboto, Arial, sans-serif`
+    ctx.font = `${fontSize}px ${fontFamily}`
 
     return ctx
 }
 
-const measureText = (text, fontSize = 11) => {
-    const ctx = getContext(fontSize)
+const measureText = (text, fontSize, fontFamily) => {
+    const ctx = getContext(fontSize, fontFamily)
 
     const textMetrics = ctx.measureText(text)
     return textMetrics.width
@@ -31,6 +34,7 @@ export const measureTextWithWrapping = (
         maxWidth = CLIPPED_CELL_MAX_SIZE,
         justifyBuffer = WRAPPED_TEXT_JUSTIFY_BUFFER,
         lineHeight = WRAPPED_TEXT_LINE_HEIGHT,
+        fontFamily,
     }
 ) => {
     if (!text) {
@@ -48,7 +52,7 @@ export const measureTextWithWrapping = (
         const words = paragraphs.shift().split(/\s+/)
         while (words.length) {
             const nextWord = (currentLineWidth === 0 ? '' : ' ') + words.shift()
-            const nextWordWidth = measureText(nextWord, fontSize)
+            const nextWordWidth = measureText(nextWord, fontSize, fontFamily)
             if (maxWidth && currentLineWidth + nextWordWidth > maxWidth) {
                 if (currentLineWidth <= maxWidth - justifyBuffer) {
                     // Wrapping this word would cause an unnaturally short line

--- a/src/modules/response/response.js
+++ b/src/modules/response/response.js
@@ -20,9 +20,18 @@ import { applyBooleanHandler } from './boolean.js'
 import { applyDefaultHandler } from './default.js'
 import { applyOptionSetHandler } from './optionSet.js'
 
-export const NA_VALUE = ''
-export const NA_VALUE_DISPLAY_NAME = i18n.t('No value')
 export const PREFIX_SEPARATOR = '_'
+export const NA_VALUE = ''
+export const NA_VALUE_ITEM = {
+    name: i18n.t('No value'),
+    style: {
+        fontStyle: 'italic',
+        color: '#6C7787',
+        fontFamily: 'monospace',
+        letterSpacing: '-0.3px',
+    },
+}
+
 export const UNSUPPORTED_VALUE_TYPES = [
     VALUE_TYPE_COORDINATE,
     VALUE_TYPE_GEOJSON,
@@ -117,9 +126,7 @@ export const transformResponse = (response, { hideNaData = false } = {}) => {
                     NA_VALUE,
                 ]
 
-                transformedResponse.metaData.items[NA_VALUE] = {
-                    name: i18n.t('No value'),
-                }
+                transformedResponse.metaData.items[NA_VALUE] = NA_VALUE_ITEM
             }
         })
     }


### PR DESCRIPTION
Based on https://github.com/dhis2/analytics/pull/1788

Adds support for flexible style for dimension items without breaking width calculation / table clipping.

Removes awareness of "N/A data" in the pivot table engine.