### PR TITLE
fix: add support for enrollments/aggregate endpoint

### DIFF
--- a/src/api/analytics/AnalyticsEnrollments.js
+++ b/src/api/analytics/AnalyticsEnrollments.js
@@ -14,6 +14,28 @@ class AnalyticsEnrollments extends AnalyticsBase {
     /**
      * @param {!AnalyticsRequest} req Request object
      *
+     * @returns {Promise} Promise that resolves with the analytics aggregate data from the api.
+     *
+     * @example
+     * const req = new analytics.request()
+     *  .withProgram('eBAyeGv0exc')
+     *  .addDataDimension(['Uvn6LCg7dVU','OdiHJayrsKo'])
+     *  .addPeriodDimension('LAST_4_QUARTERS')
+     *  .addOrgUnitDimension(['lc3eMKXaEfw','PMa2VCrupOd'])
+     *  .addOrgUnitFilter('O6uvpzGd5pu')
+     *  .withStartDate('2017-10-01')
+     *  .withEndDate('2017-10-31');
+     *
+     * analytics.enrollments.getAggregate(req)
+     *  .then(console.log);
+     */
+    getAggregate(req) {
+        return this.fetch(req.withPath('enrollments/aggregate'))
+    }
+
+    /**
+     * @param {!AnalyticsRequest} req Request object
+     *
      * @returns {Promise} Promise that resolves with the analytics query data from the api.
      *
      * @example

--- a/src/api/analytics/__tests__/AnalyticsEnrollments.spec.js
+++ b/src/api/analytics/__tests__/AnalyticsEnrollments.spec.js
@@ -27,6 +27,29 @@ describe('analytics.enrollments', () => {
         expect(enrollments.dataEngine).toBe(dataEngineMockObject)
     })
 
+    describe('.getAggregate()', () => {
+        beforeEach(() => {
+            enrollments = new AnalyticsEnrollments(new DataEngineMock())
+
+            request = new AnalyticsRequest().withLimit(10)
+
+            fixture = fixtures.get('/api/analytics/aggregate')
+
+            dataEngineMock.query.mockReturnValue(
+                Promise.resolve({ data: fixture })
+            )
+        })
+
+        it('should be a function', () => {
+            expect(enrollments.getAggregate).toBeInstanceOf(Function)
+        })
+
+        it('should resolve a promise with data', () =>
+            enrollments.getAggregate(request).then((data) => {
+                expect(data).toEqual(fixture)
+            }))
+    })
+
     describe('.getQuery()', () => {
         beforeEach(() => {
             enrollments = new AnalyticsEnrollments(new DataEngineMock())


### PR DESCRIPTION

### Key features

1. add support for enrollments/aggregate endpoint

---

### Description

In the new EVER app it's possible to create event and enrollment pivot tables.
We didn't have support for the `enrollments/aggregate` in the analytics library like we did for `events/aggregate`.

---

### Screenshots

<img width="495" height="229" alt="Screenshot 2026-05-12 at 11 39 47" src="https://github.com/user-attachments/assets/3a1c703d-bc2b-41e7-a45d-13fbbe05af18" />


