### PR TITLE
fix: pass a valid function to the cancel button onClick

### DIFF
--- a/src/components/Interpretations/common/Interpretation/InterpretationUpdateForm.js
+++ b/src/components/Interpretations/common/Interpretation/InterpretationUpdateForm.js
@@ -59,7 +59,12 @@ export const InterpretationUpdateForm = ({
                     >
                         {i18n.t('Update')}
                     </Button>
-                    <Button disabled={loading} secondary small onClick={close}>
+                    <Button
+                        disabled={loading}
+                        secondary
+                        small
+                        onClick={onComplete}
+                    >
                         {i18n.t('Cancel')}
                     </Button>
                 </MessageButtonStrip>


### PR DESCRIPTION
No ticket available: quick fix for a regression introduced in 29.0.0

**Relates to https://github.com/dhis2/data-visualizer-app/pull/XXX**
- https://github.com/dhis2/data-visualizer-app/pull/3438
- https://github.com/dhis2/line-listing-app/pull/716
- https://github.com/dhis2/maps-app/pull/3568
- https://github.com/dhis2/dashboard-app/pull/3312

---

### Key features

1. Clicking cancel in the update-interpreation-form is now working again

---

### Description

Unfortunately we missed this in the KFMT, and the linter didn't pick up on this either, because `window.close` is a global function, so ESLint didn't scream at us for passing a non-existing function to a prop.

---

