### PR TITLE
fix: interpretations panel not showing for pivot tables

### DIFF
--- a/src/components/PivotTable/PivotTable.js
+++ b/src/components/PivotTable/PivotTable.js
@@ -18,7 +18,6 @@ const PivotTable = ({
 }) => {
     const containerRef = useRef(undefined)
     const { width, height } = useParentSize(containerRef, renderCounter)
-
     const engine = useMemo(
         () => new PivotTableEngine(visualization, data, legendSets),
         [visualization, data, legendSets]

--- a/src/components/PivotTable/PivotTable.js
+++ b/src/components/PivotTable/PivotTable.js
@@ -18,6 +18,7 @@ const PivotTable = ({
 }) => {
     const containerRef = useRef(undefined)
     const { width, height } = useParentSize(containerRef, renderCounter)
+
     const engine = useMemo(
         () => new PivotTableEngine(visualization, data, legendSets),
         [visualization, data, legendSets]

--- a/src/modules/pivotTable/useParentSize.js
+++ b/src/modules/pivotTable/useParentSize.js
@@ -4,10 +4,7 @@ import ResizeObserver from 'resize-observer-polyfill'
 const initialSize = { width: 0, height: 0 }
 
 export const useParentSize = (elementRef, renderCounter) => {
-    const [size, setSize] = useState({
-        width: initialSize.width || 0,
-        height: initialSize.height || 0,
-    })
+    const [size, setSize] = useState(initialSize)
 
     useEffect(() => {
         const el = elementRef.current && elementRef.current.parentElement

--- a/src/modules/pivotTable/useParentSize.js
+++ b/src/modules/pivotTable/useParentSize.js
@@ -1,13 +1,9 @@
 import { useState, useEffect } from 'react'
 import ResizeObserver from 'resize-observer-polyfill'
 
-const initialState = { width: 0, height: 0 }
+const initialSize = { width: 0, height: 0 }
 
-export const useParentSize = (
-    elementRef,
-    renderCounter,
-    initialSize = initialState
-) => {
+export const useParentSize = (elementRef, renderCounter) => {
     const [size, setSize] = useState({
         width: initialSize.width || 0,
         height: initialSize.height || 0,
@@ -20,16 +16,20 @@ export const useParentSize = (
         }
 
         const onResize = () => {
-            setSize({
-                width: el.clientWidth,
-                height: el.clientHeight,
-            })
+            setTimeout(
+                () =>
+                    setSize({
+                        width: el.clientWidth,
+                        height: el.clientHeight,
+                    }),
+                0
+            )
         }
 
         onResize(el)
 
         if (renderCounter) {
-            setSize(initialState)
+            setSize(initialSize)
         }
 
         const observer = new ResizeObserver(onResize)


### PR DESCRIPTION
Implements [DHIS2-20325](https://dhis2.atlassian.net/browse/DHIS2-20325)

**Relates to https://github.com/dhis2/data-visualizer-app/pull/3445

---

### Key features

Set the width of the pivot table to the available width. The available width is relevant when the right sidebar of the Data Visualizer app is being opened or closed. The ResizeObserver wasn't catching this sort of resizing.

[DHIS2-20325]: https://dhis2.atlassian.net/browse/DHIS2-20325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ