### PR TITLE
fix: total cell crash due to empty currentHeader

### DIFF
--- a/src/modules/pivotTable/getHeaderForDisplay.js
+++ b/src/modules/pivotTable/getHeaderForDisplay.js
@@ -42,6 +42,6 @@ export const getHeaderForDisplay = ({
         span,
         label,
         includesHierarchy,
-        ...(currentHeader.style ? { style: currentHeader.style } : {}),
+        ...(currentHeader?.style ? { style: currentHeader.style } : {}),
     }
 }


### PR DESCRIPTION
Fixes an issue where `currentHeader` was mistakenly always assumed to be an object. This caused a crash when rendering "Total" cells (when column/row totals are enabled).