### PR TITLE
fix: omit optionSetId from dataItems query on DHIS2 < v42 [DHIS2-20499]

### DIFF
--- a/src/api/dimensions.js
+++ b/src/api/dimensions.js
@@ -46,8 +46,10 @@ const recommendedDimensionsQuery = {
 
 export const dataItemsQuery = {
     resource: 'dataItems',
-    params: ({ nameProp, filter, searchTerm, page }) => {
-        let fields = `id,${nameProp}~rename(name),dimensionItemType,expression,optionSetId`
+    params: ({ nameProp, filter, searchTerm, page, supportsOptionSetId }) => {
+        let fields = `id,${nameProp}~rename(name),dimensionItemType,expression${
+            supportsOptionSetId ? ',optionSetId' : ''
+        }`
         const filters = []
 
         // TODO: Extract all of this logic out of the query?
@@ -289,6 +291,7 @@ export const apiFetchOptions = ({
     filter,
     searchTerm,
     page,
+    supportsOptionSetId,
 }) => {
     switch (filter?.dataType) {
         case DIMENSION_TYPE_INDICATOR: {
@@ -335,6 +338,7 @@ export const apiFetchOptions = ({
                 filter,
                 searchTerm,
                 page,
+                supportsOptionSetId,
             })
     }
 }
@@ -433,6 +437,7 @@ const fetchDataItems = async ({
     filter,
     searchTerm,
     page,
+    supportsOptionSetId,
 }) => {
     const dataItemsData = await dataEngine.query(
         { dataItems: dataItemsQuery },
@@ -442,6 +447,7 @@ const fetchDataItems = async ({
                 filter,
                 searchTerm,
                 page,
+                supportsOptionSetId,
             },
             onError,
         }

--- a/src/components/DataDimension/DataDimension.js
+++ b/src/components/DataDimension/DataDimension.js
@@ -56,6 +56,7 @@ const DataDimension = ({
     const supportsEDI = dataTypes
         .map(({ id }) => id)
         .includes(DIMENSION_TYPE_EXPRESSION_DIMENSION_ITEM)
+    const supportsOptionSetId = serverVersion.minor >= 42
 
     const [currentCalculation, setCurrentCalculation] = useState()
     const [currentDataItem, setCurrentDataItem] = useState()
@@ -126,6 +127,7 @@ const DataDimension = ({
                 dataTypes={dataTypes}
                 itemsRef={itemsRef}
                 supportsEDI={supportsEDI}
+                supportsOptionSetId={supportsOptionSetId}
                 onEDISave={onCalculationSave}
                 isOptionViewMode={Boolean(currentDataItem)}
                 currentCalculation={currentCalculation}

--- a/src/components/DataDimension/ItemSelector/ItemSelector.js
+++ b/src/components/DataDimension/ItemSelector/ItemSelector.js
@@ -136,6 +136,7 @@ const ItemSelector = ({
     onEditClick,
     isOptionViewMode,
     supportsEDI,
+    supportsOptionSetId,
     height = TRANSFER_HEIGHT,
     heightCalculation,
     maxSelections,
@@ -176,6 +177,7 @@ const ItemSelector = ({
             page,
             filter: state.filter,
             searchTerm: state.searchTerm,
+            supportsOptionSetId,
         })
         const newOptions = []
         result.dimensionItems?.forEach((item) => {
@@ -492,6 +494,7 @@ ItemSelector.propTypes = {
     setCurrentCalculation: PropTypes.func,
     setInfoDataItem: PropTypes.func,
     supportsEDI: PropTypes.bool,
+    supportsOptionSetId: PropTypes.bool,
     onEDISave: PropTypes.func,
     onEditClick: PropTypes.func,
 }


### PR DESCRIPTION
Implements [DHIS2-20499](https://dhis2.atlassian.net/browse/DHIS2-20499)

---

### Key features

1. The optionSetId field is no longer requested from the /dataItems endpoint on DHIS2 instances older than v42

---

### Description

`optionSetId` was introduced in the `/dataItems` endpoint in DHIS2 v42 (DHIS2-18644) and was not backported to v40/v41. Requesting it on older instances caused a `NoSuchFieldException: optionSetId` warning to flood `dhis.log` every time the Data dimension panel was opened.

The fix gates the field behind a `serverVersion.minor >= 42` check, following the same pattern used for other version-dependent features (`supportsEDI` for v40, enabled period types for v43). On v41 and below the option-set selector simply won't appear in the Data dimension, which is correct since the backend doesn't support it there.

[DHIS2-20499]: https://dhis2.atlassian.net/browse/DHIS2-20499?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ