### PR TITLE
fix: preserve period ids for program-level time dimensions in event PTs

### DIFF
--- a/src/components/PivotTable/PivotTableValueCell.js
+++ b/src/components/PivotTable/PivotTableValueCell.js
@@ -24,6 +24,13 @@ export const PivotTableValueCell = ({
         column,
     })
 
+    // engine.get returns undefined when the requested cell falls outside the
+    // current row/column maps (e.g. a degenerate matrix with no rows or
+    // columns). Render an empty cell rather than dereferencing undefined.
+    if (!cellContent) {
+        return <PivotTableEmptyCell ref={cellRef} classes={['value']} />
+    }
+
     const isClickable =
         onToggleContextualMenu &&
         cellContent.cellType === CELL_TYPE_VALUE &&
@@ -37,7 +44,7 @@ export const PivotTableValueCell = ({
         onToggleContextualMenu(cellRef.current, { ouId: cellContent.ouId })
     }
 
-    if (!cellContent || cellContent.empty) {
+    if (cellContent.empty) {
         return (
             <PivotTableEmptyCell
                 onClick={isClickable ? onClick : undefined}

--- a/src/modules/pivotTable/__tests__/clipPartitionedAxis.spec.js
+++ b/src/modules/pivotTable/__tests__/clipPartitionedAxis.spec.js
@@ -1,0 +1,37 @@
+import { clipPartitionedAxis } from '../clipPartitionedAxis.js'
+
+describe('clipPartitionedAxis', () => {
+    it('renders no indices for an empty axis (no partitions)', () => {
+        // A degenerate matrix (e.g. a dimension with no members) yields an
+        // empty axis map and therefore no partitions. This must render nothing
+        // rather than a phantom index 0 that isn't in the map (which made
+        // engine.get return undefined and PivotTableValueCell throw).
+        const result = clipPartitionedAxis({
+            partitionSize: 400,
+            partitions: [],
+            axisMap: [],
+            widthMap: [],
+            viewportWidth: 1000,
+            viewportPosition: 0,
+            totalWidth: 0,
+        })
+
+        expect(result.indices).toEqual([])
+        expect(result.pre).toBe(0)
+        expect(result.post).toBe(0)
+    })
+
+    it('still falls back to index 0 when scrolled past the last partition of a non-empty axis', () => {
+        const result = clipPartitionedAxis({
+            partitionSize: 400,
+            partitions: [0],
+            axisMap: [0],
+            widthMap: [{ pre: 0, size: 100 }],
+            viewportWidth: 500,
+            viewportPosition: 100000, // far beyond the only partition
+            totalWidth: 100,
+        })
+
+        expect(result.indices).toEqual([0])
+    })
+})

--- a/src/modules/pivotTable/clipPartitionedAxis.js
+++ b/src/modules/pivotTable/clipPartitionedAxis.js
@@ -9,6 +9,17 @@ export const clipPartitionedAxis = ({
 }) => {
     const partition = Math.floor(viewportPosition / partitionSize)
 
+    // Empty axis (no rows/columns to render, e.g. a degenerate matrix where a
+    // dimension has no members). Render nothing instead of falling back to a
+    // phantom index 0 that isn't present in the axis map.
+    if (partitions.length === 0) {
+        return {
+            indices: [],
+            pre: 0,
+            post: 0,
+        }
+    }
+
     if (partitions[partition] === undefined) {
         return {
             indices: [0],

--- a/src/modules/response/event/__tests__/timeDimensions.spec.js
+++ b/src/modules/response/event/__tests__/timeDimensions.spec.js
@@ -1,0 +1,39 @@
+import { transformResponse } from '../response.js'
+
+const months = ['202505', '202506', '202507']
+
+// Minimal enrollment/aggregate-style response with NO data rows.
+// The server still returns the full relative-period buckets in
+// metaData.dimensions for the period dimensions.
+const makeEmptyResponse = () => ({
+    headers: [
+        { name: 'value', valueType: 'NUMBER', meta: false },
+        { name: 'enrollmentdate', valueType: 'TEXT', meta: true },
+        { name: 'A03MvHHogjR.eventdate', valueType: 'DATE', meta: true },
+    ],
+    metaData: {
+        items: months.reduce((o, m) => ({ ...o, [m]: { name: m } }), {}),
+        dimensions: {
+            enrollmentdate: [...months],
+            'A03MvHHogjR.eventdate': [...months],
+        },
+    },
+    rows: [],
+})
+
+describe('transformResponse - time dimension members', () => {
+    it('preserves the bare program-level time dimension members when there are no rows', () => {
+        const { metaData } = transformResponse(makeEmptyResponse())
+
+        // Regression: applyDefaultHandler used to re-derive enrollmentdate's
+        // members from the (empty) rows and overwrite the server buckets with
+        // [], collapsing the pivot table (dataWidth -> 0 -> cellType crash).
+        expect(metaData.dimensions.enrollmentdate).toEqual(months)
+    })
+
+    it('preserves the stage-prefixed time dimension members when there are no rows', () => {
+        const { metaData } = transformResponse(makeEmptyResponse())
+
+        expect(metaData.dimensions['A03MvHHogjR.eventdate']).toEqual(months)
+    })
+})

--- a/src/modules/response/event/response.js
+++ b/src/modules/response/event/response.js
@@ -96,10 +96,21 @@ const EXCLUDED_HEADER_SUFFIXES = [
     '.ou',
 ]
 
+// Time/org-unit dimensions must keep the dimension members provided by the
+// server (e.g. all the period buckets of a relative period like LAST_12_MONTHS)
+// instead of having them re-derived from the data rows by applyDefaultHandler.
+// EXCLUDED_HEADER_SUFFIXES already covers the program-stage-prefixed forms
+// (e.g. "<stageId>.eventdate"); their bare, program-level counterparts
+// (e.g. "enrollmentdate") must be excluded too, otherwise a response with no
+// rows would re-derive an empty members list and collapse the pivot table.
+const isExcludedHeaderName = (name) =>
+    EXCLUDED_HEADER_NAMES.has(name) ||
+    EXCLUDED_HEADER_SUFFIXES.some(
+        (suffix) => name.endsWith(suffix) || name === suffix.slice(1)
+    )
+
 const isIncludedHeader = (header) =>
-    Boolean(header.meta) &&
-    !EXCLUDED_HEADER_NAMES.has(header.name) &&
-    !EXCLUDED_HEADER_SUFFIXES.some((suffix) => header.name.endsWith(suffix))
+    Boolean(header.meta) && !isExcludedHeaderName(header.name)
 
 export const transformResponse = (response, { hideNaData = false } = {}) => {
     // Do not modify the original response


### PR DESCRIPTION
 Implements DHIS2-XXXX

  ---
###  Key features

  1. Fixes a crash that blanked out some enrollment/event Pivot Tables with a console error (`Cannot read properties of undefined (reading 'cellType')`).

  ---
###  Description

  Certain enrollment Pivot Tables — those using a program-level time dimension such as `enrollmentdate` on rows/columns — would crash and render nothing when the query returned no matching data.

  Cause. Two issues combined:

  - When transforming the analytics response, the period buckets for bare program-level time dimensions (e.g. enrollmentdate, incidentdate) were being re-derived from the returned data rows. For a query with no data this produced an empty set of periods, even though the server had returned the full period range. (Their program-stage-scoped equivalents, e.g. <stage>.eventdate, were already handled correctly.)
  The result was a Pivot Table with zero columns.
  - The table renderer did not handle a "zero rows or zero columns" matrix gracefully and threw while trying to render a cell that didn't exist.

  Fix.

  - The response transformation now preserves the server-provided period members for program-level time dimensions, consistent with how period and organisation-unit dimensions are already treated. So the table keeps its full set of period columns even when there's no data.
  - The renderer is hardened so that a table with no rows or no columns renders as an empty table instead of throwing — defense-in-depth against any other source of an empty matrix.

  Behaviour note. A Pivot Table using a program-level time dimension now shows all periods in the selected range (e.g. all of the last 12 months), including empty ones, matching the behaviour of other period dimensions. The "hide empty rows/columns" options continue to control whether empty periods
  are shown. Previously these dimensions silently dropped periods that had no data.

  ---
###  TODO

  - [x] Tests added
  - [ ] PRs for all affected apps created
  - [ ] Storybook added

 ---
 ### Screenshots
 
 Example of PT visualization that returns no data.
 
 Before:
 
<img width="850" height="338" alt="Screenshot 2026-06-25 at 12 51 20" src="https://github.com/user-attachments/assets/e6bf4928-f8fe-49e0-9f86-0c160480bb6a" />


 After:
 
<img width="1052" height="350" alt="Screenshot 2026-06-25 at 12 50 21" src="https://github.com/user-attachments/assets/9f13945b-d397-4bd0-a5a1-bd02d6d10c7c" />
