### PR TITLE
feat(CalculationsDialog): add keyboard support and improve UX [UX-159]

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -74,11 +74,38 @@ msgstr "This app could not retrieve required data."
 msgid "Network error"
 msgstr "Network error"
 
+msgid "Add or select the focused item"
+msgstr "Add or select the focused item"
+
+msgid "Move the selected item"
+msgstr "Move the selected item"
+
+msgid "Insert an operator after the selected item"
+msgstr "Insert an operator after the selected item"
+
+msgid "Keyboard navigation"
+msgstr "Keyboard navigation"
+
+msgid "The formula is valid"
+msgstr "The formula is valid"
+
+msgid "Could not validate the formula"
+msgstr "Could not validate the formula"
+
 msgid "Data / Edit calculation"
 msgstr "Data / Edit calculation"
 
 msgid "Data / New calculation"
 msgstr "Data / New calculation"
+
+msgid "Calculation name"
+msgstr "Calculation name"
+
+msgid "Shown in table headers and chart axes/legends"
+msgstr "Shown in table headers and chart axes/legends"
+
+msgid "Formula"
+msgstr "Formula"
 
 msgid "Remove item"
 msgstr "Remove item"
@@ -86,11 +113,14 @@ msgstr "Remove item"
 msgid "Check formula"
 msgstr "Check formula"
 
-msgid "Calculation name"
-msgstr "Calculation name"
-
-msgid "Shown in table headers and chart axes/legends"
-msgstr "Shown in table headers and chart axes/legends"
+msgid ""
+"Drag or click a data element or operator to add it to the formula. Drag to "
+"reorder. Select an item and click Remove item, or double-click, to delete "
+"it."
+msgstr ""
+"Drag or click a data element or operator to add it to the formula. Drag to "
+"reorder. Select an item and click Remove item, or double-click, to delete "
+"it."
 
 msgid "Delete calculation"
 msgstr "Delete calculation"
@@ -139,14 +169,11 @@ msgid "No data elements found"
 msgstr "No data elements found"
 
 msgid ""
-"Drag items here, or double click in the list, to start building a "
-"calculation formula"
+"Drag a data element or operator here, or click one, to start building a "
+"formula"
 msgstr ""
-"Drag items here, or double click in the list, to start building a "
-"calculation formula"
-
-msgid "Math operators"
-msgstr "Math operators"
+"Drag a data element or operator here, or click one, to start building a "
+"formula"
 
 msgid "Expression description"
 msgstr "Expression description"
@@ -1197,8 +1224,8 @@ msgstr "Option"
 msgid "Number"
 msgstr "Number"
 
-msgid "Formula is empty. Add items to the formula from the lists on the left."
-msgstr "Formula is empty. Add items to the formula from the lists on the left."
+msgid "Formula is empty. Add a data element or operator to the formula."
+msgstr "Formula is empty. Add a data element or operator to the formula."
 
 msgid "Consecutive math operators"
 msgstr "Consecutive math operators"

--- a/src/__demo__/CalculationModal.stories.js
+++ b/src/__demo__/CalculationModal.stories.js
@@ -208,6 +208,19 @@ const DATA_ELEMENT_GROUPS = {
     ],
 }
 
+const VALIDATION_OK = {
+    status: 'OK',
+    message: 'Valid',
+    description: 'ANC 1st visit / 10 * ANC 4th or more visits',
+}
+
+const providerData = {
+    dataElements: DATA_ELEMENTS,
+    dataElementGroups: DATA_ELEMENT_GROUPS,
+    dataElementOperands: DATA_ELEMENT_OPERANDS,
+    'indicators/expression/description': VALIDATION_OK,
+}
+
 const calculation = {
     id: 'calculationid',
     name: 'My calculation',
@@ -226,13 +239,7 @@ export default {
 
 export const Default = () => {
     return (
-        <CustomDataProvider
-            data={{
-                dataElements: DATA_ELEMENTS,
-                dataElementGroups: DATA_ELEMENT_GROUPS,
-                dataElementOperands: DATA_ELEMENT_OPERANDS,
-            }}
-        >
+        <CustomDataProvider data={providerData}>
             <CalculationModal
                 displayNameProp="name"
                 onClose={Function.prototype}
@@ -245,13 +252,7 @@ export const Default = () => {
 
 export const WithCalculation = () => {
     return (
-        <CustomDataProvider
-            data={{
-                dataElements: DATA_ELEMENTS,
-                dataElementGroups: DATA_ELEMENT_GROUPS,
-                dataElementOperands: DATA_ELEMENT_OPERANDS,
-            }}
-        >
+        <CustomDataProvider data={providerData}>
             <CalculationModal
                 calculation={calculation}
                 displayNameProp="name"
@@ -269,13 +270,7 @@ WithCalculation.story = {
 
 export const WithCalculationContainingOperand = () => {
     return (
-        <CustomDataProvider
-            data={{
-                dataElements: DATA_ELEMENTS,
-                dataElementGroups: DATA_ELEMENT_GROUPS,
-                dataElementOperands: DATA_ELEMENT_OPERANDS,
-            }}
-        >
+        <CustomDataProvider data={providerData}>
             <CalculationModal
                 calculation={calculationWithOperand}
                 displayNameProp="name"
@@ -295,6 +290,7 @@ export const NoAvailableData = () => {
     return (
         <CustomDataProvider
             data={{
+                ...providerData,
                 dataElements: {
                     pager: {
                         page: 1,

--- a/src/components/DataDimension/Calculation/CalculationModal.js
+++ b/src/components/DataDimension/Calculation/CalculationModal.js
@@ -6,11 +6,14 @@ import {
     ModalContent,
     ModalActions,
     ButtonStrip,
+    Help,
     InputField,
+    NoticeBox,
+    Popper,
+    Portal,
 } from '@dhis2/ui'
-import cx from 'classnames'
 import PropTypes from 'prop-types'
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import {
     createCalculationMutation,
     deleteCalculationMutation,
@@ -22,15 +25,20 @@ import {
     parseExpressionToArray,
     parseArrayToExpression,
     validateExpression,
+    getOperators,
     EXPRESSION_TYPE_DATA,
     EXPRESSION_TYPE_NUMBER,
+    EXPRESSION_TYPE_OPERATOR,
     INVALID_EXPRESSION,
     VALID_EXPRESSION,
     getItemIdsFromExpression,
 } from '../../../modules/expressions.js'
 import { OfflineTooltip as Tooltip } from '../../OfflineTooltip.js'
 import DataElementSelector from './DataElementSelector.js'
-import DndContext, { OPTIONS_PANEL } from './DndContext.js'
+import DndContext, {
+    OPTIONS_PANEL,
+    isInteractiveElement,
+} from './DndContext.js'
 import FormulaField, {
     LAST_DROPZONE_ID,
     FORMULA_BOX_ID,
@@ -41,6 +49,81 @@ import styles from './styles/CalculationModal.style.js'
 const FIRST_POSITION = 0
 const LAST_POSITION = -1
 const CALCULATION_PROP_DEFAULT = {}
+const OPERATORS = getOperators()
+
+const Key = ({ children }) => (
+    <kbd className="key">
+        {children}
+        <style jsx>{styles}</style>
+    </kbd>
+)
+
+Key.propTypes = {
+    children: PropTypes.node.isRequired,
+}
+
+const ShortcutsPopoverContent = () => (
+    <div className="shortcuts">
+        <ul>
+            <li>
+                <span className="shortcut-keys">
+                    <Key>Enter</Key>
+                    <Key>Space</Key>
+                </span>
+                {i18n.t('Add or select the focused item')}
+            </li>
+            <li>
+                <span className="shortcut-keys">
+                    <Key>←</Key>
+                    <Key>→</Key>
+                </span>
+                {i18n.t('Move the selected item')}
+            </li>
+            <li>
+                <span className="shortcut-keys">
+                    <Key>+</Key>
+                    <Key>-</Key>
+                    <Key>*</Key>
+                    <Key>/</Key>
+                    <Key>(</Key>
+                    <Key>)</Key>
+                </span>
+                {i18n.t('Insert an operator after the selected item')}
+            </li>
+        </ul>
+        <style jsx>{styles}</style>
+    </div>
+)
+
+const KeyboardNavigationHint = () => {
+    const [isOpen, setIsOpen] = useState(false)
+    const triggerRef = useRef()
+
+    return (
+        <span className="hint">
+            <button
+                type="button"
+                className="hint-trigger"
+                ref={triggerRef}
+                data-test="keyboard-navigation-hint"
+                onMouseEnter={() => setIsOpen(true)}
+                onMouseLeave={() => setIsOpen(false)}
+                onFocus={() => setIsOpen(true)}
+                onBlur={() => setIsOpen(false)}
+            >
+                {i18n.t('Keyboard navigation')}
+            </button>
+            {isOpen && (
+                <Portal>
+                    <Popper placement="top-start" reference={triggerRef}>
+                        <ShortcutsPopoverContent />
+                    </Popper>
+                </Portal>
+            )}
+            <style jsx>{styles}</style>
+        </span>
+    )
+}
 
 const CalculationModal = ({
     calculation = CALCULATION_PROP_DEFAULT,
@@ -61,7 +144,12 @@ const CalculationModal = ({
     const [doBackendValidation, { loading: isValidating }] = useDataMutation(
         validateIndicatorExpressionMutation,
         {
-            onError: (error) => showError(error),
+            onError: (error) =>
+                showError(
+                    error?.message ||
+                        error ||
+                        i18n.t('Could not validate the formula')
+                ),
         }
     )
 
@@ -124,7 +212,11 @@ const CalculationModal = ({
         }
     }, [data, calculation.expression])
 
-    const [newIdCount, setNewIdCount] = useState(1)
+    const nextItemIdRef = useRef(1)
+    // State is read through this ref instead of a closure, so the
+    // document-level keydown listener can be registered once on mount
+    // and still see fresh state on every keystroke.
+    const latestRef = useRef()
 
     const [validationOutput, setValidationOutput] = useState(null)
     const [expressionArray, setExpressionArray] = useState()
@@ -136,11 +228,19 @@ const CalculationModal = ({
     const [selectedItemId, setSelectedItemId] = useState(null)
 
     const expressionStatus = validationOutput?.status
+    const validationMessage =
+        expressionStatus === VALID_EXPRESSION
+            ? i18n.t('The formula is valid')
+            : validationOutput?.message
 
     const selectItem = (itemId) =>
-        setSelectedItemId((prevSelected) =>
-            prevSelected !== itemId ? itemId : null
-        )
+        setSelectedItemId((prevSelected) => {
+            const next = prevSelected !== itemId ? itemId : null
+            if (latestRef.current) {
+                latestRef.current.selectedItemId = next
+            }
+            return next
+        })
 
     const isLoading =
         isCreatingCalculation ||
@@ -149,49 +249,62 @@ const CalculationModal = ({
         isSavingCalculation ||
         isValidating
 
-    const addItem = ({ label, value, type, destIndex = LAST_POSITION }) => {
-        if (isLoading) {
-            return null
+    const addItem = ({ label, value, type, destIndex }) => {
+        if (isLoading || !expressionArray) {
+            return
         }
-        setValidationOutput()
+        setValidationOutput(null)
 
         const newItem = {
-            id: `${type}-${newIdCount}`,
+            id: `${type}-${nextItemIdRef.current++}`,
             value: type === EXPRESSION_TYPE_DATA ? `#{${value}}` : value,
             label,
             type,
         }
 
-        setNewIdCount(newIdCount + 1)
+        // Without an explicit destIndex, insert after the selected item
+        // instead of always appending.
+        const selectedId = latestRef.current?.selectedItemId
+        setExpressionArray((prevArray) => {
+            let insertAt = destIndex
+            if (insertAt === undefined) {
+                const selectedIndex = prevArray.findIndex(
+                    (item) => item.id === selectedId
+                )
+                insertAt =
+                    selectedIndex === -1 ? prevArray.length : selectedIndex + 1
+            } else if (insertAt === LAST_POSITION) {
+                insertAt = prevArray.length
+            }
 
-        if (destIndex === LAST_POSITION) {
-            setExpressionArray((prevArray) => prevArray.concat([newItem]))
-        } else if (destIndex === FIRST_POSITION) {
-            setExpressionArray((prevArray) => [newItem].concat(prevArray))
-        } else {
-            const items = Array.from(expressionArray)
-            const newFormulaItems = [
-                ...items.slice(0, destIndex),
+            return [
+                ...prevArray.slice(0, insertAt),
                 newItem,
-                ...items.slice(destIndex),
+                ...prevArray.slice(insertAt),
             ]
-            setExpressionArray(newFormulaItems)
-        }
+        })
 
         if (newItem.type === EXPRESSION_TYPE_NUMBER) {
             setFocusItemId(newItem.id)
         }
+
+        // Keep the newly added item selected so it becomes the anchor for
+        // the next typed operator or arrow-key move.
+        setSelectedItemId(newItem.id)
+        latestRef.current.selectedItemId = newItem.id
     }
 
     const moveItem = ({ sourceIndex, destIndex }) => {
         if (isLoading) {
-            return null
+            return
         }
-        setValidationOutput()
-        const sourceList = Array.from(expressionArray)
-        const [moved] = sourceList.splice(sourceIndex, 1)
-        sourceList.splice(destIndex, 0, moved)
-        setExpressionArray(sourceList)
+        setValidationOutput(null)
+        setExpressionArray((prevArray) => {
+            const sourceList = Array.from(prevArray)
+            const [moved] = sourceList.splice(sourceIndex, 1)
+            sourceList.splice(destIndex, 0, moved)
+            return sourceList
+        })
     }
 
     const setItemValue = ({ itemId, value }) => {
@@ -203,7 +316,7 @@ const CalculationModal = ({
 
     const removeItem = (itemId) => {
         if (!isLoading && itemId !== null) {
-            setValidationOutput()
+            setValidationOutput(null)
             const index = expressionArray.findIndex(
                 (item) => item.id === itemId
             )
@@ -213,6 +326,81 @@ const CalculationModal = ({
             setSelectedItemId(null)
         }
     }
+
+    latestRef.current = {
+        isLoading,
+        showDeletePrompt,
+        selectedItemId,
+        expressionArray,
+        addItem,
+        moveItem,
+    }
+
+    useEffect(() => {
+        const handleKeyDown = (event) => {
+            const {
+                isLoading,
+                showDeletePrompt,
+                selectedItemId,
+                expressionArray,
+                addItem,
+                moveItem,
+            } = latestRef.current
+
+            // On some layouts (e.g. German, French) operator characters
+            // like ( ) * are typed via AltGr, which browsers report as
+            // altKey/ctrlKey being set - don't let that block the shortcut.
+            const isAltGraph = event.getModifierState?.('AltGraph')
+
+            if (
+                isLoading ||
+                showDeletePrompt ||
+                event.metaKey ||
+                (!isAltGraph && (event.ctrlKey || event.altKey)) ||
+                isInteractiveElement(event.target)
+            ) {
+                return
+            }
+
+            const operator = OPERATORS.find(
+                (op) =>
+                    op.type === EXPRESSION_TYPE_OPERATOR &&
+                    op.value === event.key
+            )
+
+            if (operator) {
+                event.preventDefault()
+                addItem(operator)
+                return
+            }
+
+            if (!selectedItemId || !expressionArray) {
+                return
+            }
+
+            const index = expressionArray.findIndex(
+                (item) => item.id === selectedItemId
+            )
+            if (index === -1) {
+                return
+            }
+
+            if (event.key === 'ArrowLeft' && index > 0) {
+                event.preventDefault()
+                moveItem({ sourceIndex: index, destIndex: index - 1 })
+            } else if (
+                event.key === 'ArrowRight' &&
+                index < expressionArray.length - 1
+            ) {
+                event.preventDefault()
+                moveItem({ sourceIndex: index, destIndex: index + 1 })
+            }
+        }
+
+        document.addEventListener('keydown', handleKeyDown)
+
+        return () => document.removeEventListener('keydown', handleKeyDown)
+    }, [])
 
     const addOrMoveDraggedItem = ({ item, destination }) => {
         const destContainerId = destination.containerId
@@ -238,14 +426,31 @@ const CalculationModal = ({
     }
 
     const validate = async () => {
-        setValidationOutput()
+        setValidationOutput(null)
         const expression = parseArrayToExpression(expressionArray)
         let result = validateExpression(expression)
+
         if (!result) {
-            result = await doBackendValidation({
+            const backendResult = await doBackendValidation({
                 expression,
             })
+
+            // useDataMutation never rejects; network/engine failures go to
+            // onError and this promise does not resolve.
+            if (!backendResult) {
+                return
+            }
+
+            if (backendResult.status === INVALID_EXPRESSION) {
+                result = backendResult
+            } else {
+                result = {
+                    ...backendResult,
+                    status: VALID_EXPRESSION,
+                }
+            }
         }
+
         setValidationOutput(result)
 
         return result?.status
@@ -303,6 +508,20 @@ const CalculationModal = ({
                         : i18n.t('Data / New calculation')}
                 </ModalTitle>
                 <ModalContent dataTest="calculation-modal-content">
+                    <div className="name-field">
+                        <InputField
+                            label={i18n.t('Calculation name')}
+                            helpText={i18n.t(
+                                'Shown in table headers and chart axes/legends'
+                            )}
+                            onChange={({ value }) =>
+                                setName(value.substr(0, 50))
+                            }
+                            value={name}
+                            dataTest="calculation-label"
+                            dense
+                        />
+                    </div>
                     <DndContext
                         onDragStart={() => setFocusItemId(null)}
                         onDragEnd={addOrMoveDraggedItem}
@@ -311,77 +530,77 @@ const CalculationModal = ({
                             <div className="left-section">
                                 <DataElementSelector
                                     displayNameProp={displayNameProp}
-                                    onDoubleClick={addItem}
+                                    onClick={addItem}
                                     height={height}
                                 />
-                                <MathOperatorSelector onDoubleClick={addItem} />
                             </div>
                             <div className="right-section">
-                                <FormulaField
-                                    items={expressionArray}
-                                    selectedItemId={selectedItemId}
-                                    focusItemId={focusItemId}
-                                    onChange={setItemValue}
-                                    onClick={selectItem}
-                                    onDoubleClick={removeItem}
-                                    loading={!expressionArray}
-                                    disabled={isLoading}
-                                />
-                                <div className="actions-wrapper">
-                                    <div className="button-container">
-                                        <div className="remove-button">
-                                            <Button
-                                                small
-                                                secondary
-                                                onClick={() =>
-                                                    removeItem(selectedItemId)
-                                                }
-                                                dataTest="remove-button"
-                                                disabled={!selectedItemId}
-                                            >
-                                                {i18n.t('Remove item')}
-                                            </Button>
-                                        </div>
-                                        <div className="validate-button">
-                                            <Button
-                                                small
-                                                secondary
-                                                onClick={validate}
-                                                dataTest="validate-button"
-                                                loading={isValidating}
-                                                disabled={isLoading}
-                                            >
-                                                {i18n.t('Check formula')}
-                                            </Button>
-                                        </div>
+                                <div className="formula-section">
+                                    <h4 className="sub-header">
+                                        {i18n.t('Formula')}
+                                    </h4>
+                                    <FormulaField
+                                        items={expressionArray}
+                                        selectedItemId={selectedItemId}
+                                        focusItemId={focusItemId}
+                                        onChange={setItemValue}
+                                        onClick={selectItem}
+                                        onDoubleClick={removeItem}
+                                        loading={!expressionArray}
+                                    />
+                                    <MathOperatorSelector onClick={addItem} />
+                                    <div className="formula-actions">
+                                        <Button
+                                            small
+                                            secondary
+                                            onClick={() =>
+                                                removeItem(selectedItemId)
+                                            }
+                                            dataTest="remove-button"
+                                            disabled={!selectedItemId}
+                                        >
+                                            {i18n.t('Remove item')}
+                                        </Button>
+                                        <Button
+                                            small
+                                            secondary
+                                            onClick={validate}
+                                            dataTest="validate-button"
+                                            loading={isValidating}
+                                            disabled={isLoading}
+                                        >
+                                            {i18n.t('Check formula')}
+                                        </Button>
                                     </div>
-                                    <span
-                                        className={cx('validation-message', {
-                                            'validation-error':
-                                                expressionStatus ===
-                                                INVALID_EXPRESSION,
-                                            'validation-success':
-                                                expressionStatus ===
-                                                VALID_EXPRESSION,
-                                        })}
+                                </div>
+                                {validationMessage && (
+                                    <div
+                                        className="validation-notice"
                                         data-test="validation-message"
                                     >
-                                        {validationOutput?.message}
-                                    </span>
-                                    <div className="name-input">
-                                        <InputField
-                                            label={i18n.t('Calculation name')}
-                                            helpText={i18n.t(
-                                                'Shown in table headers and chart axes/legends'
-                                            )}
-                                            onChange={({ value }) =>
-                                                setName(value.substr(0, 50))
+                                        <NoticeBox
+                                            error={
+                                                expressionStatus ===
+                                                INVALID_EXPRESSION
                                             }
-                                            value={name}
-                                            dataTest="calculation-label"
-                                            dense
-                                        />
+                                            valid={
+                                                expressionStatus ===
+                                                VALID_EXPRESSION
+                                            }
+                                        >
+                                            {validationMessage}
+                                        </NoticeBox>
                                     </div>
+                                )}
+                                <div className="usage-legend">
+                                    <Help>
+                                        {i18n.t(
+                                            'Drag or click a data element or operator to add it to the formula. Drag to reorder. Select an item and click Remove item, or double-click, to delete it.'
+                                        )}
+                                    </Help>
+                                    <p className="see-also">
+                                        <KeyboardNavigationHint />
+                                    </p>
                                 </div>
                             </div>
                         </div>

--- a/src/components/DataDimension/Calculation/CalculationModal.js
+++ b/src/components/DataDimension/Calculation/CalculationModal.js
@@ -481,33 +481,47 @@ const CalculationModal = ({
                                 />
                             </div>
                             <div className="right-section">
-                                <div
-                                    className={cx('formula-section', {
-                                        valid:
-                                            expressionStatus ===
-                                            VALID_EXPRESSION,
-                                        invalid:
-                                            expressionStatus ===
-                                            INVALID_EXPRESSION,
-                                    })}
-                                >
+                                <div className="formula-section">
                                     <div className="sub-header-row">
                                         <h4 className="sub-header">
                                             {i18n.t('Formula')}
                                         </h4>
-                                        <div
-                                            className="validation-status"
-                                            aria-live="polite"
-                                            data-test="validation-message"
-                                        >
-                                            {validationMessage && (
-                                                <span
-                                                    className={cx('status', {
-                                                        valid:
-                                                            expressionStatus ===
-                                                            VALID_EXPRESSION,
-                                                    })}
-                                                >
+                                    </div>
+                                    <FormulaToolbar
+                                        onAddOperator={addItem}
+                                        onRemove={() =>
+                                            removeItem(selectedItemId)
+                                        }
+                                        onValidate={validate}
+                                        canRemove={Boolean(selectedItemId)}
+                                        isValidating={isValidating}
+                                        isLoading={isLoading}
+                                    />
+                                    <div
+                                        className={cx('formula-box', {
+                                            valid:
+                                                expressionStatus ===
+                                                VALID_EXPRESSION,
+                                            invalid:
+                                                expressionStatus ===
+                                                INVALID_EXPRESSION,
+                                        })}
+                                    >
+                                        <FormulaField
+                                            items={expressionArray}
+                                            selectedItemId={selectedItemId}
+                                            focusItemId={focusItemId}
+                                            onChange={setItemValue}
+                                            onClick={selectItem}
+                                            loading={!expressionArray}
+                                        />
+                                        {validationMessage && (
+                                            <div
+                                                className="validation-bar"
+                                                aria-live="polite"
+                                                data-test="validation-message"
+                                            >
+                                                <span className="status">
                                                     {expressionStatus ===
                                                     VALID_EXPRESSION ? (
                                                         <IconCheckmarkCircle16
@@ -526,27 +540,9 @@ const CalculationModal = ({
                                                         {validationMessage}
                                                     </span>
                                                 </span>
-                                            )}
-                                        </div>
+                                            </div>
+                                        )}
                                     </div>
-                                    <FormulaToolbar
-                                        onAddOperator={addItem}
-                                        onRemove={() =>
-                                            removeItem(selectedItemId)
-                                        }
-                                        onValidate={validate}
-                                        canRemove={Boolean(selectedItemId)}
-                                        isValidating={isValidating}
-                                        isLoading={isLoading}
-                                    />
-                                    <FormulaField
-                                        items={expressionArray}
-                                        selectedItemId={selectedItemId}
-                                        focusItemId={focusItemId}
-                                        onChange={setItemValue}
-                                        onClick={selectItem}
-                                        loading={!expressionArray}
-                                    />
                                 </div>
                             </div>
                         </div>

--- a/src/components/DataDimension/Calculation/CalculationModal.js
+++ b/src/components/DataDimension/Calculation/CalculationModal.js
@@ -8,7 +8,6 @@ import {
     ButtonStrip,
     IconQuestion16,
     InputField,
-    NoticeBox,
     Popper,
     Portal,
 } from '@dhis2/ui'
@@ -592,6 +591,8 @@ const CalculationModal = ({
                                         canRemove={Boolean(selectedItemId)}
                                         isValidating={isValidating}
                                         isLoading={isLoading}
+                                        validationStatus={expressionStatus}
+                                        validationMessage={validationMessage}
                                     />
                                     <FormulaField
                                         items={expressionArray}
@@ -602,25 +603,6 @@ const CalculationModal = ({
                                         loading={!expressionArray}
                                     />
                                 </div>
-                                {validationMessage && (
-                                    <div
-                                        className="validation-notice"
-                                        data-test="validation-message"
-                                    >
-                                        <NoticeBox
-                                            error={
-                                                expressionStatus ===
-                                                INVALID_EXPRESSION
-                                            }
-                                            valid={
-                                                expressionStatus ===
-                                                VALID_EXPRESSION
-                                            }
-                                        >
-                                            {validationMessage}
-                                        </NoticeBox>
-                                    </div>
-                                )}
                             </div>
                         </div>
                     </DndContext>

--- a/src/components/DataDimension/Calculation/CalculationModal.js
+++ b/src/components/DataDimension/Calculation/CalculationModal.js
@@ -6,11 +6,12 @@ import {
     ModalContent,
     ModalActions,
     ButtonStrip,
-    IconQuestion16,
+    IconCheckmarkCircle16,
+    IconErrorFilled16,
     InputField,
-    Popper,
-    Portal,
+    colors,
 } from '@dhis2/ui'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useEffect, useRef, useState } from 'react'
 import css from 'styled-jsx/css'
@@ -63,101 +64,6 @@ const getContentWidthCSS = (width) => css.resolve`
         width: ${width}px;
     }
 `
-
-const Key = ({ children }) => (
-    <kbd className="key">
-        {children}
-        <style jsx>{styles}</style>
-    </kbd>
-)
-
-Key.propTypes = {
-    children: PropTypes.node.isRequired,
-}
-
-const ShortcutsPopoverContent = () => (
-    <div className="shortcuts">
-        <h4 className="shortcuts-header">{i18n.t('Usage tips')}</h4>
-        <ul>
-            <li>
-                {i18n.t(
-                    'Click or drag a data element or operator to add it to the formula.'
-                )}
-            </li>
-            <li>{i18n.t('Drag an item to reorder it.')}</li>
-            <li>
-                {i18n.t('Select an item, then click')}{' '}
-                <strong>{i18n.t('Remove item')}</strong>{' '}
-                {i18n.t('to delete it.')}
-            </li>
-        </ul>
-        <h4 className="shortcuts-header">{i18n.t('Keyboard shortcuts')}</h4>
-        <ul>
-            <li>
-                {i18n.t('Press')}{' '}
-                <span className="shortcut-keys">
-                    <Key>Enter</Key>
-                    {i18n.t('or')}
-                    <Key>Space</Key>
-                </span>{' '}
-                {i18n.t('to add or select the focused item.')}
-            </li>
-            <li>
-                {i18n.t('Press')}{' '}
-                <span className="shortcut-keys">
-                    <Key>←</Key>
-                    {i18n.t('or')}
-                    <Key>→</Key>
-                </span>{' '}
-                {i18n.t('to move the selected item.')}
-            </li>
-            <li>
-                {i18n.t('Press')}{' '}
-                <span className="shortcut-keys">
-                    <Key>+</Key>
-                    <Key>-</Key>
-                    <Key>*</Key>
-                    <Key>/</Key>
-                    <Key>(</Key>
-                    <Key>)</Key>
-                </span>{' '}
-                {i18n.t('to insert an operator after the selected item.')}
-            </li>
-        </ul>
-        <style jsx>{styles}</style>
-    </div>
-)
-
-const UsageHint = () => {
-    const [isOpen, setIsOpen] = useState(false)
-    const triggerRef = useRef()
-
-    return (
-        <span className="hint">
-            <button
-                type="button"
-                className="hint-trigger"
-                ref={triggerRef}
-                data-test="usage-hint"
-                aria-label={i18n.t('Usage tips')}
-                onMouseEnter={() => setIsOpen(true)}
-                onMouseLeave={() => setIsOpen(false)}
-                onFocus={() => setIsOpen(true)}
-                onBlur={() => setIsOpen(false)}
-            >
-                <IconQuestion16 />
-            </button>
-            {isOpen && (
-                <Portal>
-                    <Popper placement="bottom-start" reference={triggerRef}>
-                        <ShortcutsPopoverContent />
-                    </Popper>
-                </Portal>
-            )}
-            <style jsx>{styles}</style>
-        </span>
-    )
-}
 
 const CalculationModal = ({
     calculation = CALCULATION_PROP_DEFAULT,
@@ -575,12 +481,53 @@ const CalculationModal = ({
                                 />
                             </div>
                             <div className="right-section">
-                                <div className="formula-section">
+                                <div
+                                    className={cx('formula-section', {
+                                        valid:
+                                            expressionStatus ===
+                                            VALID_EXPRESSION,
+                                        invalid:
+                                            expressionStatus ===
+                                            INVALID_EXPRESSION,
+                                    })}
+                                >
                                     <div className="sub-header-row">
                                         <h4 className="sub-header">
                                             {i18n.t('Formula')}
                                         </h4>
-                                        <UsageHint />
+                                        <div
+                                            className="validation-status"
+                                            aria-live="polite"
+                                            data-test="validation-message"
+                                        >
+                                            {validationMessage && (
+                                                <span
+                                                    className={cx('status', {
+                                                        valid:
+                                                            expressionStatus ===
+                                                            VALID_EXPRESSION,
+                                                    })}
+                                                >
+                                                    {expressionStatus ===
+                                                    VALID_EXPRESSION ? (
+                                                        <IconCheckmarkCircle16
+                                                            color={
+                                                                colors.green700
+                                                            }
+                                                        />
+                                                    ) : (
+                                                        <IconErrorFilled16
+                                                            color={
+                                                                colors.red700
+                                                            }
+                                                        />
+                                                    )}
+                                                    <span className="status-text">
+                                                        {validationMessage}
+                                                    </span>
+                                                </span>
+                                            )}
+                                        </div>
                                     </div>
                                     <FormulaToolbar
                                         onAddOperator={addItem}
@@ -591,8 +538,6 @@ const CalculationModal = ({
                                         canRemove={Boolean(selectedItemId)}
                                         isValidating={isValidating}
                                         isLoading={isLoading}
-                                        validationStatus={expressionStatus}
-                                        validationMessage={validationMessage}
                                     />
                                     <FormulaField
                                         items={expressionArray}

--- a/src/components/DataDimension/Calculation/CalculationModal.js
+++ b/src/components/DataDimension/Calculation/CalculationModal.js
@@ -6,7 +6,7 @@ import {
     ModalContent,
     ModalActions,
     ButtonStrip,
-    Help,
+    IconQuestion16,
     InputField,
     NoticeBox,
     Popper,
@@ -64,22 +64,42 @@ Key.propTypes = {
 
 const ShortcutsPopoverContent = () => (
     <div className="shortcuts">
+        <h4 className="shortcuts-header">{i18n.t('Usage tips')}</h4>
         <ul>
             <li>
+                {i18n.t(
+                    'Click or drag a data element or operator to add it to the formula.'
+                )}
+            </li>
+            <li>{i18n.t('Drag an item to reorder it.')}</li>
+            <li>
+                {i18n.t('Select an item, then click')}{' '}
+                <strong>{i18n.t('Remove item')}</strong>{' '}
+                {i18n.t('to delete it.')}
+            </li>
+        </ul>
+        <h4 className="shortcuts-header">{i18n.t('Keyboard shortcuts')}</h4>
+        <ul>
+            <li>
+                {i18n.t('Press')}{' '}
                 <span className="shortcut-keys">
                     <Key>Enter</Key>
+                    {i18n.t('or')}
                     <Key>Space</Key>
-                </span>
-                {i18n.t('Add or select the focused item')}
+                </span>{' '}
+                {i18n.t('to add or select the focused item.')}
             </li>
             <li>
+                {i18n.t('Press')}{' '}
                 <span className="shortcut-keys">
                     <Key>←</Key>
+                    {i18n.t('or')}
                     <Key>→</Key>
-                </span>
-                {i18n.t('Move the selected item')}
+                </span>{' '}
+                {i18n.t('to move the selected item.')}
             </li>
             <li>
+                {i18n.t('Press')}{' '}
                 <span className="shortcut-keys">
                     <Key>+</Key>
                     <Key>-</Key>
@@ -87,15 +107,15 @@ const ShortcutsPopoverContent = () => (
                     <Key>/</Key>
                     <Key>(</Key>
                     <Key>)</Key>
-                </span>
-                {i18n.t('Insert an operator after the selected item')}
+                </span>{' '}
+                {i18n.t('to insert an operator after the selected item.')}
             </li>
         </ul>
         <style jsx>{styles}</style>
     </div>
 )
 
-const KeyboardNavigationHint = () => {
+const UsageHint = () => {
     const [isOpen, setIsOpen] = useState(false)
     const triggerRef = useRef()
 
@@ -105,17 +125,18 @@ const KeyboardNavigationHint = () => {
                 type="button"
                 className="hint-trigger"
                 ref={triggerRef}
-                data-test="keyboard-navigation-hint"
+                data-test="usage-hint"
+                aria-label={i18n.t('Usage tips')}
                 onMouseEnter={() => setIsOpen(true)}
                 onMouseLeave={() => setIsOpen(false)}
                 onFocus={() => setIsOpen(true)}
                 onBlur={() => setIsOpen(false)}
             >
-                {i18n.t('Keyboard navigation')}
+                <IconQuestion16 />
             </button>
             {isOpen && (
                 <Portal>
-                    <Popper placement="top-start" reference={triggerRef}>
+                    <Popper placement="bottom-start" reference={triggerRef}>
                         <ShortcutsPopoverContent />
                     </Popper>
                 </Portal>
@@ -536,16 +557,18 @@ const CalculationModal = ({
                             </div>
                             <div className="right-section">
                                 <div className="formula-section">
-                                    <h4 className="sub-header">
-                                        {i18n.t('Formula')}
-                                    </h4>
+                                    <div className="sub-header-row">
+                                        <h4 className="sub-header">
+                                            {i18n.t('Formula')}
+                                        </h4>
+                                        <UsageHint />
+                                    </div>
                                     <FormulaField
                                         items={expressionArray}
                                         selectedItemId={selectedItemId}
                                         focusItemId={focusItemId}
                                         onChange={setItemValue}
                                         onClick={selectItem}
-                                        onDoubleClick={removeItem}
                                         loading={!expressionArray}
                                     />
                                     <MathOperatorSelector onClick={addItem} />
@@ -592,16 +615,6 @@ const CalculationModal = ({
                                         </NoticeBox>
                                     </div>
                                 )}
-                                <div className="usage-legend">
-                                    <Help>
-                                        {i18n.t(
-                                            'Drag or click a data element or operator to add it to the formula. Drag to reorder. Select an item and click Remove item, or double-click, to delete it.'
-                                        )}
-                                    </Help>
-                                    <p className="see-also">
-                                        <KeyboardNavigationHint />
-                                    </p>
-                                </div>
                             </div>
                         </div>
                     </DndContext>

--- a/src/components/DataDimension/Calculation/CalculationModal.js
+++ b/src/components/DataDimension/Calculation/CalculationModal.js
@@ -14,6 +14,7 @@ import {
 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React, { useEffect, useRef, useState } from 'react'
+import css from 'styled-jsx/css'
 import {
     createCalculationMutation,
     deleteCalculationMutation,
@@ -33,6 +34,7 @@ import {
     VALID_EXPRESSION,
     getItemIdsFromExpression,
 } from '../../../modules/expressions.js'
+import { useModalContentWidth } from '../../../modules/useModalContentWidth.js'
 import { OfflineTooltip as Tooltip } from '../../OfflineTooltip.js'
 import DataElementSelector from './DataElementSelector.js'
 import DndContext, {
@@ -43,13 +45,25 @@ import FormulaField, {
     LAST_DROPZONE_ID,
     FORMULA_BOX_ID,
 } from './FormulaField.js'
-import MathOperatorSelector from './MathOperatorSelector.js'
+import FormulaToolbar from './FormulaToolbar.js'
 import styles from './styles/CalculationModal.style.js'
 
 const FIRST_POSITION = 0
 const LAST_POSITION = -1
 const CALCULATION_PROP_DEFAULT = {}
 const OPERATORS = getOperators()
+// Matches the content width of the previous fixed `large` Modal size, so
+// the modal never gets narrower than it used to on small windows.
+const MODAL_MIN_CONTENT_WIDTH = 740
+// Caps how far the modal grows on wide screens, so the two columns don't
+// stretch out further than is useful.
+const MODAL_MAX_CONTENT_WIDTH = 1000
+
+const getContentWidthCSS = (width) => css.resolve`
+    .content {
+        width: ${width}px;
+    }
+`
 
 const Key = ({ children }) => (
     <kbd className="key">
@@ -247,6 +261,12 @@ const CalculationModal = ({
 
     const [focusItemId, setFocusItemId] = useState(null)
     const [selectedItemId, setSelectedItemId] = useState(null)
+
+    const modalContentWidth = useModalContentWidth({
+        minWidth: MODAL_MIN_CONTENT_WIDTH,
+        maxWidth: MODAL_MAX_CONTENT_WIDTH,
+    })
+    const contentWidthCSS = getContentWidthCSS(modalContentWidth)
 
     const expressionStatus = validationOutput?.status
     const validationMessage =
@@ -522,7 +542,7 @@ const CalculationModal = ({
 
     return (
         <>
-            <Modal dataTest="calculation-modal" position="top" large>
+            <Modal dataTest="calculation-modal" position="top" fluid>
                 <ModalTitle dataTest="calculation-modal-title">
                     {calculation.id
                         ? i18n.t('Data / Edit calculation')
@@ -547,7 +567,7 @@ const CalculationModal = ({
                         onDragStart={() => setFocusItemId(null)}
                         onDragEnd={addOrMoveDraggedItem}
                     >
-                        <div className="content">
+                        <div className={`content ${contentWidthCSS.className}`}>
                             <div className="left-section">
                                 <DataElementSelector
                                     displayNameProp={displayNameProp}
@@ -563,6 +583,16 @@ const CalculationModal = ({
                                         </h4>
                                         <UsageHint />
                                     </div>
+                                    <FormulaToolbar
+                                        onAddOperator={addItem}
+                                        onRemove={() =>
+                                            removeItem(selectedItemId)
+                                        }
+                                        onValidate={validate}
+                                        canRemove={Boolean(selectedItemId)}
+                                        isValidating={isValidating}
+                                        isLoading={isLoading}
+                                    />
                                     <FormulaField
                                         items={expressionArray}
                                         selectedItemId={selectedItemId}
@@ -571,30 +601,6 @@ const CalculationModal = ({
                                         onClick={selectItem}
                                         loading={!expressionArray}
                                     />
-                                    <MathOperatorSelector onClick={addItem} />
-                                    <div className="formula-actions">
-                                        <Button
-                                            small
-                                            secondary
-                                            onClick={() =>
-                                                removeItem(selectedItemId)
-                                            }
-                                            dataTest="remove-button"
-                                            disabled={!selectedItemId}
-                                        >
-                                            {i18n.t('Remove item')}
-                                        </Button>
-                                        <Button
-                                            small
-                                            secondary
-                                            onClick={validate}
-                                            dataTest="validate-button"
-                                            loading={isValidating}
-                                            disabled={isLoading}
-                                        >
-                                            {i18n.t('Check formula')}
-                                        </Button>
-                                    </div>
                                 </div>
                                 {validationMessage && (
                                     <div
@@ -703,6 +709,7 @@ const CalculationModal = ({
                     </ModalActions>
                 </Modal>
             )}
+            {contentWidthCSS.styles}
             <style jsx>{styles}</style>
         </>
     )

--- a/src/components/DataDimension/Calculation/DataElementOption.js
+++ b/src/components/DataDimension/Calculation/DataElementOption.js
@@ -5,9 +5,10 @@ import React from 'react'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../../modules/dataTypes.js'
 import { getIcon } from '../../../modules/dimensionListItem.js'
 import { EXPRESSION_TYPE_DATA } from '../../../modules/expressions.js'
+import { onActivationKeydown } from './DndContext.js'
 import styles from './styles/DataElementOption.style.js'
 
-const DataElementOption = ({ label, value, onDoubleClick }) => {
+const DataElementOption = ({ label, value, onClick }) => {
     const data = { label, value, type: EXPRESSION_TYPE_DATA }
     const { attributes, listeners, setNodeRef, transform } = useSortable({
         id: value,
@@ -25,10 +26,11 @@ const DataElementOption = ({ label, value, onDoubleClick }) => {
                 {...listeners}
                 ref={setNodeRef}
                 style={style}
+                onKeyDown={onActivationKeydown(() => onClick(data))}
             >
                 <div
                     className="chip"
-                    onDoubleClick={() => onDoubleClick(data)}
+                    onClick={() => onClick(data)}
                     data-test="data-element-option"
                 >
                     <span className="icon">
@@ -45,7 +47,7 @@ const DataElementOption = ({ label, value, onDoubleClick }) => {
 DataElementOption.propTypes = {
     label: PropTypes.string,
     value: PropTypes.string,
-    onDoubleClick: PropTypes.func,
+    onClick: PropTypes.func,
 }
 
 export default DataElementOption

--- a/src/components/DataDimension/Calculation/DataElementSelector.js
+++ b/src/components/DataDimension/Calculation/DataElementSelector.js
@@ -127,7 +127,7 @@ DisaggregationSelector.propTypes = {
 
 const DataElementSelector = ({
     displayNameProp,
-    onDoubleClick,
+    onClick,
     height = SCROLLBOX_HEIGHT,
 }) => {
     const dataEngine = useDataEngine()
@@ -296,7 +296,7 @@ const DataElementSelector = ({
                                     key={value}
                                     label={label}
                                     value={value}
-                                    onDoubleClick={onDoubleClick}
+                                    onClick={onClick}
                                 />
                             ))}
                         {!loading && !options.length && (
@@ -325,7 +325,7 @@ const DataElementSelector = ({
 
 DataElementSelector.propTypes = {
     displayNameProp: PropTypes.string.isRequired,
-    onDoubleClick: PropTypes.func.isRequired,
+    onClick: PropTypes.func.isRequired,
     height: PropTypes.string,
 }
 

--- a/src/components/DataDimension/Calculation/DndContext.js
+++ b/src/components/DataDimension/Calculation/DndContext.js
@@ -79,20 +79,18 @@ const rectIntersectionCustom = ({
     return collisions.sort(sortCollisionsDesc)
 }
 
-const isInteractiveElement = (el) => {
-    const interactiveElements = [
-        'button',
-        'input',
-        'textarea',
-        'select',
-        'option',
-    ]
+const INTERACTIVE_SELECTOR = 'button, input, textarea, select, option'
 
-    if (interactiveElements.includes(el.tagName.toLowerCase())) {
-        return true
+export const isInteractiveElement = (el) =>
+    Boolean(el?.closest?.(INTERACTIVE_SELECTOR))
+
+// Mirrors a click on Enter/Space, so draggable chips (which aren't
+// natively clickable elements) can be activated from the keyboard.
+export const onActivationKeydown = (callback) => (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault()
+        callback()
     }
-
-    return false
 }
 
 // disable dragging if user is in an input

--- a/src/components/DataDimension/Calculation/FormulaField.js
+++ b/src/components/DataDimension/Calculation/FormulaField.js
@@ -32,7 +32,6 @@ const FormulaField = ({
     focusItemId,
     onChange,
     onClick,
-    onDoubleClick,
     loading,
 }) => {
     const { over, setNodeRef: setLastDropzoneRef } = useDroppable({
@@ -74,7 +73,6 @@ const FormulaField = ({
                                 isLast={index === items.length - 1}
                                 onChange={onChange}
                                 onClick={onClick}
-                                onDoubleClick={onDoubleClick}
                                 overLastDropZone={overLastDropZone}
                             />
                         ))}
@@ -88,7 +86,6 @@ const FormulaField = ({
 FormulaField.propTypes = {
     onChange: PropTypes.func.isRequired,
     onClick: PropTypes.func.isRequired,
-    onDoubleClick: PropTypes.func.isRequired,
     focusItemId: PropTypes.string,
     items: PropTypes.arrayOf(
         PropTypes.shape({

--- a/src/components/DataDimension/Calculation/FormulaField.js
+++ b/src/components/DataDimension/Calculation/FormulaField.js
@@ -17,7 +17,7 @@ const Placeholder = () => (
         <FormulaIcon />
         <span className="help-text">
             {i18n.t(
-                'Drag items here, or double click in the list, to start building a calculation formula'
+                'Drag a data element or operator here, or click one, to start building a formula'
             )}
         </span>
         <style jsx>{styles}</style>
@@ -44,45 +44,42 @@ const FormulaField = ({
     const overLastDropZone = over?.id === LAST_DROPZONE_ID
 
     return (
-        <div className="container">
-            <div className="border"></div>
-            <div
-                className="formula-field"
-                ref={setLastDropzoneRef}
-                data-test="formula-field"
-            >
-                {loading && (
-                    <Center>
-                        <CircularLoader small />
-                    </Center>
-                )}
-                {!loading && itemIds && (
-                    <SortableContext id={FORMULA_BOX_ID} items={itemIds}>
-                        <DropZone
-                            firstElementId={itemIds[0]}
-                            overLastDropZone={overLastDropZone}
-                        />
-                        {!items.length && <Placeholder />}
-                        {Boolean(items.length) &&
-                            items.map(({ id, label, type, value }, index) => (
-                                <FormulaItem
-                                    key={id}
-                                    id={id}
-                                    label={label}
-                                    type={type}
-                                    value={value}
-                                    hasFocus={focusItemId === id}
-                                    isHighlighted={selectedItemId === id}
-                                    isLast={index === items.length - 1}
-                                    onChange={onChange}
-                                    onClick={onClick}
-                                    onDoubleClick={onDoubleClick}
-                                    overLastDropZone={overLastDropZone}
-                                />
-                            ))}
-                    </SortableContext>
-                )}
-            </div>
+        <div
+            className="formula-field"
+            ref={setLastDropzoneRef}
+            data-test="formula-field"
+        >
+            {loading && (
+                <Center>
+                    <CircularLoader small />
+                </Center>
+            )}
+            {!loading && (
+                <SortableContext id={FORMULA_BOX_ID} items={itemIds}>
+                    <DropZone
+                        firstElementId={itemIds[0]}
+                        overLastDropZone={overLastDropZone}
+                    />
+                    {!items.length && <Placeholder />}
+                    {Boolean(items.length) &&
+                        items.map(({ id, label, type, value }, index) => (
+                            <FormulaItem
+                                key={id}
+                                id={id}
+                                label={label}
+                                type={type}
+                                value={value}
+                                hasFocus={focusItemId === id}
+                                isHighlighted={selectedItemId === id}
+                                isLast={index === items.length - 1}
+                                onChange={onChange}
+                                onClick={onClick}
+                                onDoubleClick={onDoubleClick}
+                                overLastDropZone={overLastDropZone}
+                            />
+                        ))}
+                </SortableContext>
+            )}
             <style jsx>{styles}</style>
         </div>
     )

--- a/src/components/DataDimension/Calculation/FormulaItem.js
+++ b/src/components/DataDimension/Calculation/FormulaItem.js
@@ -3,22 +3,21 @@ import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import cx from 'classnames'
 import PropTypes from 'prop-types'
-import React, { useState, useRef, useEffect } from 'react'
+import React, { useRef, useEffect } from 'react'
 import { DIMENSION_TYPE_DATA_ELEMENT } from '../../../modules/dataTypes.js'
 import { getIcon } from '../../../modules/dimensionListItem.js'
 import {
     EXPRESSION_TYPE_NUMBER,
     EXPRESSION_TYPE_DATA,
 } from '../../../modules/expressions.js'
+import { isInteractiveElement, onActivationKeydown } from './DndContext.js'
 import DragHandleIcon from './DragHandleIcon.js'
 import styles from './styles/FormulaItem.style.js'
 
 const BEFORE = 'BEFORE'
 const AFTER = 'AFTER'
 
-const maxMsBetweenClicks = 300
-
-const TAG_INPUT = 'INPUT'
+const DOUBLE_CLICK_THRESHOLD_MS = 300
 
 const FormulaItem = ({
     id,
@@ -49,8 +48,12 @@ const FormulaItem = ({
     })
 
     const inputRef = useRef(null)
+    const clickTimeoutRef = useRef(null)
+    const ignoreClickRef = useRef(false)
 
-    const [clickTimeoutId, setClickTimeoutId] = useState(null)
+    useEffect(() => {
+        return () => clearTimeout(clickTimeoutRef.current)
+    }, [])
 
     useEffect(() => {
         if (hasFocus && inputRef.current) {
@@ -97,29 +100,44 @@ const FormulaItem = ({
     }
 
     const handleClick = (e) => {
-        const tagname = e.target.tagName
-        clearTimeout(clickTimeoutId)
-        const to = setTimeout(function () {
-            if (tagname !== TAG_INPUT) {
-                onClick(id)
-            } else {
-                inputRef.current && inputRef.current.focus()
-            }
-        }, maxMsBetweenClicks)
-        setClickTimeoutId(to)
+        if (ignoreClickRef.current) {
+            ignoreClickRef.current = false
+            return
+        }
+        if (isInteractiveElement(e.target)) {
+            inputRef.current && inputRef.current.focus()
+            return
+        }
+        // Delay in case this click is the first of a double-click, so
+        // selecting the item doesn't flicker in between removing it.
+        clearTimeout(clickTimeoutRef.current)
+        clickTimeoutRef.current = setTimeout(() => {
+            onClick(id)
+        }, DOUBLE_CLICK_THRESHOLD_MS)
     }
 
     const handleDoubleClick = (e) => {
-        clearTimeout(clickTimeoutId)
-        setClickTimeoutId(null)
-        if (e.target.tagName !== TAG_INPUT) {
-            onDoubleClick(id)
-        } else {
+        if (isInteractiveElement(e.target)) {
             inputRef.current && inputRef.current.focus()
+            return
         }
+        clearTimeout(clickTimeoutRef.current)
+        onDoubleClick(id)
     }
 
     const handleChange = (e) => onChange({ itemId: id, value: e.target.value })
+
+    const handleKeyDown = (e) => {
+        if (isInteractiveElement(e.target)) {
+            return
+        }
+        if (e.key === 'Enter' || e.key === ' ') {
+            // role="button" from dnd-kit also synthesizes a click on Enter/Space;
+            // ignore that click so selection is not toggled off 300ms later.
+            ignoreClickRef.current = true
+        }
+        onActivationKeydown(() => onClick(id))(e)
+    }
 
     const getContent = () => {
         if (type === EXPRESSION_TYPE_NUMBER) {
@@ -196,6 +214,7 @@ const FormulaItem = ({
                     })}
                     onClick={handleClick}
                     onDoubleClick={handleDoubleClick}
+                    onKeyDown={handleKeyDown}
                     data-test={`formula-item-${id}`}
                 >
                     {getContent()}

--- a/src/components/DataDimension/Calculation/FormulaItem.js
+++ b/src/components/DataDimension/Calculation/FormulaItem.js
@@ -1,4 +1,3 @@
-import { Tooltip } from '@dhis2/ui'
 import { useSortable } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
 import cx from 'classnames'
@@ -147,19 +146,17 @@ const FormulaItem = ({
 
         if (type === EXPRESSION_TYPE_DATA) {
             return (
-                <Tooltip content={label} placement="bottom">
-                    <div
-                        className={cx('content', 'data', {
-                            highlighted: isHighlighted,
-                        })}
-                    >
-                        <span className="icon">
-                            {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
-                        </span>
-                        <span className="label">{label}</span>
-                        <style jsx>{styles}</style>
-                    </div>
-                </Tooltip>
+                <div
+                    className={cx('content', 'data', {
+                        highlighted: isHighlighted,
+                    })}
+                >
+                    <span className="icon">
+                        {getIcon(DIMENSION_TYPE_DATA_ELEMENT)}
+                    </span>
+                    <span className="label">{label}</span>
+                    <style jsx>{styles}</style>
+                </div>
             )
         }
 

--- a/src/components/DataDimension/Calculation/FormulaItem.js
+++ b/src/components/DataDimension/Calculation/FormulaItem.js
@@ -17,8 +17,6 @@ import styles from './styles/FormulaItem.style.js'
 const BEFORE = 'BEFORE'
 const AFTER = 'AFTER'
 
-const DOUBLE_CLICK_THRESHOLD_MS = 300
-
 const FormulaItem = ({
     id,
     label,
@@ -29,7 +27,6 @@ const FormulaItem = ({
     overLastDropZone,
     onChange,
     onClick,
-    onDoubleClick,
     hasFocus,
 }) => {
     const {
@@ -48,12 +45,7 @@ const FormulaItem = ({
     })
 
     const inputRef = useRef(null)
-    const clickTimeoutRef = useRef(null)
     const ignoreClickRef = useRef(false)
-
-    useEffect(() => {
-        return () => clearTimeout(clickTimeoutRef.current)
-    }, [])
 
     useEffect(() => {
         if (hasFocus && inputRef.current) {
@@ -108,21 +100,7 @@ const FormulaItem = ({
             inputRef.current && inputRef.current.focus()
             return
         }
-        // Delay in case this click is the first of a double-click, so
-        // selecting the item doesn't flicker in between removing it.
-        clearTimeout(clickTimeoutRef.current)
-        clickTimeoutRef.current = setTimeout(() => {
-            onClick(id)
-        }, DOUBLE_CLICK_THRESHOLD_MS)
-    }
-
-    const handleDoubleClick = (e) => {
-        if (isInteractiveElement(e.target)) {
-            inputRef.current && inputRef.current.focus()
-            return
-        }
-        clearTimeout(clickTimeoutRef.current)
-        onDoubleClick(id)
+        onClick(id)
     }
 
     const handleChange = (e) => onChange({ itemId: id, value: e.target.value })
@@ -133,7 +111,7 @@ const FormulaItem = ({
         }
         if (e.key === 'Enter' || e.key === ' ') {
             // role="button" from dnd-kit also synthesizes a click on Enter/Space;
-            // ignore that click so selection is not toggled off 300ms later.
+            // ignore that click so selection is not toggled off right after.
             ignoreClickRef.current = true
         }
         onActivationKeydown(() => onClick(id))(e)
@@ -213,7 +191,6 @@ const FormulaItem = ({
                         insertAfter: insertPosition === AFTER,
                     })}
                     onClick={handleClick}
-                    onDoubleClick={handleDoubleClick}
                     onKeyDown={handleKeyDown}
                     data-test={`formula-item-${id}`}
                 >
@@ -231,7 +208,6 @@ FormulaItem.propTypes = {
     type: PropTypes.string.isRequired,
     onChange: PropTypes.func.isRequired,
     onClick: PropTypes.func.isRequired,
-    onDoubleClick: PropTypes.func.isRequired,
     hasFocus: PropTypes.bool,
     isHighlighted: PropTypes.bool,
     isLast: PropTypes.bool,

--- a/src/components/DataDimension/Calculation/FormulaToolbar.js
+++ b/src/components/DataDimension/Calculation/FormulaToolbar.js
@@ -1,7 +1,15 @@
-import { Button, ButtonStrip } from '@dhis2/ui'
+import {
+    Button,
+    ButtonStrip,
+    IconCheckmarkCircle16,
+    IconErrorFilled16,
+    colors,
+} from '@dhis2/ui'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React from 'react'
 import i18n from '../../../locales/index.js'
+import { VALID_EXPRESSION } from '../../../modules/expressions.js'
 import MathOperatorSelector from './MathOperatorSelector.js'
 import styles from './styles/FormulaToolbar.style.js'
 
@@ -12,31 +20,51 @@ const FormulaToolbar = ({
     canRemove,
     isValidating,
     isLoading,
+    validationStatus,
+    validationMessage,
 }) => (
     <div className="formula-toolbar">
-        <MathOperatorSelector onClick={onAddOperator} />
-        <span className="divider" />
-        <ButtonStrip>
-            <Button
-                small
-                secondary
-                onClick={onRemove}
-                dataTest="remove-button"
-                disabled={!canRemove}
-            >
-                {i18n.t('Remove item')}
-            </Button>
-            <Button
-                small
-                secondary
-                onClick={onValidate}
-                dataTest="validate-button"
-                loading={isValidating}
-                disabled={isLoading}
-            >
-                {i18n.t('Check formula')}
-            </Button>
-        </ButtonStrip>
+        <div className="buttons-row">
+            <MathOperatorSelector onClick={onAddOperator} />
+            <span className="divider" />
+            <ButtonStrip>
+                <Button
+                    small
+                    secondary
+                    onClick={onRemove}
+                    dataTest="remove-button"
+                    disabled={!canRemove}
+                >
+                    {i18n.t('Remove item')}
+                </Button>
+                <Button
+                    small
+                    secondary
+                    onClick={onValidate}
+                    dataTest="validate-button"
+                    loading={isValidating}
+                    disabled={isLoading}
+                >
+                    {i18n.t('Check formula')}
+                </Button>
+            </ButtonStrip>
+        </div>
+        <div aria-live="polite" data-test="validation-message">
+            {validationMessage && (
+                <span
+                    className={cx('status', {
+                        valid: validationStatus === VALID_EXPRESSION,
+                    })}
+                >
+                    {validationStatus === VALID_EXPRESSION ? (
+                        <IconCheckmarkCircle16 color={colors.green700} />
+                    ) : (
+                        <IconErrorFilled16 color={colors.red700} />
+                    )}
+                    <span className="status-text">{validationMessage}</span>
+                </span>
+            )}
+        </div>
         <style jsx>{styles}</style>
     </div>
 )
@@ -48,6 +76,8 @@ FormulaToolbar.propTypes = {
     canRemove: PropTypes.bool,
     isLoading: PropTypes.bool,
     isValidating: PropTypes.bool,
+    validationMessage: PropTypes.string,
+    validationStatus: PropTypes.string,
 }
 
 export default FormulaToolbar

--- a/src/components/DataDimension/Calculation/FormulaToolbar.js
+++ b/src/components/DataDimension/Calculation/FormulaToolbar.js
@@ -1,0 +1,53 @@
+import { Button, ButtonStrip } from '@dhis2/ui'
+import PropTypes from 'prop-types'
+import React from 'react'
+import i18n from '../../../locales/index.js'
+import MathOperatorSelector from './MathOperatorSelector.js'
+import styles from './styles/FormulaToolbar.style.js'
+
+const FormulaToolbar = ({
+    onAddOperator,
+    onRemove,
+    onValidate,
+    canRemove,
+    isValidating,
+    isLoading,
+}) => (
+    <div className="formula-toolbar">
+        <MathOperatorSelector onClick={onAddOperator} />
+        <span className="divider" />
+        <ButtonStrip>
+            <Button
+                small
+                secondary
+                onClick={onRemove}
+                dataTest="remove-button"
+                disabled={!canRemove}
+            >
+                {i18n.t('Remove item')}
+            </Button>
+            <Button
+                small
+                secondary
+                onClick={onValidate}
+                dataTest="validate-button"
+                loading={isValidating}
+                disabled={isLoading}
+            >
+                {i18n.t('Check formula')}
+            </Button>
+        </ButtonStrip>
+        <style jsx>{styles}</style>
+    </div>
+)
+
+FormulaToolbar.propTypes = {
+    onAddOperator: PropTypes.func.isRequired,
+    onRemove: PropTypes.func.isRequired,
+    onValidate: PropTypes.func.isRequired,
+    canRemove: PropTypes.bool,
+    isLoading: PropTypes.bool,
+    isValidating: PropTypes.bool,
+}
+
+export default FormulaToolbar

--- a/src/components/DataDimension/Calculation/FormulaToolbar.js
+++ b/src/components/DataDimension/Calculation/FormulaToolbar.js
@@ -1,15 +1,7 @@
-import {
-    Button,
-    ButtonStrip,
-    IconCheckmarkCircle16,
-    IconErrorFilled16,
-    colors,
-} from '@dhis2/ui'
-import cx from 'classnames'
+import { Button, ButtonStrip, IconDelete16 } from '@dhis2/ui'
 import PropTypes from 'prop-types'
 import React from 'react'
 import i18n from '../../../locales/index.js'
-import { VALID_EXPRESSION } from '../../../modules/expressions.js'
 import MathOperatorSelector from './MathOperatorSelector.js'
 import styles from './styles/FormulaToolbar.style.js'
 
@@ -20,23 +12,22 @@ const FormulaToolbar = ({
     canRemove,
     isValidating,
     isLoading,
-    validationStatus,
-    validationMessage,
 }) => (
     <div className="formula-toolbar">
         <div className="buttons-row">
             <MathOperatorSelector onClick={onAddOperator} />
-            <span className="divider" />
             <ButtonStrip>
-                <Button
-                    small
-                    secondary
-                    onClick={onRemove}
-                    dataTest="remove-button"
-                    disabled={!canRemove}
-                >
-                    {i18n.t('Remove item')}
-                </Button>
+                {canRemove && (
+                    <Button
+                        small
+                        secondary
+                        icon={<IconDelete16 />}
+                        onClick={onRemove}
+                        dataTest="remove-button"
+                    >
+                        {i18n.t('Remove item')}
+                    </Button>
+                )}
                 <Button
                     small
                     secondary
@@ -49,22 +40,6 @@ const FormulaToolbar = ({
                 </Button>
             </ButtonStrip>
         </div>
-        <div aria-live="polite" data-test="validation-message">
-            {validationMessage && (
-                <span
-                    className={cx('status', {
-                        valid: validationStatus === VALID_EXPRESSION,
-                    })}
-                >
-                    {validationStatus === VALID_EXPRESSION ? (
-                        <IconCheckmarkCircle16 color={colors.green700} />
-                    ) : (
-                        <IconErrorFilled16 color={colors.red700} />
-                    )}
-                    <span className="status-text">{validationMessage}</span>
-                </span>
-            )}
-        </div>
         <style jsx>{styles}</style>
     </div>
 )
@@ -76,8 +51,6 @@ FormulaToolbar.propTypes = {
     canRemove: PropTypes.bool,
     isLoading: PropTypes.bool,
     isValidating: PropTypes.bool,
-    validationMessage: PropTypes.string,
-    validationStatus: PropTypes.string,
 }
 
 export default FormulaToolbar

--- a/src/components/DataDimension/Calculation/MathOperatorSelector.js
+++ b/src/components/DataDimension/Calculation/MathOperatorSelector.js
@@ -8,19 +8,17 @@ const OPERATORS = getOperators()
 
 const MathOperatorSelector = ({ onClick }) => (
     <>
-        <div className="wrapper">
-            <div className="operators" data-test="operators-list">
-                {OPERATORS.map(({ label, value, type }, index) => (
-                    <DraggableOperator
-                        key={`${label}-${index}`}
-                        label={label}
-                        value={value}
-                        type={type}
-                        index={index}
-                        onClick={onClick}
-                    />
-                ))}
-            </div>
+        <div className="operators" data-test="operators-list">
+            {OPERATORS.map(({ label, value, type }, index) => (
+                <DraggableOperator
+                    key={`${label}-${index}`}
+                    label={label}
+                    value={value}
+                    type={type}
+                    index={index}
+                    onClick={onClick}
+                />
+            ))}
         </div>
         <style jsx>{styles}</style>
     </>

--- a/src/components/DataDimension/Calculation/MathOperatorSelector.js
+++ b/src/components/DataDimension/Calculation/MathOperatorSelector.js
@@ -1,23 +1,23 @@
 import PropTypes from 'prop-types'
 import React from 'react'
-import i18n from '../../../locales/index.js'
 import { getOperators } from '../../../modules/expressions.js'
 import DraggableOperator from './Operator.js'
 import styles from './styles/MathOperatorSelector.style.js'
 
-const MathOperatorSelector = ({ onDoubleClick }) => (
+const OPERATORS = getOperators()
+
+const MathOperatorSelector = ({ onClick }) => (
     <>
         <div className="wrapper">
-            <h4 className="sub-header">{i18n.t('Math operators')}</h4>
             <div className="operators" data-test="operators-list">
-                {getOperators().map(({ label, value, type }, index) => (
+                {OPERATORS.map(({ label, value, type }, index) => (
                     <DraggableOperator
                         key={`${label}-${index}`}
                         label={label}
                         value={value}
                         type={type}
                         index={index}
-                        onDoubleClick={onDoubleClick}
+                        onClick={onClick}
                     />
                 ))}
             </div>
@@ -27,7 +27,7 @@ const MathOperatorSelector = ({ onDoubleClick }) => (
 )
 
 MathOperatorSelector.propTypes = {
-    onDoubleClick: PropTypes.func.isRequired,
+    onClick: PropTypes.func.isRequired,
 }
 
 export default MathOperatorSelector

--- a/src/components/DataDimension/Calculation/Operator.js
+++ b/src/components/DataDimension/Calculation/Operator.js
@@ -7,10 +7,11 @@ import {
     EXPRESSION_TYPE_NUMBER,
     EXPRESSION_TYPE_OPERATOR,
 } from '../../../modules/expressions.js'
+import { onActivationKeydown } from './DndContext.js'
 import formulaItemStyles from './styles/FormulaItem.style.js'
 import styles from './styles/Operator.style.js'
 
-const Operator = ({ label, value, type, onDoubleClick }) => {
+const Operator = ({ label, value, type, onClick }) => {
     const data = { label, value, type }
     const { attributes, listeners, setNodeRef, transform } = useSortable({
         id: `operator-${label}`,
@@ -21,14 +22,20 @@ const Operator = ({ label, value, type, onDoubleClick }) => {
     }
 
     return (
-        <div {...attributes} {...listeners} ref={setNodeRef} style={style}>
+        <div
+            {...attributes}
+            {...listeners}
+            ref={setNodeRef}
+            style={style}
+            onKeyDown={onActivationKeydown(() => onClick(data))}
+        >
             <div
                 className={cx('content', {
                     operator: type === EXPRESSION_TYPE_OPERATOR,
                     number: type === EXPRESSION_TYPE_NUMBER,
                 })}
                 data-test="operator"
-                onDoubleClick={() => onDoubleClick(data)}
+                onClick={() => onClick(data)}
             >
                 <span>{label}</span>
             </div>
@@ -42,7 +49,7 @@ Operator.propTypes = {
     label: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
     value: PropTypes.string.isRequired,
-    onDoubleClick: PropTypes.func.isRequired,
+    onClick: PropTypes.func.isRequired,
 }
 
 export default Operator

--- a/src/components/DataDimension/Calculation/styles/CalculationModal.style.js
+++ b/src/components/DataDimension/Calculation/styles/CalculationModal.style.js
@@ -11,13 +11,6 @@ export default css`
         margin-top: ${spacers.dp8};
     }
 
-    .formula-actions {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        padding: ${spacers.dp8};
-    }
-
     .delete-button {
         margin-right: ${spacers.dp8};
     }

--- a/src/components/DataDimension/Calculation/styles/CalculationModal.style.js
+++ b/src/components/DataDimension/Calculation/styles/CalculationModal.style.js
@@ -1,14 +1,25 @@
-import { colors, elevations, spacers } from '@dhis2/ui'
+import { colors, spacers } from '@dhis2/ui'
 import css from 'styled-jsx/css'
 
 export default css`
     .formula-section {
+        /* Match left column height; FormulaField scrolls inside. */
+        position: absolute;
+        inset: 0;
         background: ${colors.white};
         border: 1px solid ${colors.grey400};
         display: flex;
         flex-direction: column;
-        flex: 1;
+        overflow: hidden;
         min-height: 0;
+    }
+
+    .formula-section.valid {
+        border-color: ${colors.green500};
+    }
+
+    .formula-section.invalid {
+        border-color: ${colors.red500};
     }
 
     .delete-button {
@@ -18,107 +29,64 @@ export default css`
     .content {
         display: flex;
         gap: ${spacers.dp12};
+        align-items: stretch;
     }
 
     .left-section {
         width: 40%;
+        flex-shrink: 0;
     }
 
     .right-section {
         width: 60%;
         font-size: 14px;
-        display: flex;
-        flex-direction: column;
+        position: relative;
         min-height: 0;
     }
 
     .sub-header-row {
         display: flex;
         align-items: center;
-        margin: ${spacers.dp4} ${spacers.dp8};
+        gap: ${spacers.dp8};
+        padding: ${spacers.dp8} ${spacers.dp8} 0;
+        /* Reserve space for status text so the row doesn't jump when it appears */
+        min-height: calc(${spacers.dp8} + 19px);
+        box-sizing: border-box;
+        flex-shrink: 0;
     }
 
     .sub-header {
         font-size: 14px;
         font-weight: normal;
         margin: 0;
+        flex-shrink: 0;
+    }
+
+    .validation-status {
+        margin-left: auto;
+        min-width: 0;
+        display: flex;
+        justify-content: flex-end;
+    }
+
+    .status {
+        display: inline-flex;
+        align-items: center;
+        gap: ${spacers.dp4};
+        min-width: 0;
+    }
+
+    .status-text {
+        color: ${colors.red700};
+        font-size: 14px;
+        line-height: 19px;
+    }
+
+    .valid .status-text {
+        color: ${colors.green700};
     }
 
     .name-field {
         margin-bottom: ${spacers.dp16};
-    }
-
-    .hint {
-        position: relative;
-        display: inline-flex;
-    }
-
-    .hint-trigger {
-        display: inline-flex;
-        align-items: center;
-        padding: ${spacers.dp4} ${spacers.dp4} ${spacers.dp4} 4px;
-        background: none;
-        border: none;
-        color: ${colors.grey600};
-        cursor: default;
-    }
-
-    .shortcuts {
-        background: ${colors.white};
-        border-radius: 4px;
-        box-shadow: ${elevations.popover};
-        padding: ${spacers.dp12} ${spacers.dp16};
-        max-width: 364px;
-        color: ${colors.grey900};
-        font-size: 14px;
-    }
-
-    .shortcuts-header {
-        margin: ${spacers.dp12} 0 ${spacers.dp8};
-        text-transform: uppercase;
-        font-size: 11px;
-        font-weight: 400;
-        letter-spacing: 0.3px;
-        color: ${colors.grey600};
-    }
-
-    .shortcuts-header:first-child {
-        margin-top: 0;
-    }
-
-    .shortcuts ul {
-        margin: 0;
-        padding-left: ${spacers.dp16};
-    }
-
-    .shortcuts li {
-        margin: 0 0 ${spacers.dp8};
-        line-height: 1.5;
-    }
-
-    .shortcuts li:last-child {
-        margin-bottom: 0;
-    }
-
-    .shortcut-keys {
-        display: inline-flex;
-        align-items: center;
-        flex-wrap: wrap;
-        gap: ${spacers.dp4};
-        vertical-align: middle;
-    }
-
-    .key {
-        display: inline-block;
-        min-width: 1.4em;
-        padding: 1px 5px;
-        border: 1px solid ${colors.grey400};
-        border-radius: 3px;
-        background: ${colors.grey050};
-        box-shadow: 0 1px 0 ${colors.grey400};
-        font-family: monospace;
-        font-size: 12px;
-        line-height: 1.4;
-        text-align: center;
     }
 `

--- a/src/components/DataDimension/Calculation/styles/CalculationModal.style.js
+++ b/src/components/DataDimension/Calculation/styles/CalculationModal.style.js
@@ -14,12 +14,24 @@ export default css`
         min-height: 0;
     }
 
-    .formula-section.valid {
-        border-color: ${colors.green500};
+    .formula-box {
+        position: relative;
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+        overflow: hidden;
+        border-top: 1px solid ${colors.grey400};
     }
 
-    .formula-section.invalid {
-        border-color: ${colors.red500};
+    .formula-box.valid {
+        border-top-color: transparent;
+        box-shadow: inset 0 0 0 1px ${colors.green500};
+    }
+
+    .formula-box.invalid {
+        border-top-color: transparent;
+        box-shadow: inset 0 0 0 1px ${colors.red500};
     }
 
     .delete-button {
@@ -49,8 +61,6 @@ export default css`
         align-items: center;
         gap: ${spacers.dp8};
         padding: ${spacers.dp8} ${spacers.dp8} 0;
-        /* Reserve space for status text so the row doesn't jump when it appears */
-        min-height: calc(${spacers.dp8} + 19px);
         box-sizing: border-box;
         flex-shrink: 0;
     }
@@ -62,11 +72,31 @@ export default css`
         flex-shrink: 0;
     }
 
-    .validation-status {
-        margin-left: auto;
-        min-width: 0;
+    /* Clear chips under the overlay bar when validation is shown */
+    .formula-box.valid :global(.formula-field),
+    .formula-box.invalid :global(.formula-field) {
+        padding-bottom: 40px;
+    }
+
+    .validation-bar {
+        position: absolute;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: 1;
         display: flex;
-        justify-content: flex-end;
+        align-items: center;
+        gap: ${spacers.dp4};
+        padding: ${spacers.dp8} ${spacers.dp12};
+        box-sizing: border-box;
+        background: ${colors.red050};
+        outline: 1px solid ${colors.red500};
+        outline-offset: -1px;
+    }
+
+    .formula-box.valid .validation-bar {
+        background: ${colors.green050};
+        outline-color: ${colors.green500};
     }
 
     .status {
@@ -80,6 +110,7 @@ export default css`
         color: ${colors.red700};
         font-size: 14px;
         line-height: 19px;
+        min-width: 0;
     }
 
     .valid .status-text {

--- a/src/components/DataDimension/Calculation/styles/CalculationModal.style.js
+++ b/src/components/DataDimension/Calculation/styles/CalculationModal.style.js
@@ -1,35 +1,21 @@
-import { colors, spacers } from '@dhis2/ui'
+import { colors, elevations, spacers } from '@dhis2/ui'
 import css from 'styled-jsx/css'
 
 export default css`
-    .header {
-        background: ${colors.grey200};
-        padding: ${spacers.dp16};
-        font-weight: normal;
+    .formula-section {
+        background: ${colors.white};
+        border: 1px solid ${colors.grey400};
     }
 
-    .header-icon {
-        padding: 0 ${spacers.dp8};
-        vertical-align: text-bottom;
-        line-height: 14px;
+    .validation-notice {
+        margin-top: ${spacers.dp8};
     }
 
-    .actions-wrapper {
-        margin-top: ${spacers.dp16};
-        margin-bottom: ${spacers.dp16};
-        margin-left: ${spacers.dp4};
-    }
-
-    .button-container {
-        display: inline-flex;
-    }
-
-    .validate-button {
-        margin-bottom: ${spacers.dp4};
-    }
-
-    .remove-button {
-        margin-right: ${spacers.dp8};
+    .formula-actions {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: ${spacers.dp8};
     }
 
     .delete-button {
@@ -38,31 +24,103 @@ export default css`
 
     .content {
         display: flex;
+        gap: ${spacers.dp12};
     }
 
     .left-section {
-        width: 45%;
+        width: 40%;
     }
 
     .right-section {
-        width: 55%;
-        padding-left: ${spacers.dp8};
+        width: 60%;
+        font-size: 14px;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .sub-header {
+        font-size: 14px;
+        font-weight: normal;
+        margin: ${spacers.dp4} ${spacers.dp8};
+    }
+
+    .name-field {
+        margin-bottom: ${spacers.dp16};
+    }
+
+    .usage-legend {
+        display: flex;
+        flex-direction: column;
+        gap: ${spacers.dp4};
+        padding-top: ${spacers.dp4};
+    }
+
+    .see-also {
+        margin: 0;
+        font-size: 12px;
+        line-height: 14px;
+        color: ${colors.grey700};
+    }
+
+    .hint {
+        position: relative;
+    }
+
+    .hint-trigger {
+        background: none;
+        border: none;
+        padding: 0;
+        font: inherit;
+        color: inherit;
+        text-decoration: underline dotted;
+        text-underline-offset: 2px;
+        cursor: help;
+        white-space: nowrap;
+    }
+
+    .shortcuts {
+        background: ${colors.white};
+        border-radius: 4px;
+        box-shadow: ${elevations.popover};
+        padding: ${spacers.dp12} ${spacers.dp16};
+        max-width: 340px;
+        color: ${colors.grey900};
         font-size: 14px;
     }
 
-    .validation-message {
-        margin-left: ${spacers.dp8};
+    .shortcuts ul {
+        margin: 0;
+        padding: 0;
+        list-style: none;
+        display: flex;
+        flex-direction: column;
+        gap: ${spacers.dp8};
     }
 
-    .validation-error {
-        color: ${colors.red500};
+    .shortcuts li {
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+        gap: ${spacers.dp4};
     }
 
-    .validation-success {
-        color: ${colors.green500};
+    .shortcut-keys {
+        display: flex;
+        flex-wrap: wrap;
+        gap: ${spacers.dp4};
     }
 
-    .name-input {
-        margin-top: ${spacers.dp12};
+    .key {
+        display: inline-block;
+        min-width: 1.4em;
+        padding: 1px 5px;
+        border: 1px solid ${colors.grey400};
+        border-radius: 3px;
+        background: ${colors.grey050};
+        box-shadow: 0 1px 0 ${colors.grey400};
+        font-family: monospace;
+        font-size: 12px;
+        line-height: 1.4;
+        text-align: center;
     }
 `

--- a/src/components/DataDimension/Calculation/styles/CalculationModal.style.js
+++ b/src/components/DataDimension/Calculation/styles/CalculationModal.style.js
@@ -38,44 +38,35 @@ export default css`
         flex-direction: column;
     }
 
+    .sub-header-row {
+        display: flex;
+        align-items: center;
+        margin: ${spacers.dp4} ${spacers.dp8};
+    }
+
     .sub-header {
         font-size: 14px;
         font-weight: normal;
-        margin: ${spacers.dp4} ${spacers.dp8};
+        margin: 0;
     }
 
     .name-field {
         margin-bottom: ${spacers.dp16};
     }
 
-    .usage-legend {
-        display: flex;
-        flex-direction: column;
-        gap: ${spacers.dp4};
-        padding-top: ${spacers.dp4};
-    }
-
-    .see-also {
-        margin: 0;
-        font-size: 12px;
-        line-height: 14px;
-        color: ${colors.grey700};
-    }
-
     .hint {
         position: relative;
+        display: inline-flex;
     }
 
     .hint-trigger {
+        display: inline-flex;
+        align-items: center;
+        padding: ${spacers.dp4} ${spacers.dp4} ${spacers.dp4} 4px;
         background: none;
         border: none;
-        padding: 0;
-        font: inherit;
-        color: inherit;
-        text-decoration: underline dotted;
-        text-underline-offset: 2px;
-        cursor: help;
-        white-space: nowrap;
+        color: ${colors.grey600};
+        cursor: default;
     }
 
     .shortcuts {
@@ -83,31 +74,44 @@ export default css`
         border-radius: 4px;
         box-shadow: ${elevations.popover};
         padding: ${spacers.dp12} ${spacers.dp16};
-        max-width: 340px;
+        max-width: 364px;
         color: ${colors.grey900};
         font-size: 14px;
     }
 
+    .shortcuts-header {
+        margin: ${spacers.dp12} 0 ${spacers.dp8};
+        text-transform: uppercase;
+        font-size: 11px;
+        font-weight: 400;
+        letter-spacing: 0.3px;
+        color: ${colors.grey600};
+    }
+
+    .shortcuts-header:first-child {
+        margin-top: 0;
+    }
+
     .shortcuts ul {
         margin: 0;
-        padding: 0;
-        list-style: none;
-        display: flex;
-        flex-direction: column;
-        gap: ${spacers.dp8};
+        padding-left: ${spacers.dp16};
     }
 
     .shortcuts li {
-        margin: 0;
-        display: flex;
-        flex-direction: column;
-        gap: ${spacers.dp4};
+        margin: 0 0 ${spacers.dp8};
+        line-height: 1.5;
+    }
+
+    .shortcuts li:last-child {
+        margin-bottom: 0;
     }
 
     .shortcut-keys {
-        display: flex;
+        display: inline-flex;
+        align-items: center;
         flex-wrap: wrap;
         gap: ${spacers.dp4};
+        vertical-align: middle;
     }
 
     .key {

--- a/src/components/DataDimension/Calculation/styles/CalculationModal.style.js
+++ b/src/components/DataDimension/Calculation/styles/CalculationModal.style.js
@@ -11,10 +11,6 @@ export default css`
         min-height: 0;
     }
 
-    .validation-notice {
-        margin-top: ${spacers.dp8};
-    }
-
     .delete-button {
         margin-right: ${spacers.dp8};
     }

--- a/src/components/DataDimension/Calculation/styles/CalculationModal.style.js
+++ b/src/components/DataDimension/Calculation/styles/CalculationModal.style.js
@@ -5,6 +5,10 @@ export default css`
     .formula-section {
         background: ${colors.white};
         border: 1px solid ${colors.grey400};
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+        min-height: 0;
     }
 
     .validation-notice {
@@ -29,6 +33,7 @@ export default css`
         font-size: 14px;
         display: flex;
         flex-direction: column;
+        min-height: 0;
     }
 
     .sub-header-row {

--- a/src/components/DataDimension/Calculation/styles/FormulaField.style.js
+++ b/src/components/DataDimension/Calculation/styles/FormulaField.style.js
@@ -5,7 +5,7 @@ export default css`
     .formula-field {
         border-top: 1px solid ${colors.grey400};
         flex: 1;
-        min-height: 180px;
+        min-height: 0;
         overflow: auto;
         padding: 6px 12px;
         position: relative;

--- a/src/components/DataDimension/Calculation/styles/FormulaField.style.js
+++ b/src/components/DataDimension/Calculation/styles/FormulaField.style.js
@@ -4,7 +4,8 @@ import css from 'styled-jsx/css'
 export default css`
     .formula-field {
         border-top: 1px solid ${colors.grey400};
-        height: 180px;
+        flex: 1;
+        min-height: 180px;
         overflow: auto;
         padding: 6px 12px;
         position: relative;

--- a/src/components/DataDimension/Calculation/styles/FormulaField.style.js
+++ b/src/components/DataDimension/Calculation/styles/FormulaField.style.js
@@ -3,7 +3,8 @@ import css from 'styled-jsx/css'
 
 export default css`
     .formula-field {
-        border-right: 2px solid ${colors.grey200};
+        border-top: 1px solid ${colors.grey400};
+        border-bottom: 1px solid ${colors.grey400};
         height: 180px;
         overflow: auto;
         padding: 6px 12px;
@@ -16,23 +17,9 @@ export default css`
         width: 100%;
     }
 
-    .container {
-        position: relative;
-    }
-
-    .border {
-        position: absolute;
-        top: 0;
-        left: 6px;
-        height: 180px;
-        width: calc(100% - 6px);
-        border-left: 2px solid ${colors.grey200};
-        border-top: 2px solid ${colors.grey200};
-        border-bottom: 2px solid ${colors.grey200};
-    }
-
     .placeholder {
         height: 100%;
+        width: 100%;
         display: flex;
         flex-direction: column;
         gap: ${spacers.dp8};
@@ -40,12 +27,14 @@ export default css`
         justify-content: center;
         margin-top: -28px;
         padding: 0 ${spacers.dp32};
+        text-align: center;
     }
 
     .help-text {
         color: ${colors.grey600};
         font-size: 14px;
         line-height: 19px;
+        text-align: center;
         user-select: none;
     }
 `

--- a/src/components/DataDimension/Calculation/styles/FormulaField.style.js
+++ b/src/components/DataDimension/Calculation/styles/FormulaField.style.js
@@ -4,7 +4,6 @@ import css from 'styled-jsx/css'
 export default css`
     .formula-field {
         border-top: 1px solid ${colors.grey400};
-        border-bottom: 1px solid ${colors.grey400};
         height: 180px;
         overflow: auto;
         padding: 6px 12px;

--- a/src/components/DataDimension/Calculation/styles/FormulaField.style.js
+++ b/src/components/DataDimension/Calculation/styles/FormulaField.style.js
@@ -3,7 +3,6 @@ import css from 'styled-jsx/css'
 
 export default css`
     .formula-field {
-        border-top: 1px solid ${colors.grey400};
         flex: 1;
         min-height: 0;
         overflow: auto;

--- a/src/components/DataDimension/Calculation/styles/FormulaItem.style.js
+++ b/src/components/DataDimension/Calculation/styles/FormulaItem.style.js
@@ -45,9 +45,6 @@ export default css`
     }
 
     .data .label {
-        max-width: 280px;
-        text-overflow: ellipsis;
-        overflow: hidden;
         white-space: nowrap;
     }
 

--- a/src/components/DataDimension/Calculation/styles/FormulaToolbar.style.js
+++ b/src/components/DataDimension/Calculation/styles/FormulaToolbar.style.js
@@ -1,38 +1,17 @@
-import { colors, spacers } from '@dhis2/ui'
+import { spacers } from '@dhis2/ui'
 import css from 'styled-jsx/css'
 
 export default css`
     .formula-toolbar {
         padding: ${spacers.dp8};
+        flex-shrink: 0;
     }
 
     .buttons-row {
         display: flex;
         flex-wrap: wrap;
+        justify-content: space-between;
         align-items: center;
         gap: ${spacers.dp8};
-    }
-
-    .divider {
-        align-self: stretch;
-        width: 1px;
-        background: ${colors.grey400};
-    }
-
-    .status {
-        display: inline-flex;
-        align-items: center;
-        gap: ${spacers.dp4};
-        margin-top: ${spacers.dp4};
-    }
-
-    .status-text {
-        color: ${colors.red700};
-        font-size: 14px;
-        line-height: 19px;
-    }
-
-    .valid .status-text {
-        color: ${colors.green700};
     }
 `

--- a/src/components/DataDimension/Calculation/styles/FormulaToolbar.style.js
+++ b/src/components/DataDimension/Calculation/styles/FormulaToolbar.style.js
@@ -3,16 +3,36 @@ import css from 'styled-jsx/css'
 
 export default css`
     .formula-toolbar {
+        padding: ${spacers.dp8};
+    }
+
+    .buttons-row {
         display: flex;
         flex-wrap: wrap;
         align-items: center;
         gap: ${spacers.dp8};
-        padding: ${spacers.dp8};
     }
 
     .divider {
         align-self: stretch;
         width: 1px;
         background: ${colors.grey400};
+    }
+
+    .status {
+        display: inline-flex;
+        align-items: center;
+        gap: ${spacers.dp4};
+        margin-top: ${spacers.dp4};
+    }
+
+    .status-text {
+        color: ${colors.red700};
+        font-size: 14px;
+        line-height: 19px;
+    }
+
+    .valid .status-text {
+        color: ${colors.green700};
     }
 `

--- a/src/components/DataDimension/Calculation/styles/FormulaToolbar.style.js
+++ b/src/components/DataDimension/Calculation/styles/FormulaToolbar.style.js
@@ -1,0 +1,18 @@
+import { colors, spacers } from '@dhis2/ui'
+import css from 'styled-jsx/css'
+
+export default css`
+    .formula-toolbar {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: ${spacers.dp8};
+        padding: ${spacers.dp8};
+    }
+
+    .divider {
+        align-self: stretch;
+        width: 1px;
+        background: ${colors.grey400};
+    }
+`

--- a/src/components/DataDimension/Calculation/styles/MathOperatorSelector.style.js
+++ b/src/components/DataDimension/Calculation/styles/MathOperatorSelector.style.js
@@ -3,21 +3,13 @@ import css from 'styled-jsx/css'
 
 export default css`
     .wrapper {
-        border: 1px solid ${colors.grey400};
-        margin-top: ${spacers.dp8};
+        border-bottom: 1px solid ${colors.grey400};
     }
 
     .operators {
         display: flex;
         flex-wrap: wrap;
         gap: ${spacers.dp4};
-        padding: ${spacers.dp4};
-        border-top: 1px solid ${colors.grey400};
-    }
-
-    .sub-header {
-        font-size: 14px;
-        font-weight: normal;
-        margin: ${spacers.dp4} ${spacers.dp8};
+        padding: ${spacers.dp8};
     }
 `

--- a/src/components/DataDimension/Calculation/styles/MathOperatorSelector.style.js
+++ b/src/components/DataDimension/Calculation/styles/MathOperatorSelector.style.js
@@ -1,15 +1,10 @@
-import { colors, spacers } from '@dhis2/ui'
+import { spacers } from '@dhis2/ui'
 import css from 'styled-jsx/css'
 
 export default css`
-    .wrapper {
-        border-bottom: 1px solid ${colors.grey400};
-    }
-
     .operators {
         display: flex;
         flex-wrap: wrap;
         gap: ${spacers.dp4};
-        padding: ${spacers.dp8};
     }
 `

--- a/src/components/Interpretations/InterpretationModal/InterpretationModal.js
+++ b/src/components/Interpretations/InterpretationModal/InterpretationModal.js
@@ -15,12 +15,12 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { useMemo } from 'react'
 import css from 'styled-jsx/css'
+import { useModalContentWidth } from '../../../modules/useModalContentWidth.js'
 import {
     useActiveInterpretation,
     useInterpretationsCurrentUser,
 } from '../InterpretationsProvider/hooks.js'
 import { InterpretationThread } from './InterpretationThread.js'
-import { useModalContentWidth } from './useModalContentWidth.js'
 
 const modalCSS = css.resolve`
     aside {

--- a/src/modules/__tests__/expressions.spec.js
+++ b/src/modules/__tests__/expressions.spec.js
@@ -12,7 +12,7 @@ import {
 const invalidTestExpressions = [
     {
         message:
-            'Formula is empty. Add items to the formula from the lists on the left.',
+            'Formula is empty. Add a data element or operator to the formula.',
         expressions: [''],
     },
     // {

--- a/src/modules/expressions.js
+++ b/src/modules/expressions.js
@@ -67,7 +67,7 @@ export const validateExpression = (expression) => {
         result = {
             status: INVALID_EXPRESSION,
             message: i18n.t(
-                'Formula is empty. Add items to the formula from the lists on the left.'
+                'Formula is empty. Add a data element or operator to the formula.'
             ),
         }
         // TODO: reimplement this but allow negative values, e.g. 10 / -5

--- a/src/modules/useModalContentWidth.js
+++ b/src/modules/useModalContentWidth.js
@@ -1,18 +1,22 @@
 import { useState, useEffect } from 'react'
-import { useDebounce } from '../../../modules/utils.js'
+import { useDebounce } from './utils.js'
 
 const MODAL_SIDE_PADDING = 2 * 24
 const MODAL_SIDE_MARGINS = 2 * 128
 
-const computeModalContentWidth = (windowWidth) => {
-    return windowWidth - MODAL_SIDE_MARGINS - MODAL_SIDE_PADDING
+const computeModalContentWidth = (windowWidth, minWidth, maxWidth) => {
+    const width = windowWidth - MODAL_SIDE_MARGINS - MODAL_SIDE_PADDING
+    return Math.min(Math.max(width, minWidth), maxWidth)
 }
 
-export const useModalContentWidth = () => {
+export const useModalContentWidth = ({
+    minWidth = 0,
+    maxWidth = Infinity,
+} = {}) => {
     const [windowWidth, setWindowWidth] = useState(window.innerWidth)
     const debouncedWindowWidth = useDebounce(windowWidth, 150)
     const [modalContentWidth, setModalContentWidth] = useState(
-        computeModalContentWidth(windowWidth)
+        computeModalContentWidth(windowWidth, minWidth, maxWidth)
     )
 
     useEffect(() => {
@@ -27,8 +31,10 @@ export const useModalContentWidth = () => {
     }, [])
 
     useEffect(() => {
-        setModalContentWidth(computeModalContentWidth(debouncedWindowWidth))
-    }, [debouncedWindowWidth])
+        setModalContentWidth(
+            computeModalContentWidth(debouncedWindowWidth, minWidth, maxWidth)
+        )
+    }, [debouncedWindowWidth, minWidth, maxWidth])
 
     return modalContentWidth
 }


### PR DESCRIPTION
Implements [UX-159](https://dhis2.atlassian.net/browse/UX-159)

### Description

Improves the Сalculations dialog so formulas can be built from the keyboard and the layout is easier to scan.

---

### Key features

- Single-click to add data elements and operators (double-click is no longer required).
- Type operators (+, -, *, /, (, )) to append them after the selected item; numbers are still added by clicking.
- Move the highlighted formula item left/right with the arrow keys.
- Calculation name field moved to the top of the dialog.
- Operators and actions combined into one toolbar above a taller formula area.
- “Remove item” shown only when something is selected, with a delete icon.
- Validation result applied to the whole formula area (status border + message at the bottom).
- Modal width is fluid between a min and max based on window size.
- Formula items show full labels; truncation and hover tooltips are removed.
- Double-click no longer deletes items from the formula.

---

### Deferred for future

- adding drag and drop between data elements field and formula field
- allow typing numbers

---

### TODO

- [x] Storybook updated

---

### Screenshots

Before/after:
<img width="810" height="655" alt="Screenshot 2026-09-08 at 13 09 06" src="https://github.com/user-attachments/assets/bd680620-39fe-4a4c-840f-66ad021a5c74" />
<img width="1062" height="679" alt="Screenshot 2026-09-08 at 13 09 16" src="https://github.com/user-attachments/assets/1fb73f54-1eff-469a-97df-6c20214d571f" />

Validation output:
<img width="1062" height="680" alt="Screenshot 2026-09-08 at 13 13 25" src="https://github.com/user-attachments/assets/19290aa7-6e60-4911-aaca-dc2c4661f7b8" />


[UX-159]: https://dhis2.atlassian.net/browse/UX-159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ