### PR TITLE
feat: allow the app to override metaData.items names in the event response transformer

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,8 +5,8 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2026-05-28T08:40:06.387Z\n"
-"PO-Revision-Date: 2026-05-28T08:40:06.388Z\n"
+"POT-Creation-Date: 2026-08-27T11:56:55.720Z\n"
+"PO-Revision-Date: 2026-08-27T11:56:55.720Z\n"
 
 msgid "view only"
 msgstr "view only"
@@ -37,6 +37,11 @@ msgstr "Created {{time}} by {{author}}"
 
 msgid "Created {{time}}"
 msgstr "Created {{time}}"
+
+msgid "Viewed {{count}} times"
+msgid_plural "Viewed {{count}} times"
+msgstr[0] "Viewed 1 time"
+msgstr[1] "Viewed {{count}} times"
 
 msgid "Notifications"
 msgstr "Notifications"
@@ -582,6 +587,11 @@ msgstr "Could not load interpretations"
 msgid "Reply"
 msgstr "Reply"
 
+msgid "{{count}} replies"
+msgid_plural "{{count}} replies"
+msgstr[0] "{{count}} reply"
+msgstr[1] "{{count}} replies"
+
 msgid "View replies"
 msgstr "View replies"
 
@@ -729,37 +739,23 @@ msgstr ""
 msgid "New map"
 msgstr "New map"
 
-msgid "Open a line list"
-msgstr "Open a line list"
-
-msgid "Loading line lists"
-msgstr "Loading line lists"
-
-msgid "Couldn't load line lists"
-msgstr "Couldn't load line lists"
-
-msgid ""
-"There was a problem loading line lists. Try again or contact your system "
-"administrator."
-msgstr ""
-"There was a problem loading line lists. Try again or contact your system "
-"administrator."
-
-msgid "No line lists found. Click New line list to get started."
-msgstr "No line lists found. Click New line list to get started."
-
-msgid ""
-"No line lists found. Try adjusting your search or filter options to find "
-"what you're looking for."
-msgstr ""
-"No line lists found. Try adjusting your search or filter options to find "
-"what you're looking for."
-
-msgid "New line list"
-msgstr "New line list"
-
 msgid "Hide"
 msgstr "Hide"
+
+msgid "{{count}} org units"
+msgid_plural "{{count}} org units"
+msgstr[0] "{{count}} org unit"
+msgstr[1] "{{count}} org units"
+
+msgid "{{count}} levels"
+msgid_plural "{{count}} levels"
+msgstr[0] "{{count}} level"
+msgstr[1] "{{count}} levels"
+
+msgid "{{count}} groups"
+msgid_plural "{{count}} groups"
+msgstr[0] "{{count}} group"
+msgstr[1] "{{count}} groups"
 
 msgid "Selected: {{commaSeparatedListOfOrganisationUnits}}"
 msgstr "Selected: {{commaSeparatedListOfOrganisationUnits}}"
@@ -1478,6 +1474,11 @@ msgstr "Base"
 
 msgid "Axis {{axisId}}"
 msgstr "Axis {{axisId}}"
+
+msgid "{{count}} items"
+msgid_plural "{{count}} items"
+msgstr[0] "{{count}} item"
+msgstr[1] "{{count}} items"
 
 msgid "Reset zoom"
 msgstr "Reset zoom"

--- a/src/modules/response/event/__tests__/response.spec.js
+++ b/src/modules/response/event/__tests__/response.spec.js
@@ -271,5 +271,91 @@ describe('response', () => {
                 })
             })
         })
+
+        describe('metaDataItemNames', () => {
+            const headerName = 'Zj7UnCAulEk.ou'
+            const response = {
+                headers: [
+                    {
+                        name: headerName,
+                        column: 'Organisation unit',
+                        valueType: 'TEXT',
+                        type: 'java.lang.String',
+                        hidden: false,
+                        meta: true,
+                    },
+                ],
+                metaData: {
+                    items: {
+                        ImspTQPwCqd: { name: 'Sierra Leone' },
+                        [headerName]: { name: 'Organisation unit' },
+                    },
+                    dimensions: {
+                        [headerName]: ['ImspTQPwCqd'],
+                    },
+                },
+                rows: [['ImspTQPwCqd']],
+            }
+
+            it('overrides the name the backend returned', () => {
+                const result = transformResponse(response, {
+                    metaDataItemNames: { [headerName]: 'Event org. unit' },
+                })
+
+                expect(result.metaData.items[headerName].name).toBe(
+                    'Event org. unit'
+                )
+            })
+
+            it('keeps the other fields of the overridden item', () => {
+                const result = transformResponse(
+                    {
+                        ...response,
+                        metaData: {
+                            ...response.metaData,
+                            items: {
+                                ...response.metaData.items,
+                                [headerName]: {
+                                    name: 'Organisation unit',
+                                    dimensionType: 'ORGANISATION_UNIT',
+                                },
+                            },
+                        },
+                    },
+                    { metaDataItemNames: { [headerName]: 'Event org. unit' } }
+                )
+
+                expect(result.metaData.items[headerName]).toEqual({
+                    name: 'Event org. unit',
+                    dimensionType: 'ORGANISATION_UNIT',
+                })
+            })
+
+            it('adds an item for a key the response has no item for', () => {
+                const result = transformResponse(response, {
+                    metaDataItemNames: { lastupdated: 'Last updated on' },
+                })
+
+                expect(result.metaData.items.lastupdated).toEqual({
+                    name: 'Last updated on',
+                })
+            })
+
+            it('leaves items alone when no names are passed', () => {
+                expect(transformResponse(response)).toEqual(
+                    transformResponse(response, { metaDataItemNames: {} })
+                )
+            })
+
+            it('does not mutate the original response', () => {
+                transformResponse(response, {
+                    metaDataItemNames: { [headerName]: 'Event org. unit' },
+                })
+
+                expect(response.metaData.items[headerName].name).toBe(
+                    'Organisation unit'
+                )
+            })
+        })
     })
 })

--- a/src/modules/response/event/response.js
+++ b/src/modules/response/event/response.js
@@ -112,16 +112,34 @@ const isExcludedHeaderName = (name) =>
 const isIncludedHeader = (header) =>
     Boolean(header.meta) && !isExcludedHeaderName(header.name)
 
-export const transformResponse = (response, { hideNaData = false } = {}) => {
+/* Display names supplied by the consuming app, keyed by `metaData.items` key.
+ * The backend name for a dimension is not always the one the app shows the
+ * user (the app has its own fallbacks and labels), and for some dimensions the
+ * backend omits the item altogether, so these names win over the response and
+ * may introduce an item that was not there. */
+const applyMetaDataItemNameOverrides = (items, metaDataItemNames) =>
+    Object.entries(metaDataItemNames).reduce(
+        (acc, [id, name]) => {
+            acc[id] = { ...acc[id], name }
+            return acc
+        },
+        { ...items }
+    )
+
+export const transformResponse = (
+    response,
+    { hideNaData = false, metaDataItemNames = {} } = {}
+) => {
     // Do not modify the original response
     // Rows is mapped by the handlers
     let transformedResponse = {
         ...response,
         metaData: {
             ...response.metaData,
-            items: {
-                ...response.metaData.items,
-            },
+            items: applyMetaDataItemNameOverrides(
+                response.metaData.items,
+                metaDataItemNames
+            ),
             dimensions: {
                 ...response.metaData.dimensions,
             },

--- a/src/modules/response/event/response.js
+++ b/src/modules/response/event/response.js
@@ -113,10 +113,8 @@ const isIncludedHeader = (header) =>
     Boolean(header.meta) && !isExcludedHeaderName(header.name)
 
 /* Display names supplied by the consuming app, keyed by `metaData.items` key.
- * The backend name for a dimension is not always the one the app shows the
- * user (the app has its own fallbacks and labels), and for some dimensions the
- * backend omits the item altogether, so these names win over the response and
- * may introduce an item that was not there. */
+ * The app has its own labels and fallbacks that the backend does not always
+ * match, so these win. A key with no item in the response gets one added. */
 const applyMetaDataItemNameOverrides = (items, metaDataItemNames) =>
     Object.entries(metaDataItemNames).reduce(
         (acc, [id, name]) => {


### PR DESCRIPTION
Implements [DHIS2-21681](https://dhis2.atlassian.net/browse/DHIS2-21681)

**Relates to https://github.com/dhis2/event-visualizer-app/pull/357**

---

### Description

`transformResponse` now reads a `metaDataItemNames` field in its second positional "options" argument. This name lookup takes precedence over the names in `metaData.items` so this can be used by consumers (apps) to use custom dimension names and seeing these in the pivot table too.

### Unrelated changes

Running `yarn start` produced a diff on `en.pot`. This new version seems valid, so we should keep these changes. I think sneaking them in alongside this PR is fine.

---

### TODO

- [x] Tests added
- [x] PRs for all affected apps created
- [ ] Storybook added N/A


[DHIS2-21681]: https://dhis2.atlassian.net/browse/DHIS2-21681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ