### PR TITLE
chore: remove version from CLI utils release command

### DIFF
--- a/.github/workflows/node-publish.yml
+++ b/.github/workflows/node-publish.yml
@@ -44,6 +44,6 @@ jobs:
               run: yarn test
 
             - name: Publish to NPM
-              run: npx @dhis2/cli-utils@5.1.0 release --publish npm
+              run: npx @dhis2/cli-utils release --publish npm
         env:
             CI: true


### PR DESCRIPTION
The issue preventing publishing was fixed in this PR: https://github.com/dhis2/cli/pull/632 so can revert back to using latest master