### PR TITLE
fix(about-ao): spacing, padding, visual design adjustments

### DIFF
--- a/src/__demo__/AboutAOUnit.stories.js
+++ b/src/__demo__/AboutAOUnit.stories.js
@@ -1,0 +1,145 @@
+import { CustomDataProvider } from '@dhis2/app-runtime'
+import React from 'react'
+import AboutAOUnit from '../components/AboutAOUnit/AboutAOUnit.js'
+
+const verboseData = {
+    visualizations: {
+        id: 'abc123verbose',
+        displayDescription:
+            'This is a comprehensive **visualization** showing district-level aggregate data across all 47 counties for the Expanded Programme on Immunization (EPI) including BCG, OPV, Pentavalent, and Measles-Rubella coverage rates disaggregated by age, sex, and facility ownership for the fiscal year 2024/2025.',
+        created: '2023-01-15T08:30:00.000',
+        createdBy: {
+            displayName:
+                'Dr. Alexandria Konstantinopolous-Whittington III, MD, PhD',
+        },
+        lastUpdated: '2024-11-02T14:22:00.000',
+        subscribed: true,
+        sharing: {
+            public: 'r',
+            users: {
+                u1: {
+                    displayName:
+                        'Maria-Fernanda de los Ángeles Gutiérrez-Montoya',
+                    access: 'rw',
+                },
+                u2: {
+                    displayName: 'Jean-Pierre Barthélémy Christophersen',
+                    access: 'r',
+                },
+            },
+            userGroups: {
+                g1: {
+                    displayName:
+                        'National Immunization Programme Monitoring & Evaluation Team',
+                    access: 'rw',
+                },
+                g2: {
+                    displayName:
+                        'District Health Information System Administrators Group',
+                    access: 'r',
+                },
+            },
+        },
+    },
+    'dataStatistics/favorites': {
+        views: 14873,
+    },
+}
+
+const shortData = {
+    visualizations: {
+        id: 'xyz789short',
+        displayDescription: 'ANC coverage Q3',
+        created: '2025-12-01T10:00:00.000',
+        createdBy: { displayName: 'Li Wei' },
+        lastUpdated: '2026-04-10T09:00:00.000',
+        subscribed: false,
+        sharing: {
+            public: 'rw',
+            users: {},
+            userGroups: {
+                g1: { displayName: 'HMIS', access: 'r' },
+            },
+        },
+    },
+    'dataStatistics/favorites': {
+        views: 3,
+    },
+}
+
+const missingFieldsData = {
+    visualizations: {
+        id: 'missing456',
+        displayDescription: null,
+        created: '2026-03-20T12:00:00.000',
+        createdBy: null,
+        lastUpdated: '2026-04-13T06:45:00.000',
+        subscribed: false,
+        sharing: {
+            public: '',
+            users: {},
+            userGroups: {},
+        },
+    },
+    'dataStatistics/favorites': {
+        views: 0,
+    },
+}
+
+export default {
+    title: 'AboutAOUnit',
+}
+
+export const VerboseData = () => (
+    <CustomDataProvider data={verboseData}>
+        <div
+            style={{
+                width: 372,
+                padding: '16px',
+                backgroundColor: 'lightgray',
+            }}
+        >
+            <AboutAOUnit type="visualization" id="abc123verbose" />
+        </div>
+    </CustomDataProvider>
+)
+
+VerboseData.story = {
+    name: 'Verbose data with long labels',
+}
+
+export const ShortLabels = () => (
+    <CustomDataProvider data={shortData}>
+        <div
+            style={{
+                width: 372,
+                padding: '16px',
+                backgroundColor: 'lightgray',
+            }}
+        >
+            <AboutAOUnit type="visualization" id="xyz789short" />
+        </div>
+    </CustomDataProvider>
+)
+
+ShortLabels.story = {
+    name: 'Short labels',
+}
+
+export const MissingFields = () => (
+    <CustomDataProvider data={missingFieldsData}>
+        <div
+            style={{
+                width: 372,
+                padding: '16px',
+                backgroundColor: 'lightgray',
+            }}
+        >
+            <AboutAOUnit type="visualization" id="missing456" />
+        </div>
+    </CustomDataProvider>
+)
+
+MissingFields.story = {
+    name: 'Missing fields (no description, no author, no sharing)',
+}

--- a/src/components/AboutAOUnit/AboutAOUnit.js
+++ b/src/components/AboutAOUnit/AboutAOUnit.js
@@ -11,8 +11,8 @@ import {
     IconChevronUp24,
     IconClock16,
     IconShare16,
-    IconSubscribe24,
-    IconSubscribeOff24,
+    IconSubscribe16,
+    IconSubscribeOff16,
     IconUser16,
     IconView16,
     colors,
@@ -192,8 +192,7 @@ const AboutAOUnit = forwardRef(({ type, id, renderId }, ref) => {
                     {data && (
                         <div className="content">
                             <div
-                                className={cx('detailLine', {
-                                    description: true,
+                                className={cx('description', {
                                     noDescription: !data.ao.displayDescription,
                                 })}
                             >
@@ -207,11 +206,15 @@ const AboutAOUnit = forwardRef(({ type, id, renderId }, ref) => {
                             </div>
                             <div>
                                 <p className="detailLine">
-                                    <IconShare16 color={colors.grey700} />
+                                    <span className="icon">
+                                        <IconShare16 color={colors.grey700} />
+                                    </span>
                                     {getSharingSummary(data.ao)}
                                 </p>
                                 <p className="detailLine">
-                                    <IconClock16 color={colors.grey700} />
+                                    <span className="icon">
+                                        <IconClock16 color={colors.grey700} />
+                                    </span>
                                     {i18n.t('Last updated {{time}}', {
                                         time: moment(
                                             fromServerDate(data.ao.lastUpdated)
@@ -219,7 +222,9 @@ const AboutAOUnit = forwardRef(({ type, id, renderId }, ref) => {
                                     })}
                                 </p>
                                 <p className="detailLine">
-                                    <IconUser16 color={colors.grey700} />
+                                    <span className="icon">
+                                        <IconUser16 color={colors.grey700} />
+                                    </span>
                                     {data.ao.createdBy?.displayName
                                         ? i18n.t(
                                               'Created {{time}} by {{author}}',
@@ -242,7 +247,9 @@ const AboutAOUnit = forwardRef(({ type, id, renderId }, ref) => {
                                           })}
                                 </p>
                                 <p className="detailLine">
-                                    <IconView16 color={colors.grey700} />
+                                    <span className="icon">
+                                        <IconView16 color={colors.grey700} />
+                                    </span>
                                     {i18n.t('Viewed {{count}} times', {
                                         count: data.dataStatistics.views,
                                         defaultValue: 'Viewed 1 time',
@@ -264,7 +271,7 @@ const AboutAOUnit = forwardRef(({ type, id, renderId }, ref) => {
                                         </p>
                                         <Button
                                             icon={
-                                                <IconSubscribeOff24
+                                                <IconSubscribeOff16
                                                     color={colors.grey700}
                                                 />
                                             }
@@ -285,7 +292,7 @@ const AboutAOUnit = forwardRef(({ type, id, renderId }, ref) => {
                                         </p>
                                         <Button
                                             icon={
-                                                <IconSubscribe24
+                                                <IconSubscribe16
                                                     color={colors.grey700}
                                                 />
                                             }

--- a/src/components/AboutAOUnit/styles/AboutAOUnit.style.js
+++ b/src/components/AboutAOUnit/styles/AboutAOUnit.style.js
@@ -10,17 +10,19 @@ export default css`
     }
 
     .expanded {
-        padding-bottom: ${spacers.dp32};
+        padding-bottom: ${spacers.dp16};
     }
 
     .loader {
         display: flex;
         justify-content: center;
+        padding-top: ${spacers.dp16};
     }
 
     .header {
         display: flex;
         justify-content: space-between;
+        align-items: center;
         cursor: pointer;
     }
 
@@ -33,27 +35,36 @@ export default css`
 
     .content {
         font-size: 14px;
-        line-height: 18px;
+        line-height: 20px;
         color: ${colors.grey900};
     }
 
     .detailLine {
         display: flex;
+        align-items: flex-start;
         margin: 0;
         padding: ${spacers.dp12} 0 0 0;
         gap: ${spacers.dp8};
     }
 
-    .detailLine svg {
+    .detailLine .icon {
         flex-shrink: 0;
+        display: flex;
+        align-items: center;
+        height: 20px;
     }
 
     .description {
+        padding: 0;
+    }
+
+    .description :global(p) {
+        margin: ${spacers.dp8} 0 ${spacers.dp4} 0;
         white-space: pre-line;
     }
 
     .noDescription {
-        color: ${colors.grey600};
+        color: ${colors.grey500};
     }
 
     .subsection {
@@ -61,15 +72,15 @@ export default css`
     }
 
     .subsectionTitle {
-        color: ${colors.grey700};
+        color: ${colors.grey800};
         font-weight: 500;
+        margin: 0;
     }
 
     .subscriptionLabel {
-        margin: ${spacers.dp12} 0 ${spacers.dp8} 0;
-    }
-
-    .subsection button {
-        margin-top: ${spacers.dp8};
+        font-size: 13px;
+        line-height: 18px;
+        margin: ${spacers.dp4} 0 ${spacers.dp8} 0;
+        color: ${colors.grey600};
     }
 `


### PR DESCRIPTION
This PR adjusts the visual design of the `About AO` component, used in Data Visualizer and the incoming new EVER app. Storybook stories with mock data included for testing.

Screenshots:

<img width="1764" height="3656" alt="image" src="https://github.com/user-attachments/assets/78e6d353-eabd-4666-9381-6b928424820f" />
