### PR TITLE
fix: trigger publish

### DIFF
--- a/.github/workflows/node-publish.yml
+++ b/.github/workflows/node-publish.yml
@@ -44,6 +44,6 @@ jobs:
               run: yarn test
 
             - name: Publish to NPM
-              run: npx @dhis2/cli-utils release --publish npm
+              run: npx @dhis2/cli-utils@5.1.0 release --publish npm
         env:
             CI: true


### PR DESCRIPTION

A change to @dhis2/cli-utils used in the gh publish action is causing the publish step to fail. Downgrading the version until fixed.
---

### TODO

- [ ] Tests added N/A
- [ ] PRs for all affected apps created N/A
- [ ] Storybook added N/A

---

---

### Screenshots

_supporting text_
