### PR TITLE
fix: prevent apostrophes in OU names from being escaped

### DIFF
--- a/src/components/OrgUnitDimension/OrgUnitDimension.js
+++ b/src/components/OrgUnitDimension/OrgUnitDimension.js
@@ -175,6 +175,7 @@ const OrgUnitDimension = ({
                 {
                     keySeparator: '>',
                     nsSeparator: '|',
+                    interpolation: { escapeValue: false },
                     commaSeparatedListOfOrganisationUnits: formatList(parts),
                 }
             )

--- a/src/modules/getOuLevelAndGroupText.js
+++ b/src/modules/getOuLevelAndGroupText.js
@@ -49,6 +49,7 @@ const getLevelAndGroupText = (items, metaData, isLevel) => {
             ouIdHelper.removePrefix(lastItem.id)
         )
         allDynamicOuNames = i18n.t('{{dynamicOuNames}} and {{lastOuName}}', {
+            interpolation: { escapeValue: false },
             dynamicOuNames,
             lastOuName,
         })
@@ -69,10 +70,12 @@ const getLevelAndGroupText = (items, metaData, isLevel) => {
     if (!staticOuNames) {
         if (isLevel) {
             ouLevelAndGroupText = i18n.t('{{allDynamicOuNames}} levels', {
+                interpolation: { escapeValue: false },
                 allDynamicOuNames,
             })
         } else {
             ouLevelAndGroupText = i18n.t('{{allDynamicOuNames}} groups', {
+                interpolation: { escapeValue: false },
                 allDynamicOuNames,
             })
         }
@@ -81,6 +84,7 @@ const getLevelAndGroupText = (items, metaData, isLevel) => {
             ouLevelAndGroupText = i18n.t(
                 '{{allDynamicOuNames}} levels in {{staticOuNames}}',
                 {
+                    interpolation: { escapeValue: false },
                     allDynamicOuNames,
                     staticOuNames,
                 }
@@ -89,6 +93,7 @@ const getLevelAndGroupText = (items, metaData, isLevel) => {
             ouLevelAndGroupText = i18n.t(
                 '{{allDynamicOuNames}} groups in {{staticOuNames}}',
                 {
+                    interpolation: { escapeValue: false },
                     allDynamicOuNames,
                     staticOuNames,
                 }


### PR DESCRIPTION


### Description

prevent apostrophes in OU names from being escaped (noticed in French)

Implements [DHIS2-17302](https://dhis2.atlassian.net/browse/DHIS2-17302)

---

### TODO

- [ N/A] Tests added
- [ N/A] PRs for all affected apps created <- N/A - small fix so will just be picked up on a later update
- [ N/A] Storybook added


---

### Screenshots

Before
<img width="641" height="478" alt="image" src="https://github.com/user-attachments/assets/89bd3792-e31d-4973-9ea4-5ca7a70ec428" />

After
<img width="433" height="116" alt="image" src="https://github.com/user-attachments/assets/e02b45b8-73a2-453e-847c-159efb5b7f0d" />


[DHIS2-17302]: https://dhis2.atlassian.net/browse/DHIS2-17302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ