### PR TITLE
fix: hide indicator type factor label when factor is 1 in single value charts (DHIS2-20293)

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/customSVGOptions/singleValue/getSingleValueSubtext.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/customSVGOptions/singleValue/getSingleValueSubtext.js
@@ -1,11 +1,15 @@
 import { INDICATOR_FACTOR_100 } from './getSingleValueFormattedValue.js'
 
+const INDICATOR_FACTOR_1 = 1
+
 export function getSingleValueSubtext(metaData) {
     const indicatorType =
         metaData.items[metaData.dimensions.dx[0]].indicatorType
 
     return indicatorType?.displayName &&
-        indicatorType?.factor !== INDICATOR_FACTOR_100
+        ![INDICATOR_FACTOR_1, INDICATOR_FACTOR_100].includes(
+            indicatorType?.factor
+        )
         ? indicatorType?.displayName
         : undefined
 }


### PR DESCRIPTION
Implements [DHIS2-20293](https://dhis2.atlassian.net/browse/DHIS2-20293)

Before
<img width="833" height="624" alt="Screenshot from 2025-10-09 08-31-19" src="https://github.com/user-attachments/assets/9998d02d-52e0-4ea5-91b1-7f4143f03e56" />

After
<img width="833" height="624" alt="Screenshot from 2025-10-09 08-32-00" src="https://github.com/user-attachments/assets/eae03fb3-3dfd-481d-8e76-ab1dc3df47d7" />


[DHIS2-20293]: https://dhis2.atlassian.net/browse/DHIS2-20293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ