### PR TITLE
fix(OpenFileDialog): use the same generic texts for both DV and EVER/LL

### DIFF
--- a/src/components/OpenFileDialog/utils.js
+++ b/src/components/OpenFileDialog/utils.js
@@ -61,22 +61,10 @@ const texts = {
         ),
         newButtonLabel: i18n.t('New map'),
     },
-    [AO_TYPE_EVENT_VISUALIZATION]: {
-        modalTitle: i18n.t('Open a line list'),
-        loadingText: i18n.t('Loading line lists'),
-        errorTitle: i18n.t("Couldn't load line lists"),
-        errorText: i18n.t(
-            'There was a problem loading line lists. Try again or contact your system administrator.'
-        ),
-        noDataText: i18n.t(
-            'No line lists found. Click New line list to get started.'
-        ),
-        noFilteredDataText: i18n.t(
-            "No line lists found. Try adjusting your search or filter options to find what you're looking for."
-        ),
-        newButtonLabel: i18n.t('New line list'),
-    },
 }
+
+// Event visualizations use the same texts as visualizations
+texts[AO_TYPE_EVENT_VISUALIZATION] = texts[AO_TYPE_VISUALIZATION]
 
 export const getTranslatedString = (type, key) =>
     (texts[type] || texts[NO_TYPE])[key]


### PR DESCRIPTION
Implements [DHIS2-21594](https://dhis2.atlassian.net/browse/DHIS2-21594)

---

### Key features

1. replace "line list" with a generic "visualization" in the texts used in the open file dialog

---

### Description

Now that the EVER app handles multiple visualization types (LL and PT), the texts used in the open file dialog need to be updated as they mention line lists.

---

### Screenshots

Before:
<img width="823" height="509" alt="Screenshot 2026-06-11 at 15 57 00" src="https://github.com/user-attachments/assets/fd096b46-c9ba-40c2-9cd4-10608099556c" />


After:
<img width="819" height="511" alt="Screenshot 2026-06-11 at 15 56 26" src="https://github.com/user-attachments/assets/6e2f50ba-f7e6-46d4-a475-6bdafbcf34ea" />



[DHIS2-21594]: https://dhis2.atlassian.net/browse/DHIS2-21594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ