### PR TITLE
fix: address 2 comment edit issues and a display-property issue

### DIFF
--- a/src/components/Interpretations/InterpretationModal/Comment.js
+++ b/src/components/Interpretations/InterpretationModal/Comment.js
@@ -24,7 +24,7 @@ const Comment = ({ comment, canComment }) => {
             onComplete={onUpdateComplete}
             onCancel={onUpdateCancel}
             id={comment.id}
-            text={comment.text}
+            text={commentText}
         />
     ) : (
         <Message

--- a/src/components/Interpretations/InterpretationModal/Comment.js
+++ b/src/components/Interpretations/InterpretationModal/Comment.js
@@ -14,11 +14,15 @@ const Comment = ({ comment, canComment }) => {
         setCommentText(newText)
         setIsUpdateMode(false)
     }, [])
+    const onUpdateCancel = useCallback(() => {
+        setIsUpdateMode(false)
+    }, [])
     const commentAccess = useCommentAccess(comment, canComment)
 
     return isUpdateMode ? (
         <CommentUpdateForm
             onComplete={onUpdateComplete}
+            onCancel={onUpdateCancel}
             id={comment.id}
             text={comment.text}
         />

--- a/src/components/Interpretations/InterpretationModal/CommentUpdateForm.js
+++ b/src/components/Interpretations/InterpretationModal/CommentUpdateForm.js
@@ -9,7 +9,7 @@ import {
     useUpdateCommentForActiveInterpretation,
 } from '../InterpretationsProvider/hooks.js'
 
-export const CommentUpdateForm = ({ id, text, onComplete }) => {
+export const CommentUpdateForm = ({ id, text, onCancel, onComplete }) => {
     const currentUser = useInterpretationsCurrentUser()
     const [commentText, setCommentText] = useState(text || '')
     const [update, { loading, error }] =
@@ -38,7 +38,7 @@ export const CommentUpdateForm = ({ id, text, onComplete }) => {
                         disabled={loading}
                         secondary
                         small
-                        onClick={onComplete}
+                        onClick={onCancel}
                     >
                         {i18n.t('Cancel')}
                     </Button>
@@ -56,6 +56,7 @@ export const CommentUpdateForm = ({ id, text, onComplete }) => {
 }
 CommentUpdateForm.propTypes = {
     id: PropTypes.string.isRequired,
+    onCancel: PropTypes.func.isRequired,
     onComplete: PropTypes.func.isRequired,
     text: PropTypes.string,
 }

--- a/src/components/Interpretations/InterpretationModal/InterpretationModal.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationModal.js
@@ -74,6 +74,17 @@ const InterpretationModal = ({
         }
     }, [interpretation?.created])
 
+    const displayProperty = useMemo(
+        () =>
+            // DV and EVER apps
+            currentUser.settings?.displayProperty ??
+            // LL app
+            currentUser.settings?.keyAnalysisDisplayProperty ??
+            // Maps app
+            currentUser.keyAnalysisDisplayProperty,
+        [currentUser]
+    )
+
     return (
         <>
             {loadingInProgress && (
@@ -126,10 +137,7 @@ const InterpretationModal = ({
                                         onResponsesReceived={
                                             onResponsesReceived
                                         }
-                                        displayProperty={
-                                            currentUser.settings
-                                                ?.keyAnalysisDisplayProperty
-                                        }
+                                        displayProperty={displayProperty}
                                         isInModal={true}
                                     />
                                 </div>


### PR DESCRIPTION
Implements a fixes for 2 regressions introduced when working on [DHIS2-19822](https://dhis2.atlassian.net/browse/DHIS2-19822), plus a pre-existing problem in reg. the display name.

**Relates to various App PRs:**
- Maps:
- LL:
- DV:
- Dashboards: 

---

### Bug fixes

#### Update comment cancel causes a crash

For cancelling a comment edit I has simply attached the `onUpdateComplete` handler to the cancel button `onClick`. The result was that `text` was not a string, but an object (the UI event handler payload).

The cleanest fix was to create a dedicated `onCancel` handler which doesn't set the `commentText` at all, see https://github.com/dhis2/analytics/pull/1797/commits/8f51e67c5f88615a7263e97aebda7fd739b8d4ba

### Display property not always in the same field under `currentUser`

In the Interpretations modal, the visualisation is rendered and it receives a `displayProperty`. We found that different apps store this property under different fields, but we were only checking a single field.

This fix is checking a few known fields for the correct value, see https://github.com/dhis2/analytics/pull/1797/commits/56d3981eeeda3d4a277abc1c99ef3db87f414f4c

### When re-editing a comment, the original instead of updated comment text is displayed in the rich text editor

The initial state for the `commentText` comes from the original comment, but that state gets updated after a comment is edited. However, we were passing the original state to the rich-text-editor. This bug is fixed by passing the `commentText` instead of `comment.text` to the rich-text-editor, see https://github.com/dhis2/analytics/pull/1797/commits/10d24b85ee7b969ccc941703cdf3d08adeec56a5

---

[DHIS2-19822]: https://dhis2.atlassian.net/browse/DHIS2-19822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ