### PR TITLE
fix: turn off series animations in dashboards (DHIS2-20299)

### DIFF
--- a/src/visualizations/config/adapters/dhis_highcharts/series/index.js
+++ b/src/visualizations/config/adapters/dhis_highcharts/series/index.js
@@ -255,12 +255,14 @@ export default function ({
 
     series?.forEach((seriesObj) => {
         // animation
-        seriesObj.animation = {
-            duration: getAnimation(
-                extraOptions.animation,
-                DEFAULT_ANIMATION_DURATION
-            ),
-        }
+        seriesObj.animation = extraOptions.dashboard
+            ? false
+            : {
+                  duration: getAnimation(
+                      extraOptions.animation,
+                      DEFAULT_ANIMATION_DURATION
+                  ),
+              }
     })
 
     return series


### PR DESCRIPTION
Implements [DHIS2-20299](https://dhis2.atlassian.net/browse/DHIS2-20299)

Tested by linking Analytics -> DV -> DV plugin -> Dashboard (3001):

https://github.com/user-attachments/assets/fd096def-11c4-4130-b574-7168c8b8fe82

Charts still animate in Data Visualizer (3000):

https://github.com/user-attachments/assets/9cbd7659-335f-40a3-8d63-33881ae38377

[DHIS2-20299]: https://dhis2.atlassian.net/browse/DHIS2-20299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ